### PR TITLE
fix: drone timestamp NaN + message time filter

### DIFF
--- a/studio-react/src/pages/DronesPage.tsx
+++ b/studio-react/src/pages/DronesPage.tsx
@@ -16,9 +16,17 @@ const statusDot: Record<string, string> = {
   offline: 'bg-text-muted',
 }
 
+function parseTimestamp(dateStr: string): number {
+  // Handle mixed formats: "2026-03-02 02:27:48" and "2026-03-02T02:27:53.214Z"
+  if (dateStr.includes('T')) return new Date(dateStr).getTime()
+  return new Date(dateStr.replace(' ', 'T') + 'Z').getTime()
+}
+
 function timeAgo(dateStr: string | null): string {
   if (!dateStr) return '-'
-  const diff = Date.now() - new Date(dateStr + 'Z').getTime()
+  const ts = parseTimestamp(dateStr)
+  if (isNaN(ts)) return '-'
+  const diff = Date.now() - ts
   if (diff < 60000) return 'just now'
   if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago'
   if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago'

--- a/studio-react/src/pages/MessagesPage.tsx
+++ b/studio-react/src/pages/MessagesPage.tsx
@@ -221,6 +221,7 @@ export default function MessagesPage() {
   const [composeMsgType, setComposeMsgType] = useState<'message' | 'request' | 'directive'>('message')
   const [sending, setSending] = useState(false)
   const [threadRootMsg, setThreadRootMsg] = useState<Message | null>(null)
+  const [timeRange, setTimeRange] = useState<string>('3h')
 
   const pendingCount = useMemo(() => pendingRequests.length, [pendingRequests])
 
@@ -232,10 +233,17 @@ export default function MessagesPage() {
     return counts
   }, [messages])
 
-  const sorted = useMemo(
-    () => [...messages].sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()),
-    [messages],
-  )
+  const sorted = useMemo(() => {
+    const all = [...messages].sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+    if (timeRange === 'all') return all
+    const hours: Record<string, number> = { '1h': 1, '3h': 3, '12h': 12, '24h': 24, '7d': 168 }
+    const ms = (hours[timeRange] ?? 3) * 3600000
+    const cutoff = Date.now() - ms
+    return all.filter((m) => {
+      const t = m.created_at.includes('T') ? new Date(m.created_at).getTime() : new Date(m.created_at.replace(' ', 'T') + 'Z').getTime()
+      return t >= cutoff
+    })
+  }, [messages, timeRange])
 
   const { containerRef, handleScroll } = useAutoScroll([sorted.length])
 
@@ -297,16 +305,31 @@ export default function MessagesPage() {
             </span>
           )}
         </div>
-        <button
-          onClick={() => refresh()}
-          className="text-text-muted hover:text-text transition-colors p-1 rounded-sm hover:bg-surface-raised"
-          title="Refresh"
-        >
-          <svg viewBox="0 0 16 16" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="1.5">
-            <path d="M2.5 8a5.5 5.5 0 0 1 9.3-4M13.5 8a5.5 5.5 0 0 1-9.3 4" />
-            <path d="M11.5 1v3h3M4.5 15v-3h-3" />
-          </svg>
-        </button>
+        <div className="flex items-center gap-2">
+          <select
+            value={timeRange}
+            onChange={(e) => setTimeRange(e.target.value)}
+            className="bg-surface-raised text-text text-xs rounded px-2 py-1 border border-border focus:outline-none focus:ring-1 ring-accent"
+          >
+            <option value="1h">Last hour</option>
+            <option value="3h">Last 3 hours</option>
+            <option value="12h">Last 12 hours</option>
+            <option value="24h">Last 24 hours</option>
+            <option value="7d">Last 7 days</option>
+            <option value="all">All time</option>
+          </select>
+          <span className="text-xs text-text-muted tabular-nums">{sorted.length} msgs</span>
+          <button
+            onClick={() => refresh()}
+            className="text-text-muted hover:text-text transition-colors p-1 rounded-sm hover:bg-surface-raised"
+            title="Refresh"
+          >
+            <svg viewBox="0 0 16 16" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M2.5 8a5.5 5.5 0 0 1 9.3-4M13.5 8a5.5 5.5 0 0 1-9.3 4" />
+              <path d="M11.5 1v3h3M4.5 15v-3h-3" />
+            </svg>
+          </button>
+        </div>
       </div>
 
       {/* Message list */}


### PR DESCRIPTION
## Summary
- **DronesPage**: Fix "NaNd ago" timestamps caused by mixed API formats (space-separated `2026-03-02 02:27:48` vs ISO `2026-03-02T02:27:53.214Z`). New `parseTimestamp()` normalizes both.
- **MessagesPage**: Add time range dropdown defaulting to last 3 hours. Options: 1h, 3h, 12h, 24h, 7d, all time. Shows message count.

## Test plan
- [ ] Drones page shows correct relative timestamps (not NaN) for all job fields
- [ ] Messages page defaults to showing only last 3 hours of messages
- [ ] Time range dropdown filters messages correctly across all options
- [ ] "All time" shows full message history
- [ ] Message count updates when filter changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)