### PR TITLE
feat: Admin Ops dashboard page

### DIFF
--- a/studio-react/src/App.tsx
+++ b/studio-react/src/App.tsx
@@ -15,6 +15,7 @@ import ApprovalsPage from './pages/ApprovalsPage'
 import DronesPage from './pages/DronesPage'
 import ConceptsPage from './pages/ConceptsPage'
 import ContextPage from './pages/ContextPage'
+import AdminOpsPage from './pages/AdminOpsPage'
 
 export default function App() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
@@ -46,6 +47,7 @@ export default function App() {
           <Route path="drones" element={<DronesPage />} />
           <Route path="concepts" element={<ConceptsPage />} />
           <Route path="context" element={<ContextPage />} />
+          <Route path="ops" element={<AdminOpsPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -3,6 +3,7 @@
 import { apiGet, apiPost, apiPut, apiDelete, setToken, getToken } from './client';
 import type {
   Overview,
+  AdminOps,
   Task,
   Message,
   TeamChat,
@@ -46,6 +47,12 @@ export function isAuthenticated(): boolean {
 
 export function fetchOverview(): Promise<Overview> {
   return apiGet<Overview>('/admin/overview');
+}
+
+// Admin Ops
+
+export function fetchAdminOps(): Promise<AdminOps> {
+  return apiGet<AdminOps>('/admin/ops');
 }
 
 // Tasks

--- a/studio-react/src/api/types.ts
+++ b/studio-react/src/api/types.ts
@@ -271,6 +271,16 @@ export interface DroneArtifact {
   url: string;
 }
 
+export interface AdminOps {
+  pending_requests: Message[]
+  unassigned_tasks: Task[]
+  unassigned_bugs: Bug[]
+  failed_drone_jobs: DroneJob[]
+  pending_approvals: Approval[]
+  stale_requests: Message[]
+  open_prs: { number: number; title: string; url: string; author: string; created_at: string }[]
+}
+
 export interface Overview {
   agents: Agent[];
   events: Event[];

--- a/studio-react/src/layouts/SideNav.tsx
+++ b/studio-react/src/layouts/SideNav.tsx
@@ -16,6 +16,7 @@ const navItems = [
   { to: '/drones', label: 'Drones', abbr: 'Dr' },
   { to: '/concepts', label: 'Concepts', abbr: 'Co' },
   { to: '/context', label: 'Context', abbr: 'Cx' },
+  { to: '/ops', label: 'Admin Ops', abbr: 'Ao' },
 ] as const
 
 export default function SideNav() {

--- a/studio-react/src/pages/AdminOpsPage.tsx
+++ b/studio-react/src/pages/AdminOpsPage.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useState, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import { fetchAdminOps, resolveRequest, cancelDroneJob, createDroneJob } from '../api/endpoints'
+import type { AdminOps } from '../api/types'
+import Badge from '../components/shared/Badge'
+
+function parseTimestamp(dateStr: string): number {
+  if (dateStr.includes('T')) return new Date(dateStr).getTime()
+  return new Date(dateStr.replace(' ', 'T') + 'Z').getTime()
+}
+
+function timeAgo(dateStr: string): string {
+  const ts = parseTimestamp(dateStr)
+  if (isNaN(ts)) return '-'
+  const diff = Date.now() - ts
+  if (diff < 60000) return 'just now'
+  if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago'
+  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago'
+  return Math.floor(diff / 86400000) + 'd ago'
+}
+
+function truncate(str: string, len = 80): string {
+  return str.length > len ? str.slice(0, len) + '...' : str
+}
+
+export default function AdminOpsPage() {
+  const [ops, setOps] = useState<AdminOps | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setOps(await fetchAdminOps())
+    } catch (err) {
+      console.error('Failed to fetch admin ops:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const handleResolveRequest = useCallback(async (id: string) => {
+    setActionLoading(`req-${id}`)
+    try {
+      await resolveRequest(id, 'resolved')
+      await load()
+    } catch (err) { console.error('Resolve failed:', err) }
+    finally { setActionLoading(null) }
+  }, [load])
+
+  const handleRetryJob = useCallback(async (job: AdminOps['failed_drone_jobs'][0]) => {
+    setActionLoading(`job-${job.id}`)
+    try {
+      await createDroneJob({
+        title: job.title,
+        command: job.command,
+        requires: job.requires,
+        priority: job.priority,
+        input_data: job.input_data,
+      })
+      await load()
+    } catch (err) { console.error('Retry failed:', err) }
+    finally { setActionLoading(null) }
+  }, [load])
+
+  const handleCancelJob = useCallback(async (id: number) => {
+    setActionLoading(`job-${id}`)
+    try {
+      await cancelDroneJob(id)
+      await load()
+    } catch (err) { console.error('Cancel failed:', err) }
+    finally { setActionLoading(null) }
+  }, [load])
+
+  const totalCount = ops
+    ? ops.pending_requests.length + ops.unassigned_tasks.length + ops.unassigned_bugs.length +
+      ops.failed_drone_jobs.length + ops.pending_approvals.length + ops.stale_requests.length + ops.open_prs.length
+    : 0
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <div>
+            <h1 className="text-xl font-semibold text-text">Admin Ops</h1>
+            <p className="text-sm text-text-muted mt-0.5">Actionable items requiring attention</p>
+          </div>
+          {totalCount > 0 && (
+            <Badge variant="red">{totalCount}</Badge>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={load}
+          disabled={loading}
+          className="text-xs text-text-muted hover:text-accent transition-colors px-3 py-1.5 rounded bg-surface-raised hover:ring-1 ring-border disabled:opacity-50"
+        >
+          {loading ? 'Loading...' : 'Refresh'}
+        </button>
+      </div>
+
+      {loading && !ops && (
+        <div className="text-center text-text-muted py-12 text-sm animate-pulse">Loading ops...</div>
+      )}
+
+      {ops && totalCount === 0 && (
+        <div className="bg-surface rounded-lg p-8 text-center">
+          <p className="text-green font-medium">All clear</p>
+          <p className="text-sm text-text-muted mt-1">No actionable items right now.</p>
+        </div>
+      )}
+
+      {ops && totalCount > 0 && (
+        <div className="flex-1 overflow-y-auto space-y-4">
+          {/* Pending Requests */}
+          {ops.pending_requests.length > 0 && (
+            <Section title="Pending Requests" count={ops.pending_requests.length} linkTo="/messages" variant="accent">
+              {ops.pending_requests.map((msg) => (
+                <div key={msg.id} className="flex items-center gap-2 py-2 px-3 rounded hover:bg-surface-raised/50 text-sm">
+                  <span className="text-text-muted font-mono text-xs shrink-0">#{msg.id}</span>
+                  <span className="text-accent font-mono text-xs shrink-0">{msg.from_agent}</span>
+                  <span className="text-text-muted text-xs shrink-0">-&gt;</span>
+                  <span className="text-accent font-mono text-xs shrink-0">{msg.to_agent}</span>
+                  <span className="text-text-dim truncate flex-1 min-w-0">{truncate(msg.content)}</span>
+                  <button
+                    onClick={() => handleResolveRequest(msg.id)}
+                    disabled={actionLoading === `req-${msg.id}`}
+                    className="px-2 py-0.5 rounded text-xs font-medium bg-green/10 text-green hover:bg-green/20 transition-colors disabled:opacity-50 shrink-0"
+                  >
+                    {actionLoading === `req-${msg.id}` ? '...' : 'Resolve'}
+                  </button>
+                  <span className="text-text-muted text-xs font-mono shrink-0">{timeAgo(msg.created_at)}</span>
+                </div>
+              ))}
+            </Section>
+          )}
+
+          {/* Unassigned Tasks */}
+          {ops.unassigned_tasks.length > 0 && (
+            <Section title="Unassigned Tasks" count={ops.unassigned_tasks.length} linkTo="/tasks" variant="accent">
+              {ops.unassigned_tasks.map((task) => (
+                <div key={task.id} className="flex items-center gap-2 py-2 px-3 rounded hover:bg-surface-raised/50 text-sm">
+                  <span className="text-text-muted font-mono text-xs shrink-0">#{task.id}</span>
+                  <Badge variant={task.priority === 'high' || task.priority === 'urgent' ? 'red' : 'muted'}>{task.priority}</Badge>
+                  <span className="text-text-dim truncate flex-1 min-w-0">{task.title}</span>
+                  <span className="text-text-muted text-xs font-mono shrink-0">{timeAgo(task.created_at)}</span>
+                </div>
+              ))}
+            </Section>
+          )}
+
+          {/* Unassigned Bugs */}
+          {ops.unassigned_bugs.length > 0 && (
+            <Section title="Unassigned Bugs" count={ops.unassigned_bugs.length} linkTo="/bugs" variant="red">
+              {ops.unassigned_bugs.map((bug) => (
+                <div key={bug.id} className="flex items-center gap-2 py-2 px-3 rounded hover:bg-surface-raised/50 text-sm">
+                  <span className="text-text-muted font-mono text-xs shrink-0">#{bug.id}</span>
+                  <Badge variant={bug.severity === 'high' || bug.severity === 'critical' ? 'red' : 'muted'}>{bug.severity}</Badge>
+                  <span className="text-text-dim truncate flex-1 min-w-0">{bug.title}</span>
+                  <span className="text-text-muted text-xs font-mono shrink-0">{timeAgo(bug.created_at)}</span>
+                </div>
+              ))}
+            </Section>
+          )}
+
+          {/* Failed Drone Jobs */}
+          {ops.failed_drone_jobs.length > 0 && (
+            <Section title="Failed Drone Jobs" count={ops.failed_drone_jobs.length} linkTo="/drones" variant="red">
+              {ops.failed_drone_jobs.map((job) => (
+                <div key={job.id} className="flex items-center gap-2 py-2 px-3 rounded hover:bg-surface-raised/50 text-sm">
+                  <span className="text-text-muted font-mono text-xs shrink-0">#{job.id}</span>
+                  <span className="text-text-dim truncate flex-1 min-w-0">
+                    {job.title || job.command}
+                    {job.error && <span className="text-red/70 ml-1">— {truncate(job.error, 40)}</span>}
+                  </span>
+                  <button
+                    onClick={() => handleRetryJob(job)}
+                    disabled={actionLoading === `job-${job.id}`}
+                    className="px-2 py-0.5 rounded text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50 shrink-0"
+                  >
+                    {actionLoading === `job-${job.id}` ? '...' : 'Retry'}
+                  </button>
+                  <button
+                    onClick={() => handleCancelJob(job.id)}
+                    disabled={actionLoading === `job-${job.id}`}
+                    className="px-2 py-0.5 rounded text-xs font-medium bg-red/10 text-red hover:bg-red/20 transition-colors disabled:opacity-50 shrink-0"
+                  >
+                    {actionLoading === `job-${job.id}` ? '...' : 'Cancel'}
+                  </button>
+                  <span className="text-text-muted text-xs font-mono shrink-0">{timeAgo(job.created_at)}</span>
+                </div>
+              ))}
+            </Section>
+          )}
+
+          {/* Pending Approvals */}
+          {ops.pending_approvals.length > 0 && (
+            <Section title="Pending Approvals" count={ops.pending_approvals.length} linkTo="/approvals" variant="accent">
+              {ops.pending_approvals.map((approval) => (
+                <div key={approval.id} className="flex items-center gap-2 py-2 px-3 rounded hover:bg-surface-raised/50 text-sm">
+                  <span className="text-text-muted font-mono text-xs shrink-0">#{approval.id}</span>
+                  <Badge variant="accent">{approval.risk_tier}</Badge>
+                  <span className="text-text-dim truncate flex-1 min-w-0">
+                    {approval.entity_type} by {approval.created_by}
+                  </span>
+                  <span className="text-text-muted text-xs font-mono shrink-0">{timeAgo(approval.created_at)}</span>
+                </div>
+              ))}
+            </Section>
+          )}
+
+          {/* Stale Requests */}
+          {ops.stale_requests.length > 0 && (
+            <Section title="Stale Requests" count={ops.stale_requests.length} linkTo="/messages" variant="muted">
+              {ops.stale_requests.map((msg) => (
+                <div key={msg.id} className="flex items-center gap-2 py-2 px-3 rounded hover:bg-surface-raised/50 text-sm">
+                  <span className="text-text-muted font-mono text-xs shrink-0">#{msg.id}</span>
+                  <span className="text-accent font-mono text-xs shrink-0">{msg.from_agent}</span>
+                  <span className="text-text-muted text-xs shrink-0">-&gt;</span>
+                  <span className="text-accent font-mono text-xs shrink-0">{msg.to_agent}</span>
+                  <span className="text-text-dim truncate flex-1 min-w-0">{truncate(msg.content)}</span>
+                  <button
+                    onClick={() => handleResolveRequest(msg.id)}
+                    disabled={actionLoading === `req-${msg.id}`}
+                    className="px-2 py-0.5 rounded text-xs font-medium bg-text-muted/10 text-text-muted hover:bg-text-muted/20 transition-colors disabled:opacity-50 shrink-0"
+                  >
+                    {actionLoading === `req-${msg.id}` ? '...' : 'Resolve'}
+                  </button>
+                  <span className="text-text-muted text-xs font-mono shrink-0">{timeAgo(msg.created_at)}</span>
+                </div>
+              ))}
+            </Section>
+          )}
+
+          {/* Open PRs */}
+          {ops.open_prs.length > 0 && (
+            <Section title="Open PRs" count={ops.open_prs.length} variant="blue">
+              {ops.open_prs.map((pr) => (
+                <div key={pr.number} className="flex items-center gap-2 py-2 px-3 rounded hover:bg-surface-raised/50 text-sm">
+                  <span className="text-text-muted font-mono text-xs shrink-0">#{pr.number}</span>
+                  <span className="text-text-dim truncate flex-1 min-w-0">{pr.title}</span>
+                  <span className="text-accent font-mono text-xs shrink-0">{pr.author}</span>
+                  <a
+                    href={pr.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="px-2 py-0.5 rounded text-xs font-medium bg-blue/10 text-blue hover:bg-blue/20 transition-colors shrink-0"
+                  >
+                    View
+                  </a>
+                  <span className="text-text-muted text-xs font-mono shrink-0">{timeAgo(pr.created_at)}</span>
+                </div>
+              ))}
+            </Section>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Section({ title, count, linkTo, variant, children }: {
+  title: string
+  count: number
+  linkTo?: string
+  variant: 'accent' | 'red' | 'blue' | 'muted'
+  children: React.ReactNode
+}) {
+  return (
+    <div className="bg-surface rounded-lg p-4">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold text-text-dim">{title}</span>
+          <Badge variant={variant}>{count}</Badge>
+        </div>
+        {linkTo && (
+          <Link to={linkTo} className="text-xs text-text-muted hover:text-accent transition-colors">
+            View all &rarr;
+          </Link>
+        )}
+      </div>
+      <div className="space-y-0.5">{children}</div>
+    </div>
+  )
+}

--- a/studio-react/src/pages/DashboardPage.tsx
+++ b/studio-react/src/pages/DashboardPage.tsx
@@ -122,6 +122,7 @@ const quickLinks = [
   { to: '/approvals', label: 'Approvals', desc: 'Review queue', color: 'text-green' },
   { to: '/concepts', label: 'Concepts', desc: 'Shared concepts', color: 'text-purple' },
   { to: '/context', label: 'Context', desc: 'Key-value store', color: 'text-text-dim' },
+  { to: '/ops', label: 'Admin Ops', desc: 'Action items', color: 'text-red' },
 ]
 
 export default function DashboardPage() {


### PR DESCRIPTION
## Summary
- New `/ops` page showing all actionable items from `GET /admin/ops` (Plan #9 Step 91)
- `AdminOps` type + `fetchAdminOps()` endpoint function
- Sections: pending requests, unassigned tasks, unassigned bugs, failed drone jobs, pending approvals, stale requests, open PRs
- Quick action buttons: resolve requests, retry/cancel failed jobs, view PRs
- Each section links to its detail page; shows "All clear" when empty
- Wired into SideNav (`Ao`) and Dashboard quick links

## Test plan
- [ ] `/ops` page loads and displays data from `GET /admin/ops`
- [ ] "All clear" shown when no actionable items
- [ ] Resolve button works on pending/stale requests
- [ ] Retry and Cancel buttons work on failed drone jobs
- [ ] "View all" links navigate to correct pages
- [ ] Open PR "View" links open GitHub in new tab
- [ ] Nav link and dashboard quick link route correctly
- [ ] `tsc --noEmit` and `vite build` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)