### PR TITLE
feat: asset pipeline frontend — drone job linkage & expanded statuses

### DIFF
--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -18,6 +18,7 @@ import type {
   Channel,
   ChannelMember,
   ChannelMessage,
+  DroneJob,
 } from './types';
 
 // Auth
@@ -258,4 +259,30 @@ export function createChannel(data: { name: string; slug: string; type?: string;
 
 export function fetchChannelMembers(id: number): Promise<ChannelMember[]> {
   return apiGet<ChannelMember[]>(`/channels/${id}/members`);
+}
+
+// Drone Jobs
+
+export function createDroneJob(data: Partial<DroneJob>): Promise<DroneJob> {
+  return apiPost<DroneJob>('/drone-jobs', data);
+}
+
+export function updateDroneJob(id: number, data: Partial<DroneJob>): Promise<DroneJob> {
+  return apiPut<DroneJob>(`/drone-jobs/${id}`, data);
+}
+
+export function cancelDroneJob(id: number): Promise<DroneJob> {
+  return apiPut<DroneJob>(`/drone-jobs/${id}`, { status: 'cancelled' });
+}
+
+export function linkAssetsToJob(
+  assetIds: string[],
+  droneJobId: number,
+  status?: string,
+): Promise<{ ok: boolean; updated: number }> {
+  return apiPut<{ ok: boolean; updated: number }>('/assets/link-job', {
+    asset_ids: assetIds,
+    drone_job_id: droneJobId,
+    status,
+  });
 }

--- a/studio-react/src/api/types.ts
+++ b/studio-react/src/api/types.ts
@@ -118,6 +118,7 @@ export interface Asset {
   assigned_to: string | null;
   file_path: string | null;
   download_url: string | null;
+  drone_job_id: number | null;
   created_at: string;
   updated_at: string;
   metadata: Record<string, unknown> | null;

--- a/studio-react/src/components/assets/AssetCard.tsx
+++ b/studio-react/src/components/assets/AssetCard.tsx
@@ -12,13 +12,21 @@ interface AssetCardProps {
 
 const statusStrip: Record<string, string> = {
   requested: 'bg-accent',
+  queued: 'bg-blue',
+  generating: 'bg-purple',
+  ready: 'bg-green',
+  delivered: 'bg-green',
   in_progress: 'bg-blue',
   completed: 'bg-green',
   cancelled: 'bg-text-muted',
 }
 
-const statusBadgeVariant: Record<string, 'accent' | 'blue' | 'green' | 'muted'> = {
+const statusBadgeVariant: Record<string, 'accent' | 'blue' | 'green' | 'muted' | 'purple'> = {
   requested: 'accent',
+  queued: 'blue',
+  generating: 'purple',
+  ready: 'green',
+  delivered: 'green',
   in_progress: 'blue',
   completed: 'green',
   cancelled: 'muted',
@@ -74,6 +82,9 @@ export default function AssetCard({ asset, onUpload, onDelete, onStatusChange, o
             <Badge variant="default">{asset.game}</Badge>
           )}
           <span>by {asset.requested_by}</span>
+          {asset.drone_job_id && (
+            <span className="text-blue font-mono">DJ #{asset.drone_job_id}</span>
+          )}
         </div>
 
         {/* Assigned to */}

--- a/studio-react/src/components/dashboard/SummaryCard.tsx
+++ b/studio-react/src/components/dashboard/SummaryCard.tsx
@@ -22,6 +22,7 @@ const iconMap: Record<string, string> = {
   bugs: '\u{1F41B}',
   plans: '\u{1F4D0}',
   assets: '\u{1F3A8}',
+  drones: '\u2699\uFE0F',
 }
 
 export default function SummaryCard({ title, value, subtitle, color = 'accent', icon }: SummaryCardProps) {

--- a/studio-react/src/pages/AssetsPage.tsx
+++ b/studio-react/src/pages/AssetsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, useCallback } from 'react'
+import { Link } from 'react-router-dom'
 import { useDashboardStore } from '../stores/dashboardStore'
 import { updateAsset, deleteAsset, uploadAsset } from '../api/endpoints'
 import type { Asset } from '../api/types'
@@ -6,18 +7,26 @@ import AssetCard from '../components/assets/AssetCard'
 import Badge from '../components/shared/Badge'
 
 type ViewMode = 'grid' | 'list'
-type StatusFilter = 'all' | 'requested' | 'in_progress' | 'completed' | 'cancelled'
+type StatusFilter = 'all' | 'requested' | 'queued' | 'generating' | 'ready' | 'delivered' | 'in_progress' | 'completed' | 'cancelled'
 
 const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
   { value: 'all', label: 'All' },
   { value: 'requested', label: 'Requested' },
+  { value: 'queued', label: 'Queued' },
+  { value: 'generating', label: 'Generating' },
+  { value: 'ready', label: 'Ready' },
+  { value: 'delivered', label: 'Delivered' },
   { value: 'in_progress', label: 'In Progress' },
   { value: 'completed', label: 'Completed' },
   { value: 'cancelled', label: 'Cancelled' },
 ]
 
-const statusBadgeVariant: Record<string, 'accent' | 'blue' | 'green' | 'muted' | 'default'> = {
+const statusBadgeVariant: Record<string, 'accent' | 'blue' | 'green' | 'muted' | 'default' | 'purple'> = {
   requested: 'accent',
+  queued: 'blue',
+  generating: 'purple',
+  ready: 'green',
+  delivered: 'green',
   in_progress: 'blue',
   completed: 'green',
   cancelled: 'muted',
@@ -99,6 +108,10 @@ function AssetDetailModal({ asset, onClose, onUpload, onDelete, onStatusChange }
               className="bg-surface-raised border border-border rounded-sm px-2.5 py-1.5 text-sm text-text focus:outline-none focus:ring-1 focus:ring-ring"
             >
               <option value="requested">Requested</option>
+              <option value="queued">Queued</option>
+              <option value="generating">Generating</option>
+              <option value="ready">Ready</option>
+              <option value="delivered">Delivered</option>
               <option value="in_progress">In Progress</option>
               <option value="completed">Completed</option>
               <option value="cancelled">Cancelled</option>
@@ -119,6 +132,20 @@ function AssetDetailModal({ asset, onClose, onUpload, onDelete, onStatusChange }
             <div className="flex items-center gap-3">
               <label className="text-text-muted text-xs uppercase tracking-wider w-20 shrink-0">Assigned</label>
               <span className="text-blue text-sm">{asset.assigned_to}</span>
+            </div>
+          )}
+
+          {/* Drone Job */}
+          {asset.drone_job_id && (
+            <div className="flex items-center gap-3">
+              <label className="text-text-muted text-xs uppercase tracking-wider w-20 shrink-0">Drone Job</label>
+              <Link
+                to="/drones"
+                className="text-blue text-sm hover:underline underline-offset-2"
+                onClick={onClose}
+              >
+                DJ #{asset.drone_job_id}
+              </Link>
             </div>
           )}
 

--- a/studio-react/src/pages/DashboardPage.tsx
+++ b/studio-react/src/pages/DashboardPage.tsx
@@ -48,6 +48,13 @@ const eventBadgeVariant: Record<string, 'accent' | 'blue' | 'green' | 'muted' | 
   channel_created: 'blue',
   channel_message: 'green',
   channel_deleted: 'red',
+  drone_job_created: 'blue',
+  drone_job_claimed: 'blue',
+  drone_job_done: 'green',
+  drone_job_failed: 'red',
+  artifact_uploaded: 'accent',
+  assets_linked_to_job: 'blue',
+  assets_status_updated: 'green',
   context_updated: 'muted',
   context_key_updated: 'muted',
   config_changed: 'muted',
@@ -110,6 +117,7 @@ const quickLinks = [
   { to: '/plans', label: 'Plans', desc: 'Execution plans', color: 'text-purple' },
   { to: '/bugs', label: 'Bugs', desc: 'Bug tracker', color: 'text-red' },
   { to: '/assets', label: 'Assets', desc: 'Art pipeline', color: 'text-accent' },
+  { to: '/drones', label: 'Drones', desc: 'GPU compute', color: 'text-blue' },
   { to: '/approvals', label: 'Approvals', desc: 'Review queue', color: 'text-green' },
 ]
 
@@ -123,6 +131,7 @@ export default function DashboardPage() {
     bugCounts,
     plans,
     assets,
+    droneJobs,
     loading,
     refresh,
   } = useDashboardStore()
@@ -134,6 +143,7 @@ export default function DashboardPage() {
   const onlineAgents = agents.filter((a) => a.status === 'online').length
   const totalTasks = tasks.open.length + tasks.in_progress.length
   const activePlans = plans.filter((p) => p.status === 'active' || p.status === 'in_progress').length
+  const activeDroneJobs = droneJobs.filter((j) => j.status === 'pending' || j.status === 'claimed').length
   const recentEvents = events.slice(0, 20)
 
   return (
@@ -155,7 +165,7 @@ export default function DashboardPage() {
       </div>
 
       {/* Summary cards */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3">
         <SummaryCard
           title="Agents"
           value={`${onlineAgents}/${agents.length}`}
@@ -197,6 +207,13 @@ export default function DashboardPage() {
           subtitle="total assets"
           color="accent"
           icon="assets"
+        />
+        <SummaryCard
+          title="Drones"
+          value={activeDroneJobs}
+          subtitle={`${droneJobs.length} total jobs`}
+          color="blue"
+          icon="drones"
         />
       </div>
 
@@ -296,7 +313,7 @@ export default function DashboardPage() {
       {/* Quick links */}
       <div>
         <h2 className="text-sm font-semibold text-text-dim mb-3">Quick Links</h2>
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2">
+        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-2">
           {quickLinks.map((link) => (
             <Link
               key={link.to}


### PR DESCRIPTION
## Summary
- **Asset type**: Added `drone_job_id` field to surface drone job linkage
- **API wrappers**: Added `createDroneJob`, `updateDroneJob`, `cancelDroneJob`, `linkAssetsToJob` endpoint functions
- **Assets UI**: Expanded status progression (queued, generating, ready, delivered) in filters, cards, and detail modal; drone job indicator on cards and clickable link in modal
- **Dashboard**: Added Drones summary card with active job count, drone event badge colors in activity feed, and Drones quick link

## Test plan
- [ ] `cd studio-react && npx vite build` compiles clean
- [ ] AssetsPage shows new status filter options (queued, generating, ready, delivered)
- [ ] Asset cards display `DJ #N` indicator when `drone_job_id` is set
- [ ] Asset detail modal shows Drone Job link that navigates to /drones
- [ ] Dashboard shows Drones summary card with pending+claimed count
- [ ] Drone events (drone_job_created, drone_job_done, etc.) render with correct badge colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)