### PR TITLE
feat: Heartbeat returns pending message counts (Plan #20 Step #176)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -571,6 +571,16 @@ export function listPendingRequests(agentId) {
   ).all(agentId);
 }
 
+export function countPendingForAgent(agentId) {
+  var row = db.prepare(
+    "SELECT " +
+    "(SELECT COUNT(*) FROM dv_messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('pending', 'sent')) as requests, " +
+    "(SELECT COUNT(*) FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('pending', 'sent')) as directives, " +
+    "(SELECT COUNT(*) FROM dv_messages WHERE (to_agent = ? OR to_agent IS NULL) AND msg_type IN ('message', 'info') AND status = 'sent') as unread"
+  ).get(agentId, agentId, agentId);
+  return row;
+}
+
 export function getDvMessage(id) {
   return db.prepare("SELECT * FROM dv_messages WHERE id = ?").get(id);
 }

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -88,7 +88,8 @@ import {
   updateSavepointNotes, computeSavepointDiff, pruneSavepoints,
   listPluginRecords, getPluginRecord, updatePluginEnabled, getDB,
   getIdleAgents, getNextUnassignedTask, getNextUnassignedPlanStep,
-  createFeedback, getFeedback, listFeedback, deleteFeedback, getFeedbackSummary
+  createFeedback, getFeedback, listFeedback, deleteFeedback, getFeedbackSummary,
+  countPendingForAgent
 } from '../db.js';
 import { loadPlugins, getPluginMcpTools } from '../plugins.js';
 import { broadcast, addClient, clientCount } from '../eventBus.js';
@@ -585,7 +586,9 @@ router.post('/agents/heartbeat', function (req, res) {
   // Prune old savepoints (keep last 100)
   pruneSavepoints(agentId, 100);
 
-  var response = { ok: true, agent: agentId, status: status };
+  // Include pending counts so agents know if they have unread messages
+  var pending = countPendingForAgent(agentId);
+  var response = { ok: true, agent: agentId, status: status, pending: pending };
 
   // Auto-dispatch: if agent just came online or is idle with no work, try to assign
   if (!workingOn && (status === 'online' || status === 'idle')) {


### PR DESCRIPTION
## Summary
- Add `countPendingForAgent()` — single query returning pending requests, directives, and unread message counts
- Heartbeat response now includes `pending: { requests, directives, unread }` so agents know immediately if they have unread messages
- Companion MCP change: heartbeat handler logs warnings to stderr when pending items exist (directives get urgent warning)

## Plan #20 Step #176
Heartbeat pulls pending messages — agents get awareness every 5 min even without SSE.

## Test plan
- [ ] Heartbeat response includes `pending` object with counts
- [ ] MCP agent sees stderr warning when directives are pending
- [ ] No warnings when inbox is clear
- [ ] Counts are accurate vs actual pending messages

Generated with [Claude Code](https://claude.com/claude-code)