### PR TITLE
feat: React dashboard — concepts, context, threading, and task/PR linking

### DIFF
--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -20,6 +20,7 @@ import type {
   ChannelMember,
   ChannelMessage,
   DroneJob,
+  ThreadSummary,
 } from './types';
 
 // Auth
@@ -61,6 +62,16 @@ export function updateTask(id: string, data: Partial<Task>): Promise<Task> {
 
 export function sendMessage(data: Partial<Message>): Promise<Message> {
   return apiPost<Message>('/messages', data);
+}
+
+// Threads
+
+export function fetchThreads(limit = 50): Promise<ThreadSummary[]> {
+  return apiGet<ThreadSummary[]>(`/messages/threads?limit=${limit}`);
+}
+
+export function fetchThreadMessages(threadId: string): Promise<Message[]> {
+  return apiGet<Message[]>(`/messages?thread=${encodeURIComponent(threadId)}`);
 }
 
 // Team Chat

--- a/studio-react/src/api/types.ts
+++ b/studio-react/src/api/types.ts
@@ -251,6 +251,13 @@ export interface DroneJob {
   workspace_branch: string;
 }
 
+export interface ThreadSummary {
+  thread_id: string;
+  message_count: number;
+  last_message_at: string;
+  last_sender: string;
+}
+
 export interface DroneArtifact {
   name: string;
   size: number;

--- a/studio-react/src/api/types.ts
+++ b/studio-react/src/api/types.ts
@@ -34,6 +34,9 @@ export interface Task {
   needs_approval: boolean;
   approved_by: string | null;
   approved_at: string | null;
+  branch: string | null;
+  pr_url: string | null;
+  repo: string | null;
   created_at: string;
   updated_at: string;
   metadata: Record<string, unknown> | null;
@@ -149,6 +152,9 @@ export interface PlanStep {
   description: string;
   status: string;
   assignee: string | null;
+  linked_task_id: number | null;
+  linked_branch: string | null;
+  linked_pr_url: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/studio-react/src/components/messages/ThreadPanel.tsx
+++ b/studio-react/src/components/messages/ThreadPanel.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { fetchThreadMessages, sendMessage } from '../../api/endpoints'
+import { useDashboardStore } from '../../stores/dashboardStore'
+import type { Message } from '../../api/types'
+import { Avatar, formatTime } from './ChatMessage'
+import Badge from '../shared/Badge'
+
+const msgTypeBadge: Record<string, 'red' | 'accent' | 'default'> = {
+  directive: 'red',
+  request: 'accent',
+  message: 'default',
+}
+
+interface ThreadPanelProps {
+  message: Message
+  onClose: () => void
+}
+
+export default function ThreadPanel({ message, onClose }: ThreadPanelProps) {
+  const refresh = useDashboardStore((s) => s.refresh)
+  const [threadMessages, setThreadMessages] = useState<Message[]>([])
+  const [loading, setLoading] = useState(true)
+  const [replyContent, setReplyContent] = useState('')
+  const [sending, setSending] = useState(false)
+  const bodyRef = useRef<HTMLDivElement>(null)
+
+  const threadId = message.thread_id || message.id.toString()
+
+  const loadThread = useCallback(async () => {
+    setLoading(true)
+    try {
+      const msgs = await fetchThreadMessages(threadId)
+      // Filter out the root message — we show it separately from props
+      setThreadMessages(
+        msgs
+          .filter((m) => m.id.toString() !== message.id.toString())
+          .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()),
+      )
+    } catch (err) {
+      console.error('Failed to load thread:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [threadId, message.id])
+
+  useEffect(() => {
+    loadThread()
+  }, [loadThread])
+
+  // Scroll to bottom when messages load
+  useEffect(() => {
+    if (!loading && bodyRef.current) {
+      bodyRef.current.scrollTop = bodyRef.current.scrollHeight
+    }
+  }, [loading, threadMessages.length])
+
+  // Escape key closes panel
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const handleSend = useCallback(async () => {
+    const content = replyContent.trim()
+    if (!content || sending) return
+    setSending(true)
+    try {
+      await sendMessage({
+        from_agent: '__admin__',
+        to_agent: message.from_agent,
+        game: message.game,
+        content,
+        thread_id: threadId,
+        msg_type: 'message',
+      })
+      setReplyContent('')
+      await loadThread()
+      await refresh()
+    } catch (err) {
+      console.error('Failed to send reply:', err)
+    } finally {
+      setSending(false)
+    }
+  }, [replyContent, sending, message.from_agent, message.game, threadId, loadThread, refresh])
+
+  const replyCount = threadMessages.length
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-bg/60 z-40"
+        onClick={onClose}
+        aria-hidden
+      />
+
+      {/* Slide-in panel */}
+      <div className="fixed top-0 right-0 h-full w-full max-w-lg bg-surface border-l border-border z-50 flex flex-col animate-in slide-in-from-right">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border shrink-0">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold text-text">Thread</h2>
+            {!loading && (
+              <span className="text-xs text-text-muted">
+                {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+              </span>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-text-muted hover:text-text transition-colors p-1 -mr-1 shrink-0"
+            aria-label="Close"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M5 5l10 10M15 5L5 15" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div ref={bodyRef} className="flex-1 overflow-y-auto px-4 py-3">
+          {/* Root message */}
+          <div className="pb-3">
+            <div className="flex items-start gap-2">
+              <Avatar name={message.from_agent} />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="font-semibold text-sm text-text">{message.from_agent}</span>
+                  <svg viewBox="0 0 12 12" className="w-3 h-3 text-text-muted shrink-0" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M2 6h8M7 3l3 3-3 3" />
+                  </svg>
+                  <span className="font-semibold text-sm text-text-dim">{message.to_agent}</span>
+                  <Badge variant={msgTypeBadge[message.msg_type] ?? 'default'}>{message.msg_type}</Badge>
+                  <span className="text-text-muted text-xs">{formatTime(message.created_at)}</span>
+                </div>
+                <p className="text-text text-sm whitespace-pre-wrap break-words mt-1">
+                  {message.content}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Divider */}
+          {replyCount > 0 && (
+            <div className="flex items-center gap-3 py-2">
+              <div className="flex-1 h-px bg-border" />
+              <span className="text-text-muted text-xs font-medium shrink-0">
+                {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+              </span>
+              <div className="flex-1 h-px bg-border" />
+            </div>
+          )}
+
+          {/* Thread replies */}
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <span className="text-text-muted text-sm">Loading thread...</span>
+            </div>
+          ) : (
+            threadMessages.map((msg) => (
+              <div key={msg.id} className="py-1.5">
+                <div className="flex items-start gap-2">
+                  <Avatar name={msg.from_agent} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold text-sm text-text">{msg.from_agent}</span>
+                      <span className="text-text-muted text-xs">{formatTime(msg.created_at)}</span>
+                    </div>
+                    <p className="text-text text-sm whitespace-pre-wrap break-words mt-0.5">
+                      {msg.content}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Footer — reply composer */}
+        <div className="border-t border-border p-4 shrink-0">
+          <textarea
+            value={replyContent}
+            onChange={(e) => setReplyContent(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault()
+                handleSend()
+              }
+            }}
+            rows={3}
+            placeholder="Reply in thread..."
+            className="w-full bg-surface-raised border border-border rounded-sm px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40 resize-none"
+          />
+          <div className="flex items-center justify-between mt-2">
+            <span className="text-xs text-text-muted">
+              {navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'}+Enter to send
+            </span>
+            <button
+              type="button"
+              onClick={handleSend}
+              disabled={!replyContent.trim() || sending}
+              className="px-4 py-1.5 rounded-sm text-sm font-medium bg-accent text-bg hover:bg-accent-light transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {sending ? 'Sending...' : 'Reply'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/studio-react/src/components/plans/StepChecklist.tsx
+++ b/studio-react/src/components/plans/StepChecklist.tsx
@@ -4,6 +4,12 @@ import Badge from '../shared/Badge'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+function formatPrUrl(url: string): string {
+  const ghMatch = url.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/)
+  if (ghMatch) return `${ghMatch[1]}#${ghMatch[2]}`
+  return url.replace(/^https?:\/\//, '').slice(0, 40)
+}
+
 const statusConfig: Record<string, { variant: 'green' | 'blue' | 'muted' | 'default'; label: string }> = {
   pending: { variant: 'default', label: 'pending' },
   in_progress: { variant: 'blue', label: 'in progress' },
@@ -164,6 +170,38 @@ export default function StepChecklist({ steps, planId, onStepUpdate }: StepCheck
                   <p className="text-text-muted text-xs mt-1.5">
                     Assigned to <span className="text-text-dim">{step.assignee}</span>
                   </p>
+                )}
+                {(step.linked_task_id || step.linked_branch || step.linked_pr_url) && (
+                  <div className="mt-2 pt-2 border-t border-border/50 space-y-1">
+                    {step.linked_task_id && (
+                      <p className="text-xs">
+                        <Badge variant="blue">Task #{step.linked_task_id}</Badge>
+                      </p>
+                    )}
+                    {step.linked_branch && (
+                      <p className="text-xs text-text-dim">
+                        <svg viewBox="0 0 16 16" className="w-3.5 h-3.5 inline-block mr-1 text-text-muted" fill="currentColor">
+                          <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
+                        </svg>
+                        <span className="font-mono">{step.linked_branch}</span>
+                      </p>
+                    )}
+                    {step.linked_pr_url && (
+                      <p className="text-xs">
+                        <a
+                          href={step.linked_pr_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-accent hover:text-accent-light transition-colors"
+                        >
+                          {formatPrUrl(step.linked_pr_url)}
+                          <svg viewBox="0 0 12 12" className="w-3 h-3 inline-block ml-1 text-text-muted" fill="none" stroke="currentColor" strokeWidth="1.5">
+                            <path d="M7 1h4v4M11 1L5.5 6.5M9 7v3.5a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-7a.5.5 0 0 1 .5-.5H5" />
+                          </svg>
+                        </a>
+                      </p>
+                    )}
+                  </div>
                 )}
               </div>
             )}

--- a/studio-react/src/components/tasks/TaskDetail.tsx
+++ b/studio-react/src/components/tasks/TaskDetail.tsx
@@ -172,6 +172,37 @@ export default function TaskDetail({ task, onClose }: TaskDetailProps) {
             </div>
           </div>
 
+          {/* Source (branch / PR / repo) */}
+          {(task.branch || task.pr_url || task.repo) && (
+            <div>
+              <h3 className="text-xs uppercase tracking-wider text-text-muted font-medium mb-2">Source</h3>
+              <div className="space-y-1.5">
+                {task.repo && (
+                  <div className="text-sm text-text-dim font-mono">{task.repo}</div>
+                )}
+                {task.branch && (
+                  <div className="text-sm text-text-dim">
+                    <BranchIcon />
+                    <span className="font-mono">{task.branch}</span>
+                  </div>
+                )}
+                {task.pr_url && (
+                  <div className="text-sm">
+                    <a
+                      href={task.pr_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-accent hover:text-accent-light transition-colors"
+                    >
+                      {formatPrUrl(task.pr_url)}
+                      <ExternalLinkIcon />
+                    </a>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
           {/* Tags */}
           {(() => {
             const tags = parseTags(task.tags)
@@ -267,6 +298,28 @@ export default function TaskDetail({ task, onClose }: TaskDetailProps) {
         </div>
       </div>
     </>
+  )
+}
+
+function formatPrUrl(url: string): string {
+  const ghMatch = url.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/)
+  if (ghMatch) return `${ghMatch[1]}#${ghMatch[2]}`
+  return url.replace(/^https?:\/\//, '').slice(0, 40)
+}
+
+function BranchIcon() {
+  return (
+    <svg viewBox="0 0 16 16" className="w-3.5 h-3.5 inline-block mr-1 text-text-muted" fill="currentColor">
+      <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
+    </svg>
+  )
+}
+
+function ExternalLinkIcon() {
+  return (
+    <svg viewBox="0 0 12 12" className="w-3 h-3 inline-block ml-1 text-text-muted" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M7 1h4v4M11 1L5.5 6.5M9 7v3.5a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-7a.5.5 0 0 1 .5-.5H5" />
+    </svg>
   )
 }
 

--- a/studio-react/src/pages/MessagesPage.tsx
+++ b/studio-react/src/pages/MessagesPage.tsx
@@ -4,6 +4,7 @@ import { resolveRequest, sendMessage } from '../api/endpoints'
 import type { Message } from '../api/types'
 import { Avatar, formatTime } from '../components/messages/ChatMessage'
 import Badge from '../components/shared/Badge'
+import ThreadPanel from '../components/messages/ThreadPanel'
 
 // ─── Date separator ──────────────────────────────────────────────────────────
 
@@ -82,6 +83,8 @@ function AgentMessage({
   onToggleExpand,
   onResolve,
   isResolving,
+  threadCount,
+  onOpenThread,
 }: {
   msg: Message
   isGrouped: boolean
@@ -89,6 +92,8 @@ function AgentMessage({
   onToggleExpand: () => void
   onResolve: (id: string) => void
   isResolving: boolean
+  threadCount?: number
+  onOpenThread?: () => void
 }) {
   const content = msg.content
   const shouldTruncate = content.length > 200
@@ -96,6 +101,32 @@ function AgentMessage({
     shouldTruncate && !isExpanded ? content.slice(0, 200) + '...' : content
 
   const isPendingRequest = msg.msg_type === 'request' && msg.status === 'pending'
+
+  const threadIndicator = threadCount && threadCount > 1 && onOpenThread ? (
+    <button
+      onClick={onOpenThread}
+      className="flex items-center gap-1 mt-1 text-xs text-accent hover:text-accent-light hover:underline underline-offset-2 transition-colors"
+    >
+      <svg viewBox="0 0 16 16" className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M2 4h12M2 8h8M2 12h5" />
+      </svg>
+      {threadCount - 1} {threadCount - 1 === 1 ? 'reply' : 'replies'}
+    </button>
+  ) : null
+
+  const replyButton = onOpenThread ? (
+    <button
+      onClick={onOpenThread}
+      className="opacity-0 group-hover:opacity-100 transition-opacity text-text-muted hover:text-accent text-xs flex items-center gap-1 mt-1"
+      title="Reply in thread"
+    >
+      <svg viewBox="0 0 16 16" className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M5 5L2 8l3 3" />
+        <path d="M2 8h8c2.2 0 4 1.8 4 4v1" />
+      </svg>
+      Reply
+    </button>
+  ) : null
 
   if (isGrouped) {
     return (
@@ -120,6 +151,8 @@ function AgentMessage({
             {isResolving ? 'Resolving...' : 'Resolve'}
           </button>
         )}
+        {threadIndicator}
+        {!threadIndicator && replyButton}
       </div>
     )
   }
@@ -164,6 +197,8 @@ function AgentMessage({
               {isResolving ? 'Resolving...' : 'Resolve'}
             </button>
           )}
+          {threadIndicator}
+          {!threadIndicator && replyButton}
         </div>
       </div>
     </div>
@@ -185,8 +220,17 @@ export default function MessagesPage() {
   const [composeContent, setComposeContent] = useState('')
   const [composeMsgType, setComposeMsgType] = useState<'message' | 'request' | 'directive'>('message')
   const [sending, setSending] = useState(false)
+  const [threadRootMsg, setThreadRootMsg] = useState<Message | null>(null)
 
   const pendingCount = useMemo(() => pendingRequests.length, [pendingRequests])
+
+  const threadCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const msg of messages) {
+      if (msg.thread_id) counts.set(msg.thread_id, (counts.get(msg.thread_id) || 0) + 1)
+    }
+    return counts
+  }, [messages])
 
   const sorted = useMemo(
     () => [...messages].sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()),
@@ -295,6 +339,8 @@ export default function MessagesPage() {
                   onToggleExpand={() => toggleExpand(msg.id)}
                   onResolve={handleResolve}
                   isResolving={resolvingId === msg.id}
+                  threadCount={msg.thread_id ? threadCounts.get(msg.thread_id) : undefined}
+                  onOpenThread={() => setThreadRootMsg(msg)}
                 />
               </div>
             )
@@ -347,6 +393,14 @@ export default function MessagesPage() {
           </button>
         </div>
       </div>
+
+      {/* Thread slide-in panel */}
+      {threadRootMsg && (
+        <ThreadPanel
+          message={threadRootMsg}
+          onClose={() => setThreadRootMsg(null)}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **Concepts page** — full CRUD with type filter tabs, detail panel, project linking, JSON data editor
- **Context Keys page** — namespace-grouped key-value viewer/editor with inline editing
- **Message threading UI** — thread indicators on messages, slide-in ThreadPanel with reply composer
- **Task/PR/Plan linking UI** — surface `branch`, `pr_url`, `repo` on TaskDetail; show `linked_task_id`, `linked_branch`, `linked_pr_url` on plan steps with git-branch icons, clickable PR links (`owner/repo#N` format), and linked task badges
- Dashboard summary cards + quick links for Concepts and Context sections

## Files changed
- 14 files changed, 1570 insertions

## Test plan
- [ ] Concepts page: create, edit, delete concepts; filter by type; link/unlink projects; edit JSON data
- [ ] Context Keys page: browse namespaces, view/edit values, create/delete keys
- [ ] Messages: threaded messages show reply indicators; clicking opens ThreadPanel
- [ ] Tasks with `branch`/`pr_url`/`repo` show Source section in TaskDetail
- [ ] Plan steps with linked fields show task badge, branch, and PR link in expanded view
- [ ] PR links open in new tab; null/empty fields are hidden
- [ ] Build compiles clean: `cd studio-react && npx tsc --noEmit && npx vite build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)