### PR TITLE
feat: One-click Railway deploy + onboarding UX (Plan #19 Step #174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,25 @@ docker run -p 3002:3002 \
 
 ### Option 3: Railway (cloud)
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/mycelium?referralCode=mycelium)
 
-Set `JWT_SECRET` and `ADMIN_KEY` as environment variables. Attach a volume at `/data` for persistent storage.
+Set these environment variables in Railway:
+- `JWT_SECRET` — any random string (e.g. `openssl rand -hex 32`)
+- `ADMIN_KEY` — your admin API key (e.g. `openssl rand -hex 24`)
+
+Attach a volume at `/app/server/data` for persistent SQLite storage.
 
 ## First Run
 
-1. Open the dashboard at `http://localhost:3002`
-2. Create an admin account (first user becomes admin)
-3. Go to **Onboarding** (`/onboarding`) to set up your network:
+1. Open the dashboard at `http://localhost:3002` (or your Railway URL)
+2. Log in with the admin key, or create a dashboard user via API
+3. The setup wizard launches automatically if no projects or agents exist
+4. Follow the **Onboarding** checklist:
    - Create an organization
    - Create a project
    - Register your first agent
    - Define its role contract
+5. The dashboard shows a getting-started checklist until all steps are complete
 
 ## Environment Variables
 

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "node server/index.js",
+    "healthcheckPath": "/health",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/studio-react/src/pages/DashboardPage.tsx
+++ b/studio-react/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useDashboardStore } from '../stores/dashboardStore'
 import { useLiveStore } from '../stores/liveStore'
 import { formatTime as formatTimestamp, timeAgo as formatTimeAgo } from '../utils/time'
@@ -113,6 +113,73 @@ const quickLinks = [
   { to: '/ops', label: 'Admin Ops', desc: 'Action items', color: 'text-red' },
 ]
 
+// -- Onboarding Checklist --
+
+function OnboardingChecklist({
+  checks,
+}: {
+  checks: { label: string; done: boolean; to: string }[]
+}) {
+  const completed = checks.filter((c) => c.done).length
+  const total = checks.length
+  const allDone = completed === total
+
+  if (allDone) return null
+
+  return (
+    <div className="bg-surface rounded-lg border border-accent/20 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold text-accent">Getting Started</h2>
+        <span className="text-xs text-text-muted tabular-nums">
+          {completed}/{total} complete
+        </span>
+      </div>
+      <div className="h-1.5 bg-surface-raised rounded-full overflow-hidden mb-3">
+        <div
+          className="h-full bg-accent rounded-full transition-all duration-500"
+          style={{ width: `${(completed / total) * 100}%` }}
+        />
+      </div>
+      <div className="space-y-1.5">
+        {checks.map((check) => (
+          <Link
+            key={check.label}
+            to={check.to}
+            className={`flex items-center gap-2.5 py-1.5 px-2 rounded transition-colors ${
+              check.done
+                ? 'text-text-muted'
+                : 'text-text hover:bg-surface-raised'
+            }`}
+          >
+            <span
+              className={`w-4 h-4 rounded-full border flex items-center justify-center shrink-0 ${
+                check.done
+                  ? 'bg-green/20 border-green/40 text-green'
+                  : 'border-border'
+              }`}
+            >
+              {check.done && (
+                <svg viewBox="0 0 12 12" className="w-2.5 h-2.5" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M2.5 6l2.5 2.5 4.5-5" />
+                </svg>
+              )}
+            </span>
+            <span className={`text-sm ${check.done ? 'line-through' : 'font-medium'}`}>
+              {check.label}
+            </span>
+          </Link>
+        ))}
+      </div>
+      <Link
+        to="/onboarding"
+        className="block mt-3 text-center text-xs text-accent hover:text-accent-light transition-colors"
+      >
+        Open setup wizard
+      </Link>
+    </div>
+  )
+}
+
 export default function DashboardPage() {
   const {
     agents,
@@ -126,13 +193,31 @@ export default function DashboardPage() {
     droneJobs,
     concepts,
     contextKeys,
+    projects,
     loading,
     refresh,
   } = useDashboardStore()
 
+  const navigate = useNavigate()
+
   useEffect(() => {
     refresh()
   }, [refresh])
+
+  // First-boot detection: if no projects and no agents, redirect to onboarding
+  useEffect(() => {
+    if (loading) return
+    if (projects.length === 0 && agents.length === 0) {
+      navigate('/onboarding', { replace: true })
+    }
+  }, [loading, projects.length, agents.length, navigate])
+
+  const onboardingChecks = useMemo(() => [
+    { label: 'Create a project', done: projects.length > 0, to: '/onboarding' },
+    { label: 'Register an agent', done: agents.length > 0, to: '/onboarding' },
+    { label: 'Create your first plan', done: plans.length > 0, to: '/plans' },
+    { label: 'Send a message', done: messages.length > 0, to: '/messages' },
+  ], [projects.length, agents.length, plans.length, messages.length])
 
   const onlineAgents = agents.filter((a) => a.status === 'online').length
   const totalTasks = tasks.open.length + tasks.in_progress.length
@@ -264,6 +349,9 @@ export default function DashboardPage() {
           </>
         )}
       </div>
+
+      {/* Onboarding checklist (hidden when all done) */}
+      <OnboardingChecklist checks={onboardingChecks} />
 
       {/* Middle row: Activity + Agents */}
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">


### PR DESCRIPTION
## Summary
- Add `railway.json` for Railway deploy button configuration
- Auto-redirect to `/onboarding` wizard on first boot (no projects or agents)
- Dashboard onboarding checklist: create project, register agent, create plan, send message
- Checklist auto-hides when all steps complete
- Updated README with proper deploy instructions

## Plan #19 Step #174
One-click Railway deploy + operator onboarding UI.

## Test plan
- [ ] Fresh instance → verify redirect to /onboarding
- [ ] Complete onboarding steps → verify checklist updates on dashboard
- [ ] All steps done → checklist disappears
- [ ] Railway deploy button in README links to correct template

Generated with [Claude Code](https://claude.com/claude-code)