### PR TITLE
feat: Concepts + Context Keys pages for React dashboard

### DIFF
--- a/studio-react/src/App.tsx
+++ b/studio-react/src/App.tsx
@@ -13,6 +13,8 @@ import AssetsPage from './pages/AssetsPage'
 import OperatorsPage from './pages/OperatorsPage'
 import ApprovalsPage from './pages/ApprovalsPage'
 import DronesPage from './pages/DronesPage'
+import ConceptsPage from './pages/ConceptsPage'
+import ContextPage from './pages/ContextPage'
 
 export default function App() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
@@ -42,6 +44,8 @@ export default function App() {
           <Route path="operators" element={<OperatorsPage />} />
           <Route path="approvals" element={<ApprovalsPage />} />
           <Route path="drones" element={<DronesPage />} />
+          <Route path="concepts" element={<ConceptsPage />} />
+          <Route path="context" element={<ContextPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -15,6 +15,7 @@ import type {
   Vote,
   Approval,
   ContextEntry,
+  Concept,
   Channel,
   ChannelMember,
   ChannelMessage,
@@ -213,6 +214,13 @@ export function resolveRequest(id: string, response: string): Promise<Message> {
 
 // Context
 
+export function fetchAllContextKeys(ns?: string): Promise<ContextEntry[]> {
+  const path = ns
+    ? `/context/keys/${encodeURIComponent(ns)}`
+    : '/context/keys';
+  return apiGet<ContextEntry[]>(path);
+}
+
 export function fetchContextKey(ns: string, key: string): Promise<ContextEntry> {
   return apiGet<ContextEntry>(
     `/context/keys/${encodeURIComponent(ns)}/${encodeURIComponent(key)}`,
@@ -222,13 +230,40 @@ export function fetchContextKey(ns: string, key: string): Promise<ContextEntry> 
 export function updateContextKey(
   ns: string,
   key: string,
-  value: unknown,
-  updatedBy: string,
+  data: unknown,
 ): Promise<ContextEntry> {
   return apiPut<ContextEntry>(
     `/context/keys/${encodeURIComponent(ns)}/${encodeURIComponent(key)}`,
-    { value, updated_by: updatedBy },
+    { data },
   );
+}
+
+export function deleteContextKey(ns: string, key: string): Promise<void> {
+  return apiDelete<void>(
+    `/context/keys/${encodeURIComponent(ns)}/${encodeURIComponent(key)}`,
+  );
+}
+
+// Concepts
+
+export function createConcept(data: { name: string; type: string; description?: string; data?: unknown }): Promise<Concept> {
+  return apiPost<Concept>('/concepts', data);
+}
+
+export function updateConcept(id: string, data: Partial<Concept>): Promise<Concept> {
+  return apiPut<Concept>(`/concepts/${id}`, data);
+}
+
+export function deleteConcept(id: string): Promise<void> {
+  return apiDelete<void>(`/concepts/${id}`);
+}
+
+export function linkConceptToProject(id: string, projectId: string): Promise<{ ok: boolean }> {
+  return apiPost<{ ok: boolean }>(`/concepts/${id}/link`, { project_id: projectId });
+}
+
+export function unlinkConceptFromProject(id: string, projectId: string): Promise<{ ok: boolean }> {
+  return apiDelete<{ ok: boolean }>(`/concepts/${id}/link/${encodeURIComponent(projectId)}`);
 }
 
 // Channels

--- a/studio-react/src/api/types.ts
+++ b/studio-react/src/api/types.ts
@@ -65,7 +65,7 @@ export interface TeamChat {
 export interface ContextEntry {
   namespace: string;
   key: string;
-  value: unknown;
+  data: unknown;
   updated_by: string;
   updated_at: string;
 }
@@ -73,6 +73,8 @@ export interface ContextEntry {
 export interface ContextKey {
   namespace: string;
   key: string;
+  data: unknown;
+  updated_by: string;
   updated_at: string;
 }
 

--- a/studio-react/src/components/concepts/ConceptCard.tsx
+++ b/studio-react/src/components/concepts/ConceptCard.tsx
@@ -1,0 +1,84 @@
+import type { Concept } from '../../api/types'
+import Badge from '../shared/Badge'
+
+interface ConceptCardProps {
+  concept: Concept
+  onClick: () => void
+}
+
+const typeBarColor: Record<string, string> = {
+  character: 'bg-purple',
+  style: 'bg-accent',
+  ruleset: 'bg-blue',
+  library: 'bg-green',
+  brand: 'bg-red',
+  custom: 'bg-text-muted',
+}
+
+const typeBadgeVariant: Record<string, 'purple' | 'accent' | 'blue' | 'green' | 'red' | 'muted'> = {
+  character: 'purple',
+  style: 'accent',
+  ruleset: 'blue',
+  library: 'green',
+  brand: 'red',
+  custom: 'muted',
+}
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(dateStr).toLocaleDateString()
+}
+
+export default function ConceptCard({ concept, onClick }: ConceptCardProps) {
+  const barColor = typeBarColor[concept.type] ?? typeBarColor.custom
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full text-left bg-surface-raised rounded-lg p-4 mb-3 cursor-pointer flex gap-3 transition-all hover:ring-1 ring-border hover:bg-surface-raised/80 group"
+    >
+      {/* Type indicator bar */}
+      <div className={`w-1 shrink-0 rounded-full self-stretch ${barColor}`} />
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        {/* Name */}
+        <p className="text-sm font-semibold text-text leading-snug group-hover:text-accent transition-colors">
+          <span className="text-text-muted font-mono">#{concept.id}:</span> {concept.name}
+        </p>
+
+        {/* Description */}
+        {concept.description && (
+          <p className="text-text-dim text-sm mt-1 line-clamp-2 leading-relaxed">
+            {concept.description}
+          </p>
+        )}
+
+        {/* Badges */}
+        <div className="flex flex-wrap items-center gap-1.5 mt-2">
+          <Badge variant={typeBadgeVariant[concept.type] ?? 'muted'}>
+            {concept.type}
+          </Badge>
+          {concept.projects?.map((p) => (
+            <Badge key={p} variant="default">{p}</Badge>
+          ))}
+        </div>
+
+        {/* Meta row */}
+        <div className="flex items-center justify-end mt-2.5 text-xs text-text-muted">
+          <span className="shrink-0 font-mono">
+            {timeAgo(concept.updated_at || concept.created_at)}
+          </span>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/studio-react/src/components/dashboard/SummaryCard.tsx
+++ b/studio-react/src/components/dashboard/SummaryCard.tsx
@@ -23,6 +23,8 @@ const iconMap: Record<string, string> = {
   plans: '\u{1F4D0}',
   assets: '\u{1F3A8}',
   drones: '\u2699\uFE0F',
+  concepts: '\u{1F9E9}',
+  context: '\u{1F511}',
 }
 
 export default function SummaryCard({ title, value, subtitle, color = 'accent', icon }: SummaryCardProps) {

--- a/studio-react/src/layouts/AppLayout.tsx
+++ b/studio-react/src/layouts/AppLayout.tsx
@@ -19,6 +19,8 @@ const routeTitles: Record<string, string> = {
   '/operators': 'Operators',
   '/approvals': 'Approvals',
   '/drones': 'Drones',
+  '/concepts': 'Concepts',
+  '/context': 'Context Keys',
 }
 
 function formatTime(date: Date | null): string {

--- a/studio-react/src/layouts/SideNav.tsx
+++ b/studio-react/src/layouts/SideNav.tsx
@@ -14,6 +14,8 @@ const navItems = [
   { to: '/operators', label: 'Operators', abbr: 'Op' },
   { to: '/approvals', label: 'Approvals', abbr: 'Ap' },
   { to: '/drones', label: 'Drones', abbr: 'Dr' },
+  { to: '/concepts', label: 'Concepts', abbr: 'Co' },
+  { to: '/context', label: 'Context', abbr: 'Cx' },
 ] as const
 
 export default function SideNav() {

--- a/studio-react/src/pages/ConceptsPage.tsx
+++ b/studio-react/src/pages/ConceptsPage.tsx
@@ -1,0 +1,619 @@
+import { useEffect, useState, useMemo, useCallback } from 'react'
+import { useDashboardStore } from '../stores/dashboardStore'
+import { createConcept, updateConcept, deleteConcept, linkConceptToProject, unlinkConceptFromProject } from '../api/endpoints'
+import type { Concept } from '../api/types'
+import ConceptCard from '../components/concepts/ConceptCard'
+import ModalOverlay from '../components/modals/ModalOverlay'
+type TypeFilter = 'all' | 'character' | 'style' | 'ruleset' | 'library' | 'brand' | 'custom'
+
+const TYPE_TABS: { key: TypeFilter; label: string; color: string }[] = [
+  { key: 'all', label: 'All', color: 'text-text-dim' },
+  { key: 'character', label: 'Character', color: 'text-purple' },
+  { key: 'style', label: 'Style', color: 'text-accent' },
+  { key: 'ruleset', label: 'Ruleset', color: 'text-blue' },
+  { key: 'library', label: 'Library', color: 'text-green' },
+  { key: 'brand', label: 'Brand', color: 'text-red' },
+  { key: 'custom', label: 'Custom', color: 'text-text-muted' },
+]
+
+const TYPE_OPTIONS = ['character', 'style', 'ruleset', 'library', 'brand', 'custom']
+
+// -- Create Concept Modal --
+
+interface CreateConceptModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+function CreateConceptModal({ isOpen, onClose }: CreateConceptModalProps) {
+  const refresh = useDashboardStore((s) => s.refresh)
+
+  const [name, setName] = useState('')
+  const [type, setType] = useState('character')
+  const [description, setDescription] = useState('')
+  const [dataStr, setDataStr] = useState('{}')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function resetForm() {
+    setName('')
+    setType('character')
+    setDescription('')
+    setDataStr('{}')
+    setError(null)
+  }
+
+  function handleClose() {
+    resetForm()
+    onClose()
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim()) return
+
+    let parsedData: unknown
+    try {
+      parsedData = JSON.parse(dataStr)
+    } catch {
+      setError('Invalid JSON in data field')
+      return
+    }
+
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      await createConcept({
+        name: name.trim(),
+        type,
+        description: description.trim(),
+        data: parsedData,
+      })
+      await refresh()
+      handleClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create concept')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <ModalOverlay isOpen={isOpen} onClose={handleClose} title="Create Concept">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="px-3 py-2 rounded-sm bg-red/10 border border-red/20 text-red text-sm">
+            {error}
+          </div>
+        )}
+
+        <div>
+          <label className="text-text-muted text-xs uppercase tracking-wider block mb-1.5">
+            Name *
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Concept name..."
+            className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40"
+            autoFocus
+            required
+          />
+        </div>
+
+        <div>
+          <label className="text-text-muted text-xs uppercase tracking-wider block mb-1.5">
+            Type
+          </label>
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-sm text-text focus:outline-none focus:ring-1 focus:ring-accent/40"
+          >
+            {TYPE_OPTIONS.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="text-text-muted text-xs uppercase tracking-wider block mb-1.5">
+            Description
+          </label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            placeholder="What this concept represents..."
+            className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40 resize-none"
+          />
+        </div>
+
+        <div>
+          <label className="text-text-muted text-xs uppercase tracking-wider block mb-1.5">
+            Data (JSON)
+          </label>
+          <textarea
+            value={dataStr}
+            onChange={(e) => setDataStr(e.target.value)}
+            rows={4}
+            placeholder="{}"
+            className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40 resize-none font-mono text-xs"
+          />
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="px-3 py-1.5 rounded-sm text-sm text-text-dim bg-surface-raised hover:bg-surface-raised/80 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !name.trim()}
+            className="px-4 py-1.5 rounded-sm text-sm font-medium bg-purple/80 text-text hover:bg-purple/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? 'Creating...' : 'Create Concept'}
+          </button>
+        </div>
+      </form>
+    </ModalOverlay>
+  )
+}
+
+// -- Concept Detail Panel --
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+interface ConceptDetailProps {
+  concept: Concept
+  onClose: () => void
+}
+
+function ConceptDetail({ concept, onClose }: ConceptDetailProps) {
+  const refresh = useDashboardStore((s) => s.refresh)
+  const projects = useDashboardStore((s) => s.projects)
+
+  const [editName, setEditName] = useState(concept.name)
+  const [editType, setEditType] = useState(concept.type)
+  const [editDescription, setEditDescription] = useState(concept.description)
+  const [editingData, setEditingData] = useState(false)
+  const [dataStr, setDataStr] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [linkProject, setLinkProject] = useState('')
+
+  useEffect(() => {
+    setEditName(concept.name)
+    setEditType(concept.type)
+    setEditDescription(concept.description)
+    setEditingData(false)
+    setConfirmDelete(false)
+  }, [concept.id, concept.name, concept.type, concept.description])
+
+  const prettyData = useMemo(() => {
+    try {
+      return JSON.stringify(concept.data, null, 2)
+    } catch {
+      return String(concept.data)
+    }
+  }, [concept.data])
+
+  const hasChanges =
+    editName !== concept.name ||
+    editType !== concept.type ||
+    editDescription !== concept.description
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    try {
+      const updates: Partial<Concept> = {}
+      if (editName !== concept.name) updates.name = editName
+      if (editType !== concept.type) updates.type = editType
+      if (editDescription !== concept.description) updates.description = editDescription
+      await updateConcept(concept.id, updates)
+      await refresh()
+    } catch (err) {
+      console.error('Failed to update concept:', err)
+    } finally {
+      setSaving(false)
+    }
+  }, [concept.id, concept.name, concept.type, concept.description, editName, editType, editDescription, refresh])
+
+  const handleSaveData = useCallback(async () => {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(dataStr)
+    } catch {
+      return
+    }
+    setSaving(true)
+    try {
+      await updateConcept(concept.id, { data: parsed })
+      await refresh()
+      setEditingData(false)
+    } catch (err) {
+      console.error('Failed to update concept data:', err)
+    } finally {
+      setSaving(false)
+    }
+  }, [concept.id, dataStr, refresh])
+
+  const handleDelete = useCallback(async () => {
+    setDeleting(true)
+    try {
+      await deleteConcept(concept.id)
+      await refresh()
+      onClose()
+    } catch (err) {
+      console.error('Failed to delete concept:', err)
+    } finally {
+      setDeleting(false)
+    }
+  }, [concept.id, refresh, onClose])
+
+  const handleLink = useCallback(async () => {
+    if (!linkProject) return
+    try {
+      await linkConceptToProject(concept.id, linkProject)
+      await refresh()
+      setLinkProject('')
+    } catch (err) {
+      console.error('Failed to link project:', err)
+    }
+  }, [concept.id, linkProject, refresh])
+
+  const handleUnlink = useCallback(async (projectId: string) => {
+    try {
+      await unlinkConceptFromProject(concept.id, projectId)
+      await refresh()
+    } catch (err) {
+      console.error('Failed to unlink project:', err)
+    }
+  }, [concept.id, refresh])
+
+  const availableProjects = useMemo(() => {
+    const linked = new Set(concept.projects || [])
+    return projects.filter((p) => !linked.has(p.id))
+  }, [projects, concept.projects])
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-bg/60 z-40"
+        onClick={onClose}
+        aria-hidden
+      />
+
+      <div className="fixed top-0 right-0 h-full w-full max-w-lg bg-surface border-l border-border z-50 flex flex-col animate-in slide-in-from-right">
+        {/* Header */}
+        <div className="flex items-start justify-between p-5 border-b border-border shrink-0">
+          <div className="min-w-0 flex-1 mr-3">
+            <p className="text-xs text-text-muted font-mono mb-1">#{concept.id}</p>
+            <h2 className="text-lg font-semibold text-text leading-snug">{concept.name}</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-text-muted hover:text-text transition-colors p-1 -mt-1 -mr-1 shrink-0"
+            aria-label="Close"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M5 5l10 10M15 5L5 15" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-6">
+          {/* Editable name */}
+          <div>
+            <h3 className="text-xs uppercase tracking-wider text-text-muted font-medium mb-2">Name</h3>
+            <input
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-sm text-text focus:outline-none focus:ring-1 focus:ring-accent/40"
+            />
+          </div>
+
+          {/* Type */}
+          <div>
+            <h3 className="text-xs uppercase tracking-wider text-text-muted font-medium mb-2">Type</h3>
+            <select
+              value={editType}
+              onChange={(e) => setEditType(e.target.value)}
+              className="bg-surface-raised border border-border rounded-sm px-2 py-1 text-xs text-text focus:outline-none focus:ring-1 focus:ring-accent/40 w-full"
+            >
+              {TYPE_OPTIONS.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Description */}
+          <div>
+            <h3 className="text-xs uppercase tracking-wider text-text-muted font-medium mb-2">Description</h3>
+            <textarea
+              value={editDescription}
+              onChange={(e) => setEditDescription(e.target.value)}
+              rows={3}
+              className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-sm text-text focus:outline-none focus:ring-1 focus:ring-accent/40 resize-none"
+            />
+          </div>
+
+          {/* Linked projects */}
+          <div>
+            <h3 className="text-xs uppercase tracking-wider text-text-muted font-medium mb-2">Linked Projects</h3>
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              {(concept.projects || []).length === 0 && (
+                <span className="text-xs text-text-muted">No linked projects</span>
+              )}
+              {(concept.projects || []).map((p) => (
+                <span key={p} className="inline-flex items-center gap-1 bg-surface-raised rounded-full px-2.5 py-0.5 text-xs text-text-dim">
+                  {p}
+                  <button
+                    type="button"
+                    onClick={() => handleUnlink(p)}
+                    className="text-text-muted hover:text-red transition-colors ml-0.5"
+                    title="Unlink"
+                  >
+                    x
+                  </button>
+                </span>
+              ))}
+            </div>
+            {availableProjects.length > 0 && (
+              <div className="flex gap-2">
+                <select
+                  value={linkProject}
+                  onChange={(e) => setLinkProject(e.target.value)}
+                  className="bg-surface-raised border border-border rounded-sm px-2 py-1 text-xs text-text focus:outline-none focus:ring-1 focus:ring-accent/40 flex-1"
+                >
+                  <option value="">Select project...</option>
+                  {availableProjects.map((p) => (
+                    <option key={p.id} value={p.id}>{p.title || p.id}</option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={handleLink}
+                  disabled={!linkProject}
+                  className="px-3 py-1 rounded-sm text-xs font-medium bg-accent/80 text-bg hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Link
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Data viewer/editor */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-xs uppercase tracking-wider text-text-muted font-medium">Data</h3>
+              <button
+                type="button"
+                onClick={() => {
+                  if (!editingData) setDataStr(prettyData)
+                  setEditingData(!editingData)
+                }}
+                className="text-xs text-accent hover:text-accent-light transition-colors"
+              >
+                {editingData ? 'Cancel' : 'Edit'}
+              </button>
+            </div>
+            {editingData ? (
+              <div className="space-y-2">
+                <textarea
+                  value={dataStr}
+                  onChange={(e) => setDataStr(e.target.value)}
+                  rows={8}
+                  className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-xs text-text font-mono focus:outline-none focus:ring-1 focus:ring-accent/40 resize-none"
+                />
+                <div className="flex justify-end">
+                  <button
+                    type="button"
+                    onClick={handleSaveData}
+                    disabled={saving}
+                    className="px-3 py-1 rounded-sm text-xs font-medium bg-accent text-bg hover:bg-accent-light transition-colors disabled:opacity-50"
+                  >
+                    {saving ? 'Saving...' : 'Save Data'}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <pre className="bg-surface-raised rounded-sm p-3 text-xs text-text-dim font-mono overflow-x-auto max-h-48 whitespace-pre-wrap">
+                {prettyData}
+              </pre>
+            )}
+          </div>
+
+          {/* Timestamps */}
+          <div className="flex items-center gap-3 text-xs text-text-muted">
+            <span>Created {formatDate(concept.created_at)}</span>
+            {concept.updated_at !== concept.created_at && (
+              <span>Updated {formatDate(concept.updated_at)}</span>
+            )}
+          </div>
+
+          {/* Save changes */}
+          {hasChanges && (
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                className="px-4 py-1.5 rounded-sm text-sm font-medium bg-accent text-bg hover:bg-accent-light transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {saving ? 'Saving...' : 'Save Changes'}
+              </button>
+            </div>
+          )}
+
+          {/* Delete */}
+          <div className="pt-2 border-t border-border">
+            {confirmDelete ? (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-red">Delete this concept permanently?</span>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="px-3 py-1 rounded-sm text-xs font-medium bg-red/80 text-text hover:bg-red/90 transition-colors disabled:opacity-50"
+                >
+                  {deleting ? 'Deleting...' : 'Confirm'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(false)}
+                  className="px-3 py-1 rounded-sm text-xs text-text-dim bg-surface-raised hover:bg-surface-raised/80 transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(true)}
+                className="text-xs text-text-muted hover:text-red transition-colors"
+              >
+                Delete concept
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+// -- Main Page --
+
+export default function ConceptsPage() {
+  const { concepts, loading, refresh } = useDashboardStore()
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all')
+  const [selectedConcept, setSelectedConcept] = useState<Concept | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const filtered = useMemo(() => {
+    let result = concepts
+    if (typeFilter !== 'all') {
+      result = result.filter((c) => c.type === typeFilter)
+    }
+    return result.sort(
+      (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    )
+  }, [concepts, typeFilter])
+
+  // Keep selected concept in sync with store data
+  useEffect(() => {
+    if (!selectedConcept) return
+    const found = concepts.find((c) => c.id === selectedConcept.id)
+    if (found) setSelectedConcept(found)
+  }, [concepts, selectedConcept])
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <h1 className="text-xl font-semibold text-text">Concepts</h1>
+          <span className="inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 rounded-full bg-purple/15 text-purple text-xs font-bold tabular-nums">
+            {concepts.length}
+          </span>
+          <button
+            type="button"
+            onClick={() => refresh()}
+            disabled={loading}
+            className="text-xs text-text-muted hover:text-accent transition-colors"
+          >
+            {loading ? 'Refreshing...' : 'Refresh'}
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setShowCreate(true)}
+          className="bg-purple/80 text-text px-4 py-1.5 rounded text-sm font-medium hover:bg-purple/90 transition-colors"
+        >
+          Create Concept
+        </button>
+      </div>
+
+      {/* Type filter tabs */}
+      <div className="flex rounded-sm overflow-hidden border border-border w-fit">
+        {TYPE_TABS.map((tab) => {
+          const count =
+            tab.key === 'all'
+              ? concepts.length
+              : concepts.filter((c) => c.type === tab.key).length
+
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setTypeFilter(tab.key)}
+              className={`px-4 py-1.5 text-xs font-medium transition-colors flex items-center gap-1.5 ${
+                typeFilter === tab.key
+                  ? 'bg-surface-raised text-text'
+                  : 'text-text-muted hover:text-text-dim'
+              }`}
+            >
+              {tab.label}
+              <span className="font-mono text-text-muted tabular-nums">{count}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Concept list */}
+      {filtered.length === 0 ? (
+        <div className="bg-surface rounded-lg p-12 text-center">
+          <p className="text-text-muted text-sm">
+            No concepts match the current filter.
+          </p>
+        </div>
+      ) : (
+        <div>
+          {filtered.map((concept) => (
+            <ConceptCard
+              key={concept.id}
+              concept={concept}
+              onClick={() => setSelectedConcept(concept)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Concept detail panel */}
+      {selectedConcept && (
+        <ConceptDetail
+          concept={selectedConcept}
+          onClose={() => setSelectedConcept(null)}
+        />
+      )}
+
+      {/* Create concept modal */}
+      <CreateConceptModal
+        isOpen={showCreate}
+        onClose={() => setShowCreate(false)}
+      />
+    </div>
+  )
+}

--- a/studio-react/src/pages/ContextPage.tsx
+++ b/studio-react/src/pages/ContextPage.tsx
@@ -1,0 +1,411 @@
+import { useEffect, useState, useMemo, useCallback } from 'react'
+import { useDashboardStore } from '../stores/dashboardStore'
+import { updateContextKey, deleteContextKey } from '../api/endpoints'
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function formatValue(val: unknown): string {
+  if (val === null || val === undefined) return 'null'
+  if (typeof val === 'string') {
+    try {
+      const parsed = JSON.parse(val)
+      return JSON.stringify(parsed, null, 2)
+    } catch {
+      return val
+    }
+  }
+  return JSON.stringify(val, null, 2)
+}
+
+function truncateValue(val: unknown, max = 80): string {
+  const str = typeof val === 'string' ? val : JSON.stringify(val)
+  if (!str) return 'null'
+  return str.length > max ? str.slice(0, max) + '...' : str
+}
+
+// -- Key Row --
+
+interface KeyRowProps {
+  namespace: string
+  keyName: string
+  data: unknown
+  updatedBy: string
+  updatedAt: string
+  onRefresh: () => void
+}
+
+function KeyRow({ namespace, keyName, data, updatedBy, updatedAt, onRefresh }: KeyRowProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [editValue, setEditValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const handleEdit = () => {
+    setEditValue(formatValue(data))
+    setEditing(true)
+    setExpanded(true)
+  }
+
+  const handleCancel = () => {
+    setEditing(false)
+  }
+
+  const handleSave = useCallback(async () => {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(editValue)
+    } catch {
+      parsed = editValue
+    }
+    setSaving(true)
+    try {
+      await updateContextKey(namespace, keyName, parsed)
+      await onRefresh()
+      setEditing(false)
+    } catch (err) {
+      console.error('Failed to update context key:', err)
+    } finally {
+      setSaving(false)
+    }
+  }, [namespace, keyName, editValue, onRefresh])
+
+  const handleDelete = useCallback(async () => {
+    setDeleting(true)
+    try {
+      await deleteContextKey(namespace, keyName)
+      await onRefresh()
+    } catch (err) {
+      console.error('Failed to delete context key:', err)
+    } finally {
+      setDeleting(false)
+      setConfirmDelete(false)
+    }
+  }, [namespace, keyName, onRefresh])
+
+  return (
+    <div className="border-b border-border last:border-b-0">
+      {/* Summary row */}
+      <div
+        className="flex items-center gap-3 px-4 py-2.5 hover:bg-surface-raised/50 transition-colors cursor-pointer"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <span className="text-xs text-text-muted w-4 shrink-0">{expanded ? '\u25BC' : '\u25B6'}</span>
+        <span className="text-sm text-accent font-mono font-medium shrink-0">{keyName}</span>
+        <span className="text-xs text-text-muted flex-1 min-w-0 truncate font-mono">
+          {truncateValue(data)}
+        </span>
+        <span className="text-xs text-text-muted shrink-0">{updatedBy}</span>
+        <span className="text-xs text-text-muted shrink-0 font-mono">{formatDate(updatedAt)}</span>
+        <div className="flex gap-1 shrink-0" onClick={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            onClick={handleEdit}
+            className="px-2 py-0.5 rounded text-xs text-text-muted hover:text-accent transition-colors"
+          >
+            Edit
+          </button>
+          {confirmDelete ? (
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting}
+                className="px-2 py-0.5 rounded text-xs bg-red/80 text-text hover:bg-red/90 transition-colors disabled:opacity-50"
+              >
+                {deleting ? '...' : 'Yes'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(false)}
+                className="px-2 py-0.5 rounded text-xs text-text-muted hover:text-text transition-colors"
+              >
+                No
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(true)}
+              className="px-2 py-0.5 rounded text-xs text-text-muted hover:text-red transition-colors"
+            >
+              Del
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div className="px-4 pb-3 pl-11">
+          {editing ? (
+            <div className="space-y-2">
+              <textarea
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                rows={6}
+                className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-xs text-text font-mono focus:outline-none focus:ring-1 focus:ring-accent/40 resize-none"
+              />
+              <div className="flex gap-2 justify-end">
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="px-3 py-1 rounded-sm text-xs text-text-dim bg-surface-raised hover:bg-surface-raised/80 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="px-3 py-1 rounded-sm text-xs font-medium bg-accent text-bg hover:bg-accent-light transition-colors disabled:opacity-50"
+                >
+                  {saving ? 'Saving...' : 'Save'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <pre className="bg-surface-raised rounded-sm p-3 text-xs text-text-dim font-mono overflow-x-auto max-h-48 whitespace-pre-wrap">
+              {formatValue(data)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// -- Add Key Form --
+
+interface AddKeyFormProps {
+  onRefresh: () => void
+  onClose: () => void
+}
+
+function AddKeyForm({ onRefresh, onClose }: AddKeyFormProps) {
+  const [namespace, setNamespace] = useState('')
+  const [key, setKey] = useState('')
+  const [value, setValue] = useState('{}')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!namespace.trim() || !key.trim()) return
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(value)
+    } catch {
+      parsed = value
+    }
+
+    setSaving(true)
+    setError(null)
+    try {
+      await updateContextKey(namespace.trim(), key.trim(), parsed)
+      await onRefresh()
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add key')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="bg-surface rounded-lg p-4 border border-border">
+      <h3 className="text-sm font-semibold text-text mb-3">Add Context Key</h3>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        {error && (
+          <div className="px-3 py-2 rounded-sm bg-red/10 border border-red/20 text-red text-sm">
+            {error}
+          </div>
+        )}
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="text-text-muted text-xs uppercase tracking-wider block mb-1">
+              Namespace *
+            </label>
+            <input
+              type="text"
+              value={namespace}
+              onChange={(e) => setNamespace(e.target.value)}
+              placeholder="e.g. config"
+              className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40"
+              required
+            />
+          </div>
+          <div>
+            <label className="text-text-muted text-xs uppercase tracking-wider block mb-1">
+              Key *
+            </label>
+            <input
+              type="text"
+              value={key}
+              onChange={(e) => setKey(e.target.value)}
+              placeholder="e.g. theme"
+              className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40"
+              required
+            />
+          </div>
+        </div>
+        <div>
+          <label className="text-text-muted text-xs uppercase tracking-wider block mb-1">
+            Value (JSON)
+          </label>
+          <textarea
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            rows={4}
+            className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-xs text-text font-mono placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40 resize-none"
+          />
+        </div>
+        <div className="flex gap-2 justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 rounded-sm text-sm text-text-dim bg-surface-raised hover:bg-surface-raised/80 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving || !namespace.trim() || !key.trim()}
+            className="px-4 py-1.5 rounded-sm text-sm font-medium bg-accent text-bg hover:bg-accent-light transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Adding...' : 'Add Key'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+// -- Main Page --
+
+export default function ContextPage() {
+  const { contextKeys, loading, refresh } = useDashboardStore()
+  const [showAdd, setShowAdd] = useState(false)
+  const [collapsedNs, setCollapsedNs] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  // Group by namespace
+  const grouped = useMemo(() => {
+    const map = new Map<string, typeof contextKeys>()
+    for (const entry of contextKeys) {
+      const ns = entry.namespace
+      if (!map.has(ns)) map.set(ns, [])
+      map.get(ns)!.push(entry)
+    }
+    return map
+  }, [contextKeys])
+
+  const namespaceCount = grouped.size
+
+  const toggleNamespace = (ns: string) => {
+    setCollapsedNs((prev) => {
+      const next = new Set(prev)
+      if (next.has(ns)) next.delete(ns)
+      else next.add(ns)
+      return next
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <h1 className="text-xl font-semibold text-text">Context Keys</h1>
+          <span className="inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 rounded-full bg-accent/15 text-accent text-xs font-bold tabular-nums">
+            {contextKeys.length}
+          </span>
+          <span className="text-xs text-text-muted">
+            {namespaceCount} namespace{namespaceCount !== 1 ? 's' : ''}
+          </span>
+          <button
+            type="button"
+            onClick={() => refresh()}
+            disabled={loading}
+            className="text-xs text-text-muted hover:text-accent transition-colors"
+          >
+            {loading ? 'Refreshing...' : 'Refresh'}
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setShowAdd(true)}
+          className="bg-accent/80 text-bg px-4 py-1.5 rounded text-sm font-medium hover:bg-accent/90 transition-colors"
+        >
+          Add Key
+        </button>
+      </div>
+
+      {/* Add key form */}
+      {showAdd && (
+        <AddKeyForm onRefresh={refresh} onClose={() => setShowAdd(false)} />
+      )}
+
+      {/* Namespace groups */}
+      {contextKeys.length === 0 && !loading ? (
+        <div className="bg-surface rounded-lg p-12 text-center">
+          <p className="text-text-muted text-sm">No context keys found.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {[...grouped.entries()].map(([ns, keys]) => {
+            const isCollapsed = collapsedNs.has(ns)
+            return (
+              <div key={ns} className="bg-surface rounded-lg overflow-hidden">
+                {/* Namespace header */}
+                <button
+                  type="button"
+                  onClick={() => toggleNamespace(ns)}
+                  className="w-full flex items-center gap-2 px-4 py-3 hover:bg-surface-raised/30 transition-colors text-left"
+                >
+                  <span className="text-xs text-text-muted w-4 shrink-0">
+                    {isCollapsed ? '\u25B6' : '\u25BC'}
+                  </span>
+                  <span className="text-sm font-semibold text-accent font-mono">{ns}</span>
+                  <span className="text-xs text-text-muted font-mono">
+                    {keys.length} key{keys.length !== 1 ? 's' : ''}
+                  </span>
+                </button>
+
+                {/* Keys */}
+                {!isCollapsed && (
+                  <div>
+                    {keys.map((entry) => (
+                      <KeyRow
+                        key={`${entry.namespace}:${entry.key}`}
+                        namespace={entry.namespace}
+                        keyName={entry.key}
+                        data={entry.data}
+                        updatedBy={entry.updated_by}
+                        updatedAt={entry.updated_at}
+                        onRefresh={refresh}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/studio-react/src/pages/DashboardPage.tsx
+++ b/studio-react/src/pages/DashboardPage.tsx
@@ -119,6 +119,8 @@ const quickLinks = [
   { to: '/assets', label: 'Assets', desc: 'Art pipeline', color: 'text-accent' },
   { to: '/drones', label: 'Drones', desc: 'GPU compute', color: 'text-blue' },
   { to: '/approvals', label: 'Approvals', desc: 'Review queue', color: 'text-green' },
+  { to: '/concepts', label: 'Concepts', desc: 'Shared concepts', color: 'text-purple' },
+  { to: '/context', label: 'Context', desc: 'Key-value store', color: 'text-text-dim' },
 ]
 
 export default function DashboardPage() {
@@ -132,6 +134,8 @@ export default function DashboardPage() {
     plans,
     assets,
     droneJobs,
+    concepts,
+    contextKeys,
     loading,
     refresh,
   } = useDashboardStore()
@@ -144,6 +148,8 @@ export default function DashboardPage() {
   const totalTasks = tasks.open.length + tasks.in_progress.length
   const activePlans = plans.filter((p) => p.status === 'active' || p.status === 'in_progress').length
   const activeDroneJobs = droneJobs.filter((j) => j.status === 'pending' || j.status === 'claimed').length
+  const characterCount = concepts.filter((c) => c.type === 'character').length
+  const contextNamespaces = new Set(contextKeys.map((k) => k.namespace)).size
   const recentEvents = events.slice(0, 20)
 
   return (
@@ -165,7 +171,7 @@ export default function DashboardPage() {
       </div>
 
       {/* Summary cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-9 gap-3">
         <SummaryCard
           title="Agents"
           value={`${onlineAgents}/${agents.length}`}
@@ -214,6 +220,20 @@ export default function DashboardPage() {
           subtitle={`${droneJobs.length} total jobs`}
           color="blue"
           icon="drones"
+        />
+        <SummaryCard
+          title="Concepts"
+          value={concepts.length}
+          subtitle={`${characterCount} characters`}
+          color="purple"
+          icon="concepts"
+        />
+        <SummaryCard
+          title="Context"
+          value={contextKeys.length}
+          subtitle={`${contextNamespaces} namespaces`}
+          color="muted"
+          icon="context"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- **Concepts page** (`/concepts`): Full CRUD with type filter tabs (character/style/ruleset/library/brand/custom), ConceptCard component, slide-in detail panel with editable fields, project linking/unlinking, JSON data viewer/editor, create modal, and delete with confirmation
- **Context Keys page** (`/context`): Namespace-grouped key-value viewer/editor with collapsible sections, inline editing, add key form, and delete with confirmation
- **Bug fix**: Fixed `ContextEntry` type to use `data` instead of `value` to match backend `dv_context_keys` column — `updateContextKey()` was silently failing
- **Dashboard integration**: Added summary cards and quick links for Concepts and Context; added 8 new API endpoint functions

## Files Changed
| File | Change |
|------|--------|
| `api/types.ts` | Fix ContextEntry/ContextKey `data` field |
| `api/endpoints.ts` | Fix updateContextKey, add 7 new endpoints |
| `components/concepts/ConceptCard.tsx` | **New** — concept card component |
| `pages/ConceptsPage.tsx` | **New** — full CRUD concepts page |
| `pages/ContextPage.tsx` | **New** — namespace-grouped context viewer/editor |
| `App.tsx` | Add 2 routes |
| `layouts/SideNav.tsx` | Add 2 nav items |
| `layouts/AppLayout.tsx` | Add 2 route titles |
| `pages/DashboardPage.tsx` | Add summary cards + quick links |
| `components/dashboard/SummaryCard.tsx` | Add 2 icons |

## Test Plan
- [x] `tsc --noEmit` — zero TypeScript errors
- [x] `vite build` — compiles clean
- [ ] `/concepts` shows type filter tabs, concept cards, clickable detail panel, create modal
- [ ] `/context` shows namespace groups, expandable key values, inline editing
- [ ] Dashboard shows Concepts + Context summary cards and quick links
- [ ] SideNav shows Concepts and Context links

🤖 Generated with [Claude Code](https://claude.com/claude-code)