### PR TITLE
fix: plan progress display + CST timestamps

### DIFF
--- a/studio-react/src/components/bugs/BugCard.tsx
+++ b/studio-react/src/components/bugs/BugCard.tsx
@@ -1,5 +1,6 @@
 import type { Bug } from '../../api/types'
 import Badge from '../shared/Badge'
+import { timeAgo } from '../../utils/time'
 
 interface BugCardProps {
   bug: Bug
@@ -37,20 +38,6 @@ const categoryBadgeVariant: Record<string, 'purple' | 'pink' | 'accent' | 'blue'
   other: 'default',
 }
 
-function timeAgo(dateStr: string): string {
-  const now = Date.now()
-  const then = new Date(dateStr).getTime()
-  const seconds = Math.floor((now - then) / 1000)
-
-  if (seconds < 60) return 'just now'
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
-  return new Date(dateStr).toLocaleDateString()
-}
 
 export default function BugCard({ bug, onClick }: BugCardProps) {
   const barColor = severityBarColor[bug.severity] ?? severityBarColor.normal

--- a/studio-react/src/components/concepts/ConceptCard.tsx
+++ b/studio-react/src/components/concepts/ConceptCard.tsx
@@ -1,5 +1,6 @@
 import type { Concept } from '../../api/types'
 import Badge from '../shared/Badge'
+import { timeAgo } from '../../utils/time'
 
 interface ConceptCardProps {
   concept: Concept
@@ -24,17 +25,6 @@ const typeBadgeVariant: Record<string, 'purple' | 'accent' | 'blue' | 'green' | 
   custom: 'muted',
 }
 
-function timeAgo(dateStr: string): string {
-  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
-  if (seconds < 60) return 'just now'
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
-  return new Date(dateStr).toLocaleDateString()
-}
 
 export default function ConceptCard({ concept, onClick }: ConceptCardProps) {
   const barColor = typeBarColor[concept.type] ?? typeBarColor.custom

--- a/studio-react/src/components/dashboard/ActionRequired.tsx
+++ b/studio-react/src/components/dashboard/ActionRequired.tsx
@@ -3,15 +3,8 @@ import { Link } from 'react-router-dom'
 import { useDashboardStore } from '../../stores/dashboardStore'
 import { createDroneJob } from '../../api/endpoints'
 import Badge from '../shared/Badge'
+import { timeAgo } from '../../utils/time'
 import type { Message, DroneJob, Bug, Approval } from '../../api/types'
-
-function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime()
-  if (diff < 60000) return 'just now'
-  if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago'
-  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago'
-  return Math.floor(diff / 86400000) + 'd ago'
-}
 
 function truncate(str: string, len = 60): string {
   return str.length > len ? str.slice(0, len) + '…' : str

--- a/studio-react/src/components/messages/ChatMessage.tsx
+++ b/studio-react/src/components/messages/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import type { TeamChat, Message } from '../../api/types'
+import { formatTime } from '../../utils/time'
 
 // ─── Avatar helpers ─────────────────────────────────────────────────────────
 
@@ -26,13 +27,6 @@ function Avatar({ name, size = 'sm' }: { name: string; size?: 'sm' | 'md' }) {
       {initial}
     </span>
   )
-}
-
-// ─── Timestamp formatting ────────────────────────────────────────────────────
-
-function formatTime(iso: string): string {
-  const d = new Date(iso)
-  return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────

--- a/studio-react/src/components/plans/PlanCard.tsx
+++ b/studio-react/src/components/plans/PlanCard.tsx
@@ -1,4 +1,5 @@
 import type { Plan } from '../../api/types'
+import { formatDate } from '../../utils/time'
 import Badge from '../shared/Badge'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -17,11 +18,6 @@ const priorityVariant: Record<string, 'red' | 'accent' | 'green' | 'muted' | 'de
   low: 'green',
 }
 
-function formatDate(iso: string): string {
-  const d = new Date(iso)
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-}
-
 // ─── Component ───────────────────────────────────────────────────────────────
 
 interface PlanCardProps {
@@ -31,12 +27,9 @@ interface PlanCardProps {
 }
 
 export default function PlanCard({ plan, onClick, isSelected = false }: PlanCardProps) {
-  const steps = plan.steps ?? []
-  const completedSteps = steps.filter(
-    (s) => s.status === 'done' || s.status === 'completed',
-  ).length
-  const totalSteps = steps.length
-  const progressPct = totalSteps > 0 ? (completedSteps / totalSteps) * 100 : 0
+  const completedSteps = plan.progress?.completed ?? 0
+  const totalSteps = plan.progress?.total ?? 0
+  const progressPct = plan.progress?.percent ?? 0
 
   return (
     <div

--- a/studio-react/src/components/tasks/TaskCard.tsx
+++ b/studio-react/src/components/tasks/TaskCard.tsx
@@ -1,5 +1,6 @@
 import type { Task } from '../../api/types'
 import Badge from '../shared/Badge'
+import { timeAgo } from '../../utils/time'
 
 interface TaskCardProps {
   task: Task
@@ -18,20 +19,6 @@ const priorityBadgeVariant: Record<string, 'red' | 'accent' | 'muted'> = {
   high: 'accent',
 }
 
-function timeAgo(dateStr: string): string {
-  const now = Date.now()
-  const then = new Date(dateStr).getTime()
-  const seconds = Math.floor((now - then) / 1000)
-
-  if (seconds < 60) return 'just now'
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
-  return new Date(dateStr).toLocaleDateString()
-}
 
 function parseTags(raw: unknown): string[] {
   if (Array.isArray(raw)) return raw

--- a/studio-react/src/layouts/AppLayout.tsx
+++ b/studio-react/src/layouts/AppLayout.tsx
@@ -31,10 +31,13 @@ const routeTitles: Record<string, string> = {
 
 function formatTime(date: Date | null): string {
   if (!date) return 'never'
-  const h = date.getHours().toString().padStart(2, '0')
-  const m = date.getMinutes().toString().padStart(2, '0')
-  const s = date.getSeconds().toString().padStart(2, '0')
-  return `${h}:${m}:${s}`
+  return date.toLocaleTimeString('en-US', {
+    timeZone: 'America/Chicago',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }) + ' CST'
 }
 
 export default function AppLayout() {

--- a/studio-react/src/pages/AdminOpsPage.tsx
+++ b/studio-react/src/pages/AdminOpsPage.tsx
@@ -1,23 +1,9 @@
 import { useEffect, useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { fetchAdminOps, resolveRequest, cancelDroneJob, createDroneJob } from '../api/endpoints'
+import { timeAgo } from '../utils/time'
 import type { AdminOps } from '../api/types'
 import Badge from '../components/shared/Badge'
-
-function parseTimestamp(dateStr: string): number {
-  if (dateStr.includes('T')) return new Date(dateStr).getTime()
-  return new Date(dateStr.replace(' ', 'T') + 'Z').getTime()
-}
-
-function timeAgo(dateStr: string): string {
-  const ts = parseTimestamp(dateStr)
-  if (isNaN(ts)) return '-'
-  const diff = Date.now() - ts
-  if (diff < 60000) return 'just now'
-  if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago'
-  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago'
-  return Math.floor(diff / 86400000) + 'd ago'
-}
 
 function truncate(str: string, len = 80): string {
   return str.length > len ? str.slice(0, len) + '...' : str

--- a/studio-react/src/pages/ChannelsPage.tsx
+++ b/studio-react/src/pages/ChannelsPage.tsx
@@ -5,6 +5,7 @@ import { fetchChannelMessages, fetchChannelUnread, sendChannelMessage, markChann
 import type { Channel, ChannelMessage } from '../api/types'
 import { Avatar, formatTime } from '../components/messages/ChatMessage'
 import Badge from '../components/shared/Badge'
+import { formatDateLabel } from '../utils/time'
 import { useVoice } from '../hooks/useVoice'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -27,16 +28,6 @@ const TRUNCATE_LENGTH = 300
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function formatDateLabel(iso: string): string {
-  const d = new Date(iso)
-  const today = new Date()
-  const yesterday = new Date()
-  yesterday.setDate(yesterday.getDate() - 1)
-
-  if (d.toDateString() === today.toDateString()) return 'Today'
-  if (d.toDateString() === yesterday.toDateString()) return 'Yesterday'
-  return d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
-}
 
 function isSameDay(a: string, b: string): boolean {
   return new Date(a).toDateString() === new Date(b).toDateString()

--- a/studio-react/src/pages/DashboardPage.tsx
+++ b/studio-react/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useDashboardStore } from '../stores/dashboardStore'
+import { formatTime as formatTimestamp, timeAgo as formatTimeAgo } from '../utils/time'
 import SummaryCard from '../components/dashboard/SummaryCard'
 import ActionRequired from '../components/dashboard/ActionRequired'
 import Badge from '../components/shared/Badge'
@@ -81,22 +82,6 @@ function getAgentInitials(name: string): string {
   const parts = name.split(/[-_ ]+/)
   if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase()
   return name.slice(0, 2).toUpperCase()
-}
-
-function formatTimestamp(dateStr: string): string {
-  const d = new Date(dateStr)
-  return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
-}
-
-function formatTimeAgo(dateStr: string): string {
-  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
-  if (seconds < 60) return 'just now'
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
 }
 
 function getEventBadgeVariant(type: string): 'accent' | 'blue' | 'green' | 'muted' | 'purple' | 'red' {

--- a/studio-react/src/pages/DronesPage.tsx
+++ b/studio-react/src/pages/DronesPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react'
 import { useDashboardStore } from '../stores/dashboardStore'
 import { cancelDroneJob, createDroneJob } from '../api/endpoints'
+import { timeAgo } from '../utils/time'
 import type { DroneJob } from '../api/types'
 
 const statusColors: Record<string, string> = {
@@ -14,23 +15,6 @@ const statusColors: Record<string, string> = {
 const statusDot: Record<string, string> = {
   online: 'bg-green',
   offline: 'bg-text-muted',
-}
-
-function parseTimestamp(dateStr: string): number {
-  // Handle mixed formats: "2026-03-02 02:27:48" and "2026-03-02T02:27:53.214Z"
-  if (dateStr.includes('T')) return new Date(dateStr).getTime()
-  return new Date(dateStr.replace(' ', 'T') + 'Z').getTime()
-}
-
-function timeAgo(dateStr: string | null): string {
-  if (!dateStr) return '-'
-  const ts = parseTimestamp(dateStr)
-  if (isNaN(ts)) return '-'
-  const diff = Date.now() - ts
-  if (diff < 60000) return 'just now'
-  if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago'
-  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago'
-  return Math.floor(diff / 86400000) + 'd ago'
 }
 
 function formatSize(bytes: number): string {

--- a/studio-react/src/pages/MessagesPage.tsx
+++ b/studio-react/src/pages/MessagesPage.tsx
@@ -3,25 +3,16 @@ import { useDashboardStore } from '../stores/dashboardStore'
 import { resolveRequest, sendMessage } from '../api/endpoints'
 import { toast } from 'sonner'
 import type { Message } from '../api/types'
-import { Avatar, formatTime } from '../components/messages/ChatMessage'
+import { Avatar } from '../components/messages/ChatMessage'
+import { formatTime, formatDateLabel, parseTimestamp } from '../utils/time'
 import Badge from '../components/shared/Badge'
 import ThreadPanel from '../components/messages/ThreadPanel'
 
 // ─── Date separator ──────────────────────────────────────────────────────────
 
-function formatDateLabel(iso: string): string {
-  const d = new Date(iso)
-  const today = new Date()
-  const yesterday = new Date()
-  yesterday.setDate(yesterday.getDate() - 1)
-
-  if (d.toDateString() === today.toDateString()) return 'Today'
-  if (d.toDateString() === yesterday.toDateString()) return 'Yesterday'
-  return d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
-}
-
 function isSameDay(a: string, b: string): boolean {
-  return new Date(a).toDateString() === new Date(b).toDateString()
+  const fmt = (s: string) => new Date(parseTimestamp(s)).toLocaleDateString('en-US', { timeZone: 'America/Chicago' })
+  return fmt(a) === fmt(b)
 }
 
 function DateSeparator({ date }: { date: string }) {
@@ -241,7 +232,7 @@ export default function MessagesPage() {
     const ms = (hours[timeRange] ?? 3) * 3600000
     const cutoff = Date.now() - ms
     return all.filter((m) => {
-      const t = m.created_at.includes('T') ? new Date(m.created_at).getTime() : new Date(m.created_at.replace(' ', 'T') + 'Z').getTime()
+      const t = parseTimestamp(m.created_at)
       return t >= cutoff
     })
   }, [messages, timeRange])

--- a/studio-react/src/pages/NetworkHealthPage.tsx
+++ b/studio-react/src/pages/NetworkHealthPage.tsx
@@ -2,35 +2,10 @@ import { useEffect, useMemo } from 'react'
 import { useDashboardStore } from '../stores/dashboardStore'
 import Badge from '../components/shared/Badge'
 import StatusDot from '../components/shared/StatusDot'
+import { parseTimestamp, timeAgo, formatTime } from '../utils/time'
 import type { Agent, Plan, DroneJob, Event, Bug, ConfigEntry } from '../api/types'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function parseTimestamp(dateStr: string): number {
-  if (dateStr.includes('T')) return new Date(dateStr).getTime()
-  return new Date(dateStr.replace(' ', 'T') + 'Z').getTime()
-}
-
-function timeAgo(dateStr: string | null): string {
-  if (!dateStr) return 'never'
-  const ts = parseTimestamp(dateStr)
-  if (isNaN(ts)) return '-'
-  const diff = Date.now() - ts
-  if (diff < 0) return 'just now'
-  if (diff < 60_000) return 'just now'
-  const minutes = Math.floor(diff / 60_000)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
-  return `${Math.floor(days / 30)}mo ago`
-}
-
-function formatTimestamp(dateStr: string): string {
-  const d = new Date(dateStr)
-  return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
-}
 
 function getAgentInitials(name: string): string {
   const parts = name.split(/[-_ ]+/)
@@ -592,7 +567,7 @@ function RecentActivityFeed({ events }: { events: Event[] }) {
             className="flex items-start gap-3 py-1.5 px-2 rounded hover:bg-surface-raised/50 transition-colors group"
           >
             <span className="text-[11px] text-text-muted font-mono w-12 shrink-0 pt-0.5 tabular-nums">
-              {formatTimestamp(event.created_at)}
+              {formatTime(event.created_at)}
             </span>
             <Badge variant={getEventBadgeVariant(event.type)} className="shrink-0 mt-0.5">
               {event.type.replace(/_/g, ' ')}

--- a/studio-react/src/pages/PlansPage.tsx
+++ b/studio-react/src/pages/PlansPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useDashboardStore } from '../stores/dashboardStore'
 import { createPlan, updatePlan, updatePlanStep, fetchPlan } from '../api/endpoints'
 import { toast } from 'sonner'
+import { formatDateTime } from '../utils/time'
 import type { Plan, PlanStep } from '../api/types'
 import PlanCard from '../components/plans/PlanCard'
 import StepChecklist from '../components/plans/StepChecklist'
@@ -22,16 +23,6 @@ const priorityBadgeVariant: Record<string, 'red' | 'accent' | 'green' | 'muted' 
   high: 'red',
   medium: 'accent',
   low: 'green',
-}
-
-function formatDate(iso: string): string {
-  const d = new Date(iso)
-  return d.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
 }
 
 // ─── Create Plan Modal ───────────────────────────────────────────────────────
@@ -253,9 +244,9 @@ function PlanDetail({ plan, onClose, onStepUpdate, onStatusChange }: PlanDetailP
 
         {/* Timestamps */}
         <div className="flex items-center gap-3 mt-2 text-xs text-text-muted">
-          <span>Created {formatDate(plan.created_at)}</span>
+          <span>Created {formatDateTime(plan.created_at)}</span>
           {plan.updated_at !== plan.created_at && (
-            <span>Updated {formatDate(plan.updated_at)}</span>
+            <span>Updated {formatDateTime(plan.updated_at)}</span>
           )}
         </div>
 

--- a/studio-react/src/pages/WebhooksPage.tsx
+++ b/studio-react/src/pages/WebhooksPage.tsx
@@ -1,24 +1,10 @@
 import { Fragment, useEffect, useState, useMemo, useCallback } from 'react'
 import { fetchWebhookDeliveries } from '../api/endpoints'
+import { timeAgo, formatFullTimestamp } from '../utils/time'
 import type { WebhookDelivery } from '../api/types'
 import Badge from '../components/shared/Badge'
 
 const PAGE_SIZE = 50
-
-function parseTimestamp(dateStr: string): number {
-  if (dateStr.includes('T')) return new Date(dateStr).getTime()
-  return new Date(dateStr.replace(' ', 'T') + 'Z').getTime()
-}
-
-function timeAgo(dateStr: string): string {
-  const ts = parseTimestamp(dateStr)
-  if (isNaN(ts)) return '-'
-  const diff = Date.now() - ts
-  if (diff < 60000) return 'just now'
-  if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago'
-  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago'
-  return Math.floor(diff / 86400000) + 'd ago'
-}
 
 function statusColor(code: number | null): string {
   if (code === null) return 'text-text-muted'
@@ -225,7 +211,7 @@ export default function WebhooksPage() {
                         <div className="flex items-center gap-4 text-xs text-text-muted">
                           <span>Webhook ID: <span className="font-mono text-text-dim">{d.webhook_id}</span></span>
                           <span>Delivery ID: <span className="font-mono text-text-dim">{d.id}</span></span>
-                          <span>{new Date(parseTimestamp(d.created_at)).toLocaleString()}</span>
+                          <span>{formatFullTimestamp(d.created_at)}</span>
                         </div>
                       </div>
                     </td>

--- a/studio-react/src/utils/time.ts
+++ b/studio-react/src/utils/time.ts
@@ -1,0 +1,80 @@
+// Centralized timestamp utilities — all display times in CST (America/Chicago)
+
+const TZ = 'America/Chicago'
+const TZ_ABBR = 'CST'
+
+/** Parse mixed timestamp formats from the API ("2026-03-02 02:27:48" or ISO "2026-03-02T02:27:53.214Z") */
+export function parseTimestamp(dateStr: string): number {
+  if (dateStr.includes('T')) return new Date(dateStr).getTime()
+  return new Date(dateStr.replace(' ', 'T') + 'Z').getTime()
+}
+
+/** Relative time: "just now", "5m ago", "3h ago", "2d ago" */
+export function timeAgo(dateStr: string | null): string {
+  if (!dateStr) return '-'
+  const ts = parseTimestamp(dateStr)
+  if (isNaN(ts)) return '-'
+  const diff = Date.now() - ts
+  if (diff < 0) return 'just now'
+  if (diff < 60_000) return 'just now'
+  const minutes = Math.floor(diff / 60_000)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return `${Math.floor(days / 30)}mo ago`
+}
+
+/** Short time: "2:45 PM CST" */
+export function formatTime(dateStr: string): string {
+  const ts = parseTimestamp(dateStr)
+  if (isNaN(ts)) return '-'
+  const d = new Date(ts)
+  return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: TZ }) + ' ' + TZ_ABBR
+}
+
+/** Short date + time: "Mar 2, 2:45 PM CST" */
+export function formatDateTime(dateStr: string): string {
+  const ts = parseTimestamp(dateStr)
+  if (isNaN(ts)) return '-'
+  const d = new Date(ts)
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: TZ,
+  }) + ' ' + TZ_ABBR
+}
+
+/** Short date: "Mar 2" */
+export function formatDate(dateStr: string): string {
+  const ts = parseTimestamp(dateStr)
+  if (isNaN(ts)) return '-'
+  const d = new Date(ts)
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: TZ })
+}
+
+/** Full timestamp: "Mar 2, 2026, 2:45:30 PM CST" */
+export function formatFullTimestamp(dateStr: string): string {
+  const ts = parseTimestamp(dateStr)
+  if (isNaN(ts)) return '-'
+  const d = new Date(ts)
+  return d.toLocaleString('en-US', { timeZone: TZ }) + ' ' + TZ_ABBR
+}
+
+/** Date separator label: "Today", "Yesterday", or "Monday, March 2" */
+export function formatDateLabel(dateStr: string): string {
+  const ts = parseTimestamp(dateStr)
+  if (isNaN(ts)) return '-'
+  const d = new Date(ts)
+  const now = new Date()
+  // Compare in CST
+  const fmt = (dt: Date) => dt.toLocaleDateString('en-US', { timeZone: TZ })
+  if (fmt(d) === fmt(now)) return 'Today'
+  const yesterday = new Date(now)
+  yesterday.setDate(yesterday.getDate() - 1)
+  if (fmt(d) === fmt(yesterday)) return 'Yesterday'
+  return d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', timeZone: TZ })
+}


### PR DESCRIPTION
## Summary
- **Plan card progress bars** now use `plan.progress` from the overview API instead of `plan.steps` (which is only populated in detail fetches). Fixes progress showing 0/0 on the plans list page.
- **Consolidated 19 duplicate timestamp functions** across 15 files into a shared `utils/time.ts` module. All timestamps now display in CST (America/Chicago) timezone with explicit "CST" label.

## Changes
- New `studio-react/src/utils/time.ts` — shared module with `parseTimestamp`, `timeAgo`, `formatTime`, `formatDateTime`, `formatDate`, `formatFullTimestamp`, `formatDateLabel`
- Updated 15 files to import from shared utils instead of defining local timestamp functions
- `PlanCard.tsx` uses `plan.progress.completed`/`total`/`percent` instead of computing from `plan.steps`
- `AppLayout.tsx` last-refresh clock now shows CST timezone

## Test plan
- [ ] Plans page shows correct progress bars (e.g., "3/10 steps") on plan cards
- [ ] Clicking a plan card still opens detail panel with full steps list
- [ ] All timestamps across the app show "CST" suffix
- [ ] Timestamps display in Central time (America/Chicago)
- [ ] `npx tsc --noEmit` and `npx vite build` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)