### PR TITLE
fix: DM channels private — only show/accessible to participants

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1459,10 +1459,35 @@ export function autoCreateEntityChannel(linkedType, linkedId, name, createdBy, m
 }
 
 export function getOrCreateDmChannel(userA, userB, userAType, userBType) {
-  var sorted = [userA, userB].sort();
-  var slug = 'dm-' + sorted[0] + '-' + sorted[1];
-  var existing = getChannelBySlug(slug);
-  if (existing) return existing.id;
+  // Find any existing active DM channel that has exactly these two participants (case-insensitive).
+  // This prevents duplicate channels when usernames differ by case or creation order.
+  var existing = db.prepare(`
+    SELECT c.id FROM dv_channels c
+    WHERE c.type = 'dm' AND c.status = 'active'
+      AND (SELECT COUNT(*) FROM dv_channel_members m
+           WHERE m.channel_id = c.id AND LOWER(m.user_id) IN (LOWER(?), LOWER(?))) = 2
+      AND (SELECT COUNT(*) FROM dv_channel_members m WHERE m.channel_id = c.id) = 2
+    ORDER BY c.id ASC
+    LIMIT 1
+  `).get(userA, userB);
+  if (existing) {
+    // Ensure both users are members (handles legacy channels missing a member row)
+    addChannelMember(existing.id, userA, userAType || 'agent', 'member');
+    addChannelMember(existing.id, userB, userBType || 'agent', 'member');
+    return existing.id;
+  }
+  // Create new DM channel — use case-insensitive sort for canonical slug
+  var sorted = [userA, userB].sort(function (a, b) {
+    return a.toLowerCase() < b.toLowerCase() ? -1 : a.toLowerCase() > b.toLowerCase() ? 1 : 0;
+  });
+  var slug = 'dm-' + sorted[0].toLowerCase() + '-' + sorted[1].toLowerCase();
+  // Check slug in case a channel exists that our member query didn't catch (e.g. single-member DM)
+  var bySlug = getChannelBySlug(slug);
+  if (bySlug) {
+    addChannelMember(bySlug.id, userA, userAType || 'agent', 'member');
+    addChannelMember(bySlug.id, userB, userBType || 'agent', 'member');
+    return bySlug.id;
+  }
   var id = createChannel('DM: ' + sorted[0] + ' & ' + sorted[1], slug, 'dm', null, null, '', userA);
   addChannelMember(id, userA, userAType || 'agent', 'member');
   addChannelMember(id, userB, userBType || 'agent', 'member');
@@ -1729,7 +1754,7 @@ export function resolveStaleRequests(hoursOld) {
   return stale.length;
 }
 
-export function getDvOverview() {
+export function getDvOverview(userId) {
   var agents = listAgents();
   var events = listDvEvents({ limit: 50 });
   var openTasks = listDvTasks({ status: 'open', limit: 20 });
@@ -1752,6 +1777,14 @@ export function getDvOverview() {
   var allChannels = listChannels({ limit: 200, status: 'all' });
   var activeChannelCount = allChannels.filter(function (c) { return c.status === 'active'; }).length;
   var archivedChannelCount = allChannels.filter(function (c) { return c.status === 'archived'; }).length;
+  // DM channels are private — only show channels where the current user is a member
+  var visibleChannels = allChannels;
+  if (userId && userId !== '__system__') {
+    visibleChannels = allChannels.filter(function (c) {
+      if (c.type !== 'dm') return true;
+      return isChannelMember(c.id, userId);
+    });
+  }
   return {
     agents: agents,
     events: events,
@@ -1776,7 +1809,7 @@ export function getDvOverview() {
       });
       return c;
     })(),
-    channels: allChannels,
+    channels: visibleChannels,
     channel_counts: { total: allChannels.length, active: activeChannelCount, archived: archivedChannelCount },
     organizations: listOrgs(),
     operators: listOperators(),

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -1595,7 +1595,8 @@ router.post('/agents/:id/savepoint', function (req, res) {
 // Full studio overview (for dashboard)
 router.get('/admin/overview', function (req, res) {
   if (!checkAdmin(req, res)) return;
-  res.json(getDvOverview());
+  var who = getAdminDisplayName(req);
+  res.json(getDvOverview(who));
 });
 
 // Actionable items needing decisions (admin only)
@@ -1983,7 +1984,16 @@ router.get('/channels', function (req, res) {
     limit: parseLimit(req.query.limit, 50),
     offset: parseInt(req.query.offset) || 0
   };
-  res.json(listChannels(filters));
+  var channels = listChannels(filters);
+  // DM channels are private — filter to only include those where the authenticated user is a member.
+  // Skip filtering if an explicit member filter is already set, or caller is __system__.
+  if (!filters.member && who !== '__system__') {
+    channels = channels.filter(function (c) {
+      if (c.type !== 'dm') return true;
+      return isChannelMember(c.id, who);
+    });
+  }
+  res.json(channels);
 });
 
 // POST /channels — create channel (admin only)
@@ -2081,6 +2091,10 @@ router.get('/channels/:id/messages', function (req, res) {
   if (!who) return;
   var channel = getChannel(parseIntParam(req.params.id));
   if (!channel) return res.status(404).json({ error: 'Channel not found' });
+  // DM channels are private — only members can read messages
+  if (channel.type === 'dm' && who !== '__system__' && !isChannelMember(channel.id, who)) {
+    return res.status(403).json({ error: 'Access denied' });
+  }
   var filters = {
     before: req.query.before ? parseIntParam(req.query.before) : undefined,
     after: req.query.after ? parseIntParam(req.query.after) : undefined,
@@ -2102,6 +2116,10 @@ router.post('/channels/:id/messages', function (req, res) {
   if (!who) return;
   var channel = getChannel(parseIntParam(req.params.id));
   if (!channel) return res.status(404).json({ error: 'Channel not found' });
+  // DM channels are private — only members can post
+  if (channel.type === 'dm' && who !== '__system__' && !isChannelMember(channel.id, who)) {
+    return res.status(403).json({ error: 'Access denied' });
+  }
   var content = req.body.content;
   if (!content) return res.status(400).json({ error: 'content is required' });
   var metadata = req.body.metadata ? JSON.stringify(req.body.metadata) : '{}';


### PR DESCRIPTION
## Summary
- Fixes Bug #18: Direct Messages were visible to ALL users in the Channels sidebar, exposing private conversations
- DM channels are now filtered server-side so each user only sees their own DMs
- Added access control on `GET/POST /channels/:id/messages` for DM channels (403 if not a member)
- `getOrCreateDmChannel` now uses case-insensitive member-based lookup to prevent duplicate DM channels when the same pair of users DM each other with different name casing or creation order

## What changed
- `server/db.js`: `getDvOverview(userId)` now accepts a user ID and filters DM channels by membership; `getOrCreateDmChannel` uses member-based dedup query
- `server/routes/mycelium.js`: overview passes requester identity; `GET /channels` auto-filters DMs; message endpoints enforce DM access

## Test plan
- [ ] Log in as user A — only see DMs involving user A in channels sidebar
- [ ] Log in as user B — only see DMs involving user B
- [ ] Verify `GET /channels/:id/messages` returns 403 for a DM channel the user isn't in
- [ ] Verify creating a DM between the same two users (different case) returns the same channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)