### PR TITLE
Dashboard cleanup: display names, channels, voice, activity

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -1037,6 +1037,7 @@ router.get('/plans/:id', function (req, res) {
   if (!who) return;
   var plan = getDvPlan(parseInt(req.params.id));
   if (!plan) return res.status(404).json({ error: 'Plan not found' });
+  if (!checkProjectScope(req, res, plan.project_id)) return;
   res.json(plan);
 });
 
@@ -1083,6 +1084,7 @@ router.post('/plans/:id/steps', function (req, res) {
   if (!agentId) return;
   var plan = getDvPlan(parseInt(req.params.id));
   if (!plan) return res.status(404).json({ error: 'Plan not found' });
+  if (!checkProjectScope(req, res, plan.project_id)) return;
   var title = escapeHtml(req.body.title);
   if (!title) return res.status(400).json({ error: 'title is required' });
   var description = escapeHtml(req.body.description || '');
@@ -1169,7 +1171,7 @@ router.get('/studio/me', function (req, res) {
   if (!user) {
     // Check admin key
     var key = req.headers['x-admin-key'];
-    if (key === ADMIN_KEY) return res.json({ id: 0, username: 'admin', display_name: '__admin__', role: 'admin' });
+    if (key === ADMIN_KEY) return res.json({ id: 0, username: 'admin', display_name: 'Admin', role: 'admin' });
     return res.status(401).json({ error: 'Not authenticated' });
   }
   var dbUser = getStudioUserById(user.userId);

--- a/studio-react/src/components/messages/ChatMessage.tsx
+++ b/studio-react/src/components/messages/ChatMessage.tsx
@@ -1,5 +1,6 @@
 import type { TeamChat, Message } from '../../api/types'
 import { formatTime } from '../../utils/time'
+import { getSenderDisplay } from '../../utils/sender'
 
 // ─── Avatar helpers ─────────────────────────────────────────────────────────
 
@@ -36,7 +37,7 @@ function isAgentMessage(msg: TeamChat | Message): msg is Message {
 }
 
 function getSenderName(msg: TeamChat | Message): string {
-  return isAgentMessage(msg) ? msg.from_agent : msg.display_name
+  return isAgentMessage(msg) ? getSenderDisplay(msg.from_agent) : msg.display_name
 }
 
 // ─── Main component ─────────────────────────────────────────────────────────

--- a/studio-react/src/components/messages/ThreadPanel.tsx
+++ b/studio-react/src/components/messages/ThreadPanel.tsx
@@ -69,7 +69,6 @@ export default function ThreadPanel({ message, onClose }: ThreadPanelProps) {
     setSending(true)
     try {
       await sendMessage({
-        from_agent: '__admin__',
         to_agent: message.from_agent,
         project_id: message.project_id,
         content,

--- a/studio-react/src/components/voice/VoiceBar.tsx
+++ b/studio-react/src/components/voice/VoiceBar.tsx
@@ -2,10 +2,25 @@ import { Link } from 'react-router-dom'
 import { useVoiceStore } from '../../stores/voiceStore'
 
 export default function VoiceBar() {
-  const { isConnected, isMuted, channelName, peers, error, leave, toggleMute } =
+  const { isConnected, isMuted, channelName, peers, error, join, leave, toggleMute } =
     useVoiceStore()
 
-  if (!isConnected) return null
+  // Disconnected state — show subtle join prompt
+  if (!isConnected) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-1.5 bg-surface border-t border-border text-xs font-mono">
+        <span className="w-2 h-2 rounded-full bg-text-muted/30 shrink-0" />
+        <span className="text-text-muted">Voice</span>
+        <div className="flex-1" />
+        <button
+          onClick={() => join()}
+          className="px-2 py-0.5 rounded-sm bg-green/20 text-green hover:bg-green/30 transition-colors"
+        >
+          JOIN
+        </button>
+      </div>
+    )
+  }
 
   const peerCount = peers.length
   const statusText = error

--- a/studio-react/src/layouts/AppLayout.tsx
+++ b/studio-react/src/layouts/AppLayout.tsx
@@ -4,7 +4,6 @@ import DirectiveBanner from '../components/directives/DirectiveBanner'
 import VoiceBar from '../components/voice/VoiceBar'
 import { useAuthStore } from '../stores/authStore'
 import { useDashboardStore } from '../stores/dashboardStore'
-import { useVoiceStore } from '../stores/voiceStore'
 import { usePolling } from '../hooks/usePolling'
 import { useMemo } from 'react'
 
@@ -48,8 +47,7 @@ export default function AppLayout() {
   const { lastRefresh } = usePolling(10_000)
 
   const pageTitle = routeTitles[location.pathname] || 'Mycelium'
-  const voiceConnected = useVoiceStore((s) => s.isConnected)
-  const showFloatingVoice = voiceConnected && location.pathname !== '/channels'
+  const showFloatingVoice = location.pathname !== '/channels'
 
   const isFrozen = useMemo(() => {
     const adminStatus = instanceConfig.find((c) => c.key === 'admin_status')

--- a/studio-react/src/pages/ChannelsPage.tsx
+++ b/studio-react/src/pages/ChannelsPage.tsx
@@ -1,11 +1,12 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { useDashboardStore } from '../stores/dashboardStore'
 import { useAuthStore } from '../stores/authStore'
-import { fetchChannelMessages, fetchChannelUnread, sendChannelMessage, markChannelRead } from '../api/endpoints'
+import { fetchChannelMessages, fetchChannelUnread, sendChannelMessage, markChannelRead, createChannel } from '../api/endpoints'
 import type { Channel, ChannelMessage } from '../api/types'
 import { Avatar, formatTime } from '../components/messages/ChatMessage'
 import Badge from '../components/shared/Badge'
 import { formatDateLabel } from '../utils/time'
+import { getSenderDisplay } from '../utils/sender'
 import { useVoice } from '../hooks/useVoice'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -31,12 +32,6 @@ const TRUNCATE_LENGTH = 300
 
 function isSameDay(a: string, b: string): boolean {
   return new Date(a).toDateString() === new Date(b).toDateString()
-}
-
-function getSenderDisplay(fromAgent: string): string {
-  if (fromAgent === '__admin__') return 'Admin'
-  if (fromAgent.startsWith('__user:')) return fromAgent.slice(7)
-  return fromAgent
 }
 
 // ─── Date Separator ─────────────────────────────────────────────────────────
@@ -218,12 +213,19 @@ function ChannelSidebar({
   activeId,
   unreadMap,
   onSelect,
+  onCreate,
 }: {
   channels: Channel[]
   activeId: number | null
   unreadMap: Record<number, number>
   onSelect: (id: number) => void
+  onCreate: (name: string, type: string, description: string) => Promise<void>
 }) {
+  const [showCreate, setShowCreate] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newType, setNewType] = useState('general')
+  const [newDesc, setNewDesc] = useState('')
+  const [creating, setCreating] = useState(false)
   const totalUnread = useMemo(
     () => Object.values(unreadMap).reduce((sum, n) => sum + n, 0),
     [unreadMap],
@@ -248,12 +250,76 @@ function ChannelSidebar({
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-3 border-b border-border shrink-0">
         <span className="font-semibold text-sm text-text">Channels</span>
-        {totalUnread > 0 && (
-          <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-accent/15 text-accent text-xs font-bold tabular-nums">
-            {totalUnread}
-          </span>
-        )}
+        <div className="flex items-center gap-1.5">
+          {totalUnread > 0 && (
+            <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-accent/15 text-accent text-xs font-bold tabular-nums">
+              {totalUnread}
+            </span>
+          )}
+          <button
+            onClick={() => setShowCreate(!showCreate)}
+            className="w-5 h-5 flex items-center justify-center rounded text-text-muted hover:text-text hover:bg-surface-raised transition-colors text-sm"
+            title="Create channel"
+          >
+            +
+          </button>
+        </div>
       </div>
+
+      {/* Create channel form */}
+      {showCreate && (
+        <div className="px-3 py-2 border-b border-border space-y-2">
+          <input
+            type="text"
+            placeholder="Channel name"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            className="w-full bg-bg border border-border rounded px-2 py-1 text-xs text-text placeholder:text-text-muted focus:outline-none focus:border-accent"
+          />
+          <select
+            value={newType}
+            onChange={(e) => setNewType(e.target.value)}
+            className="w-full bg-bg border border-border rounded px-2 py-1 text-xs text-text focus:outline-none focus:border-accent"
+          >
+            <option value="general">General</option>
+            <option value="announcement">Announcement</option>
+            <option value="project">Project</option>
+          </select>
+          <input
+            type="text"
+            placeholder="Description (optional)"
+            value={newDesc}
+            onChange={(e) => setNewDesc(e.target.value)}
+            className="w-full bg-bg border border-border rounded px-2 py-1 text-xs text-text placeholder:text-text-muted focus:outline-none focus:border-accent"
+          />
+          <div className="flex gap-1.5">
+            <button
+              disabled={!newName.trim() || creating}
+              onClick={async () => {
+                setCreating(true)
+                try {
+                  await onCreate(newName.trim(), newType, newDesc.trim())
+                  setNewName('')
+                  setNewType('general')
+                  setNewDesc('')
+                  setShowCreate(false)
+                } finally {
+                  setCreating(false)
+                }
+              }}
+              className="flex-1 bg-accent text-bg text-xs font-medium py-1 rounded hover:bg-accent/80 transition-colors disabled:opacity-50"
+            >
+              {creating ? 'Creating...' : 'Create'}
+            </button>
+            <button
+              onClick={() => setShowCreate(false)}
+              className="px-2 py-1 text-xs text-text-muted hover:text-text transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Channel list */}
       <div className="flex-1 overflow-y-auto py-2">
@@ -443,6 +509,7 @@ function ChatArea({
 
 export default function ChannelsPage() {
   const channels = useDashboardStore((s) => s.channels)
+  const refresh = useDashboardStore((s) => s.refresh)
   const user = useAuthStore((s) => s.user)
 
   const [activeChannelId, setActiveChannelId] = useState<number | null>(null)
@@ -539,6 +606,16 @@ export default function ChannelsPage() {
     [activeChannelId, user, loadMessages],
   )
 
+  const handleCreateChannel = useCallback(
+    async (name: string, type: string, description: string) => {
+      const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+      const result = await createChannel({ name, slug, type, description: description || undefined })
+      await refresh()
+      if (result.id) setActiveChannelId(result.id)
+    },
+    [refresh],
+  )
+
   return (
     <div className="h-[calc(100vh-7rem)] rounded-sm overflow-hidden border border-border flex">
       <ChannelSidebar
@@ -546,6 +623,7 @@ export default function ChannelsPage() {
         activeId={activeChannelId}
         unreadMap={unreadMap}
         onSelect={handleSelectChannel}
+        onCreate={handleCreateChannel}
       />
       <ChatArea
         channel={activeChannel}

--- a/studio-react/src/pages/DashboardPage.tsx
+++ b/studio-react/src/pages/DashboardPage.tsx
@@ -6,6 +6,7 @@ import SummaryCard from '../components/dashboard/SummaryCard'
 import ActionRequired from '../components/dashboard/ActionRequired'
 import Badge from '../components/shared/Badge'
 import StatusDot from '../components/shared/StatusDot'
+import { useVoiceStore } from '../stores/voiceStore'
 
 // -- Event type color mapping --
 const eventBadgeVariant: Record<string, 'accent' | 'blue' | 'green' | 'muted' | 'purple' | 'red'> = {
@@ -139,6 +140,7 @@ export default function DashboardPage() {
   const characterCount = concepts.filter((c) => c.type === 'character').length
   const contextNamespaces = new Set(contextKeys.map((k) => k.namespace)).size
   const recentEvents = events.slice(0, 20)
+  const { isConnected: voiceConnected, channelName, peers, join: joinVoice, leave: leaveVoice } = useVoiceStore()
 
   return (
     <div className="space-y-6">
@@ -228,6 +230,27 @@ export default function DashboardPage() {
       {/* Action Required */}
       <ActionRequired />
 
+      {/* Voice Chat */}
+      <div className="bg-surface rounded-lg p-3 flex items-center gap-3">
+        <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${voiceConnected ? 'bg-green animate-pulse' : 'bg-text-muted/30'}`} />
+        <span className="text-sm font-medium text-text">Voice Chat</span>
+        {voiceConnected ? (
+          <>
+            <span className="text-xs text-accent font-mono">#{channelName}</span>
+            <span className="text-xs text-text-muted">{peers.length} peer{peers.length !== 1 ? 's' : ''}</span>
+            <div className="flex-1" />
+            <Link to="/channels" className="text-xs text-accent hover:underline">Open</Link>
+            <button onClick={leaveVoice} className="text-xs px-2 py-0.5 rounded bg-red/20 text-red hover:bg-red/30 transition-colors">Leave</button>
+          </>
+        ) : (
+          <>
+            <span className="text-xs text-text-muted">Not connected</span>
+            <div className="flex-1" />
+            <button onClick={() => joinVoice()} className="text-xs px-2 py-0.5 rounded bg-green/20 text-green hover:bg-green/30 transition-colors">Join</button>
+          </>
+        )}
+      </div>
+
       {/* Middle row: Activity + Agents */}
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
         {/* Recent Activity */}
@@ -255,7 +278,7 @@ export default function DashboardPage() {
                   {event.agent && (
                     <span className="font-mono text-xs text-accent mr-1.5">{event.agent}</span>
                   )}
-                  <span className="truncate">{event.summary}</span>
+                  <span className="break-words">{event.summary}</span>
                 </span>
               </div>
             ))}

--- a/studio-react/src/pages/MessagesPage.tsx
+++ b/studio-react/src/pages/MessagesPage.tsx
@@ -7,6 +7,7 @@ import { Avatar } from '../components/messages/ChatMessage'
 import { formatTime, formatDateLabel, parseTimestamp } from '../utils/time'
 import Badge from '../components/shared/Badge'
 import ThreadPanel from '../components/messages/ThreadPanel'
+import { getSenderDisplay } from '../utils/sender'
 
 // ─── Date separator ──────────────────────────────────────────────────────────
 
@@ -156,11 +157,11 @@ function AgentMessage({
         <div className="flex-1 min-w-0">
           {/* Header */}
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="font-semibold text-sm text-text">{msg.from_agent}</span>
+            <span className="font-semibold text-sm text-text">{getSenderDisplay(msg.from_agent)}</span>
             <svg viewBox="0 0 12 12" className="w-3 h-3 text-text-muted shrink-0" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M2 6h8M7 3l3 3-3 3" />
             </svg>
-            <span className="font-semibold text-sm text-text-dim">{msg.to_agent}</span>
+            <span className="font-semibold text-sm text-text-dim">{getSenderDisplay(msg.to_agent)}</span>
             <Badge variant={msgTypeBadge[msg.msg_type] ?? 'default'}>{msg.msg_type}</Badge>
             <Badge variant={statusBadgeVariant[msg.status] ?? 'default'}>{msg.status}</Badge>
             <span className="text-text-muted text-xs">{formatTime(msg.created_at)}</span>
@@ -254,7 +255,6 @@ export default function MessagesPage() {
       setSending(true)
       try {
         await sendMessage({
-          from_agent: '__admin__',
           to_agent: composeTo.trim(),
           content: composeContent.trim(),
           msg_type: composeMsgType,

--- a/studio-react/src/utils/sender.ts
+++ b/studio-react/src/utils/sender.ts
@@ -1,0 +1,6 @@
+export function getSenderDisplay(name: string): string {
+  if (name === '__admin__') return 'Admin'
+  if (name === '__system__') return 'System'
+  if (name.startsWith('__user:')) return name.slice(7)
+  return name
+}


### PR DESCRIPTION
## Summary
- **Display names**: Replace raw `__admin__`/`__system__` with friendly names ("Admin", "System") across all dashboard pages via shared `getSenderDisplay()` utility. Fix `/me` endpoint to return `Admin` instead of `__admin__`.
- **Create channel UI**: Add `+` button to Channels sidebar with inline form (name, type, description dropdown).
- **Voice discoverability**: VoiceBar now shows "Join" button when disconnected on all non-channel pages. Added voice card to Dashboard homepage.
- **Activity feed**: Fix text wrapping — event summaries now wrap instead of truncating with ellipsis.

## Test plan
- [ ] Open Dashboard — activity feed text wraps, voice card shows with Join button
- [ ] Open Messages — sender/recipient show friendly names, no `__admin__`
- [ ] Open Channels — `+` button creates new channel, voice panel still works in sidebar
- [ ] Join voice from Dashboard card or bottom bar, verify it connects
- [ ] Send message from dashboard, confirm no `from_agent: '__admin__'` in payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)