### PR TITLE
feat: Concepts system — boot payload + dashboard grid (Plan #19 Step #172)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -768,6 +768,15 @@ export function getBootPayload(agentId) {
   // --- Project record ---
   var project = getProject(agent.project_id);
 
+  // --- Project concepts: cross-project creative DNA ---
+  var concepts = [];
+  if (agent.project_id) {
+    concepts = getProjectConcepts(agent.project_id);
+    for (var con of concepts) {
+      try { con.data = JSON.parse(con.data); } catch (e) { /* keep as string */ }
+    }
+  }
+
   return {
     agent: safeAgent,
     project: project || null,
@@ -788,6 +797,7 @@ export function getBootPayload(agentId) {
     plans: myPlans,
     channels: myChannels,
     unread_counts: unreadMap,
+    concepts: concepts,
     plugins: listPluginRecords().filter(function (p) { return p.enabled; }),
     team_agents: otherAgents.filter(function (a) { return a.project_id === agent.project_id; }),
     server_time: new Date().toISOString()

--- a/studio-react/src/components/concepts/ConceptCard.tsx
+++ b/studio-react/src/components/concepts/ConceptCard.tsx
@@ -33,7 +33,7 @@ export default function ConceptCard({ concept, onClick }: ConceptCardProps) {
     <button
       type="button"
       onClick={onClick}
-      className="w-full text-left bg-surface-raised rounded-lg p-4 mb-3 cursor-pointer flex gap-3 transition-all hover:ring-1 ring-border hover:bg-surface-raised/80 group"
+      className="w-full text-left bg-surface-raised rounded-lg p-4 cursor-pointer flex gap-3 transition-all hover:ring-1 ring-border hover:bg-surface-raised/80 group"
     >
       {/* Type indicator bar */}
       <div className={`w-1 shrink-0 rounded-full self-stretch ${barColor}`} />

--- a/studio-react/src/pages/ConceptsPage.tsx
+++ b/studio-react/src/pages/ConceptsPage.tsx
@@ -582,7 +582,41 @@ export default function ConceptsPage() {
         })}
       </div>
 
-      {/* Concept list */}
+      {/* Project linkage summary */}
+      {concepts.length > 0 && (
+        <div className="bg-surface rounded-lg border border-border p-4">
+          <h3 className="text-xs uppercase tracking-wider text-text-muted font-medium mb-2">Cross-Project DNA</h3>
+          <div className="flex flex-wrap gap-3">
+            {(() => {
+              const projectMap = new Map<string, number>()
+              for (const c of concepts) {
+                for (const p of c.projects || []) {
+                  projectMap.set(p, (projectMap.get(p) || 0) + 1)
+                }
+              }
+              const unlinked = concepts.filter((c) => !c.projects?.length).length
+              return (
+                <>
+                  {Array.from(projectMap.entries()).map(([proj, count]) => (
+                    <div key={proj} className="flex items-center gap-1.5 bg-surface-raised rounded px-2.5 py-1">
+                      <span className="text-sm font-medium text-text">{proj}</span>
+                      <span className="text-xs text-text-muted tabular-nums">{count} concepts</span>
+                    </div>
+                  ))}
+                  {unlinked > 0 && (
+                    <div className="flex items-center gap-1.5 bg-surface-raised rounded px-2.5 py-1">
+                      <span className="text-sm font-medium text-text-dim">Unlinked</span>
+                      <span className="text-xs text-text-muted tabular-nums">{unlinked}</span>
+                    </div>
+                  )}
+                </>
+              )
+            })()}
+          </div>
+        </div>
+      )}
+
+      {/* Concept grid */}
       {filtered.length === 0 ? (
         <div className="bg-surface rounded-lg p-12 text-center">
           <p className="text-text-muted text-sm">
@@ -590,7 +624,7 @@ export default function ConceptsPage() {
           </p>
         </div>
       ) : (
-        <div>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
           {filtered.map((concept) => (
             <ConceptCard
               key={concept.id}


### PR DESCRIPTION
## Summary
- Add project concepts to agent boot payload — agents now receive linked concepts (characters, styles, rulesets, etc.) with parsed JSON data on boot
- Dashboard: switch concepts page from list to responsive 3-column grid layout
- Add "Cross-Project DNA" summary bar showing concept counts per project and unlinked concepts
- Companion MCP PR: grbarajas-soymd/dioverse-mcp#1

## Plan #19 Step #172
Concepts system — make it real. The concepts infrastructure existed in schema and API but agents didn't receive concepts on boot and the dashboard layout was basic.

## Test plan
- [ ] Boot an agent → verify concepts array in boot payload
- [ ] Dashboard /concepts → verify grid layout with project badges
- [ ] Create concept, link to project → verify cross-project DNA bar updates
- [ ] Boot agent on linked project → verify concept appears in boot output

Generated with [Claude Code](https://claude.com/claude-code)