### PR TITLE
feat: sleep mode — autonomous night operations

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -62,6 +62,9 @@ export function initDB() {
     ["dv_projects", "org_id", "TEXT NOT NULL DEFAULT ''"],
     ["dv_projects", "type", "TEXT NOT NULL DEFAULT 'software'"],
     ["dv_projects", "status", "TEXT NOT NULL DEFAULT 'active'"],
+    ["dv_operators", "availability", "TEXT NOT NULL DEFAULT 'available'"],
+    ["dv_operators", "last_seen_at", "TEXT"],
+    ["dv_operators", "away_message", "TEXT NOT NULL DEFAULT ''"],
   ];
 
   for (var [table, col, def] of migrations) {
@@ -246,8 +249,24 @@ export function updateOperator(id, fields) {
   if (fields.email !== undefined) { sets.push('email = ?'); values.push(fields.email); }
   if (fields.studio_user_id !== undefined) { sets.push('studio_user_id = ?'); values.push(fields.studio_user_id); }
   if (fields.status !== undefined) { sets.push('status = ?'); values.push(fields.status); }
+  if (fields.availability !== undefined) { sets.push('availability = ?'); values.push(fields.availability); }
+  if (fields.away_message !== undefined) { sets.push('away_message = ?'); values.push(fields.away_message); }
   values.push(id);
   db.prepare('UPDATE dv_operators SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+}
+
+export function setOperatorAvailability(id, availability, awayMessage) {
+  db.prepare(`UPDATE dv_operators SET availability = ?, away_message = ?, last_seen_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`)
+    .run(availability, awayMessage || '', id);
+}
+
+export function getAvailableOperators() {
+  return db.prepare("SELECT * FROM dv_operators WHERE status = 'active' AND availability = 'available'").all();
+}
+
+export function isNetworkAutonomous() {
+  var count = db.prepare("SELECT COUNT(*) as c FROM dv_operators WHERE status = 'active' AND availability = 'available'").get();
+  return count.c === 0;
 }
 
 export function deleteOperator(id) {
@@ -274,6 +293,25 @@ export function listInstanceConfig() {
 
 export function deleteInstanceConfig(key) {
   stmt('dvDeleteConfig', 'DELETE FROM dv_instance_config WHERE key = ?').run(key);
+}
+
+// -- Sleep Mode --
+
+export function getSleepMode() {
+  var val = getInstanceConfig('sleep_mode');
+  if (!val) return { active: false };
+  try { return JSON.parse(val); } catch (e) { return { active: false }; }
+}
+
+export function appendSleepLog(field, item) {
+  var val = getInstanceConfig('sleep_mode_log');
+  var log;
+  try { log = val ? JSON.parse(val) : {}; } catch (e) { log = {}; }
+  if (!log[field]) log[field] = [];
+  if (Array.isArray(log[field])) {
+    log[field].push(item);
+  }
+  setInstanceConfig('sleep_mode_log', JSON.stringify(log), '__system__');
 }
 
 // -- Projects --

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -75,7 +75,9 @@ import {
   markApprovalExecuted, countPendingApprovals, listPendingApprovalsByAgent,
   castApprovalVote, getApprovalVotes, countApprovalVotes,
   createOperator, getOperator, listOperators, updateOperator, deleteOperator,
+  setOperatorAvailability, getAvailableOperators, isNetworkAutonomous,
   getInstanceConfig, setInstanceConfig, listInstanceConfig, deleteInstanceConfig,
+  getSleepMode, appendSleepLog,
   createChannel, getChannel, getChannelBySlug, getChannelByLink,
   listChannels, updateChannel, deleteChannel,
   addChannelMember, removeChannelMember, listChannelMembers,
@@ -302,7 +304,6 @@ function checkAgentOrAdmin(req, res) {
 var sseClients = new Set();
 
 // ---- Event helper ----
-import { broadcast, addClient, clientCount } from '../eventBus.js';
 
 function emitEvent(type, agentId, projectId, summary, data) {
   var id = createDvEvent(type, agentId || '', projectId || null, summary || '', JSON.stringify(data || {}));
@@ -427,6 +428,13 @@ function dispatchWorkToIdleAgents(triggerContext) {
     break;
   }
 
+  // Log dispatches during sleep mode
+  if (dispatched.length > 0 && getSleepMode().active) {
+    for (var d of dispatched) {
+      appendSleepLog('dispatches', { agent: d.agent, type: d.type, id: d.id, title: d.title, time: new Date().toISOString() });
+    }
+  }
+
   return dispatched;
 }
 
@@ -489,6 +497,10 @@ router.get('/boot/:agentId', function (req, res) {
   if (!payload) return res.status(404).json({ error: 'Agent not found' });
   // Attach savepoint diff
   payload.savepoint = computeSavepointDiff(agentId);
+  // Attach sleep mode / autonomous status
+  payload.sleep_mode = getSleepMode();
+  payload.autonomous_mode = isNetworkAutonomous();
+  payload.operators_available = getAvailableOperators().length;
   emitEvent('agent_boot', agentId, null, agentId + ' booted');
   res.json(payload);
 });
@@ -765,6 +777,7 @@ router.put('/tasks/:id', function (req, res) {
 
   // When task completes: resolve dependencies and update linked asset
   if (fields.status === 'done') {
+    if (getSleepMode().active) appendSleepLog('tasks_completed', { id: task.id, title: task.title, agent: agentId, time: new Date().toISOString() });
     var unblocked = resolveTaskDependencies(task.id);
     if (unblocked.length > 0) {
       result.unblocked = unblocked;
@@ -1479,6 +1492,9 @@ router.put('/plans/:id/steps/:stepId', function (req, res) {
   var stepPlanId = parseIntParam(req.params.id);
   var stepStepId = parseIntParam(req.params.stepId);
   updateDvPlanStep(stepStepId, fields);
+  if (fields.status === 'done' && getSleepMode().active) {
+    appendSleepLog('steps_completed', { id: stepStepId, plan_id: stepPlanId, agent: agentId, time: new Date().toISOString() });
+  }
   emitEvent('plan_step_updated', agentId, plan ? plan.project_id : null, agentId + ' updated step #' + stepStepId + ' on plan #' + stepPlanId, { plan_id: stepPlanId, step_id: stepStepId, fields: fields });
   dispatchWebhook('plan_step_updated', agentId, { plan_id: stepPlanId, step_id: stepStepId, fields: fields });
   res.json({ ok: true, step_id: stepStepId });
@@ -1681,6 +1697,144 @@ router.put('/admin/override', function (req, res) {
   } else {
     res.status(400).json({ error: 'action must be freeze or unfreeze' });
   }
+});
+
+// ======== SLEEP MODE ========
+
+router.put('/admin/sleep', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var who = getAdminDisplayName(req);
+  var action = req.body.action;
+  if (action !== 'on' && action !== 'off') {
+    return res.status(400).json({ error: 'action must be on or off' });
+  }
+
+  if (action === 'on') {
+    var directive = req.body.directive || '';
+    var priorities = req.body.priorities || [];
+    var approvalPolicy = req.body.approval_policy || 'queue_high';
+    var autoWakeAt = req.body.auto_wake_at || null;
+
+    // Find the operator linked to this admin user
+    var operatorId = req.body.operator_id;
+    if (operatorId) {
+      var op = getOperator(operatorId);
+      if (op) setOperatorAvailability(operatorId, 'sleeping', directive);
+    }
+
+    var config = {
+      active: true,
+      directive: directive,
+      priorities: priorities,
+      approval_policy: approvalPolicy,
+      auto_wake_at: autoWakeAt,
+      started_at: new Date().toISOString(),
+      started_by: who
+    };
+    setInstanceConfig('sleep_mode', JSON.stringify(config), who);
+    setInstanceConfig('sleep_mode_log', JSON.stringify({
+      tasks_completed: [], steps_completed: [], approvals_queued: [],
+      dispatches: [], errors: [], messages_sent: 0
+    }), who);
+
+    var autonomous = isNetworkAutonomous();
+    if (autonomous && directive) {
+      // Broadcast night directive to all online agents
+      var agents = listAgents();
+      for (var agent of agents) {
+        if (agent.status === 'online' || agent.status === 'idle') {
+          createDvMessage('__system__', agent.id, null, 'AUTONOMOUS MODE ACTIVE — Night directive from ' + who + ': ' + directive, 'directive');
+        }
+      }
+    }
+
+    emitEvent('sleep_mode_on', who, null, who + ' activated sleep mode' + (autonomous ? ' (network autonomous)' : ''));
+    res.json({ ok: true, sleep_mode: config, autonomous: autonomous });
+
+  } else {
+    // action === 'off'
+    var operatorId2 = req.body.operator_id;
+    if (operatorId2) {
+      var op2 = getOperator(operatorId2);
+      if (op2) setOperatorAvailability(operatorId2, 'available', '');
+    }
+
+    var log = null;
+    var logVal = getInstanceConfig('sleep_mode_log');
+    try { log = logVal ? JSON.parse(logVal) : null; } catch (e) { log = null; }
+
+    setInstanceConfig('sleep_mode', JSON.stringify({ active: false }), who);
+    emitEvent('sleep_mode_off', who, null, who + ' deactivated sleep mode');
+
+    // Notify agents that humans are back
+    var agents2 = listAgents();
+    for (var agent2 of agents2) {
+      if (agent2.status === 'online' || agent2.status === 'idle') {
+        createDvMessage('__system__', agent2.id, null, 'Sleep mode ended. Human operators are available again.', 'info');
+      }
+    }
+
+    res.json({ ok: true, sleep_mode: { active: false }, morning_summary: log });
+  }
+});
+
+router.get('/admin/sleep', function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  var config = getSleepMode();
+  var log = null;
+  var logVal = getInstanceConfig('sleep_mode_log');
+  try { log = logVal ? JSON.parse(logVal) : null; } catch (e) {}
+  res.json({
+    sleep_mode: config,
+    autonomous: isNetworkAutonomous(),
+    available_operators: getAvailableOperators().length,
+    log: log
+  });
+});
+
+router.put('/operators/:id/availability', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var who = getAdminDisplayName(req);
+  var op = getOperator(req.params.id);
+  if (!op) return res.status(404).json({ error: 'Operator not found' });
+
+  var availability = req.body.availability;
+  if (!['available', 'away', 'sleeping'].includes(availability)) {
+    return res.status(400).json({ error: 'availability must be available, away, or sleeping' });
+  }
+
+  var wasBefore = isNetworkAutonomous();
+  setOperatorAvailability(req.params.id, availability, req.body.message || '');
+  var isNow = isNetworkAutonomous();
+
+  // Transition to autonomous
+  if (!wasBefore && isNow) {
+    var sleepConfig = getSleepMode();
+    if (sleepConfig.active && sleepConfig.directive) {
+      var agents = listAgents();
+      for (var agent of agents) {
+        if (agent.status === 'online' || agent.status === 'idle') {
+          createDvMessage('__system__', agent.id, null, 'All operators are now away. Night directive: ' + sleepConfig.directive, 'directive');
+        }
+      }
+    }
+    emitEvent('autonomous_mode_on', who, null, 'All operators away — network is autonomous');
+  }
+
+  // Transition from autonomous
+  if (wasBefore && !isNow) {
+    emitEvent('autonomous_mode_off', who, null, displayName(req.params.id) + ' is back — autonomous mode ended');
+    var agents2 = listAgents();
+    for (var agent2 of agents2) {
+      if (agent2.status === 'online' || agent2.status === 'idle') {
+        createDvMessage('__system__', agent2.id, null, 'Operator ' + displayName(req.params.id) + ' is back. Human operators available.', 'info');
+      }
+    }
+  }
+
+  emitEvent('operator_availability', who, null, displayName(req.params.id) + ' is now ' + availability);
+  res.json(getOperator(req.params.id));
 });
 
 // ======== ADMIN ========
@@ -2673,6 +2827,17 @@ router.post('/approvals', function (req, res) {
   emitEvent('approval_requested', who, project,
     who + ' requested approval: [' + actionType + '] ' + title, JSON.stringify({ approval_id: id, action_type: actionType }));
   dispatchWebhook('approval_requested', who, { approval_id: id, action_type: actionType, title: title, risk_tier: riskTier, requested_by: who });
+
+  // In autonomous mode, queue high/critical approvals for morning instead of blocking
+  var effectiveRiskTier = riskTier || 'medium';
+  if (isNetworkAutonomous() && (effectiveRiskTier === 'high' || effectiveRiskTier === 'critical')) {
+    var sleepConfig = getSleepMode();
+    if (sleepConfig.active && sleepConfig.approval_policy === 'queue_high') {
+      appendSleepLog('approvals_queued', { id: id, action_type: actionType, title: title, requested_by: who, time: new Date().toISOString() });
+      return res.json({ id: id, status: 'queued_for_morning', queued: true, message: 'Queued for operator review — all operators are away. Continue with other work.' });
+    }
+  }
+
   res.json({ id: id, status: 'pending', approval_required: true });
 });
 

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -334,6 +334,9 @@ CREATE TABLE IF NOT EXISTS dv_operators (
   email           TEXT NOT NULL DEFAULT '',
   studio_user_id  INTEGER REFERENCES dv_studio_users(id),
   status          TEXT NOT NULL DEFAULT 'active',
+  availability    TEXT NOT NULL DEFAULT 'available',
+  last_seen_at    TEXT,
+  away_message    TEXT NOT NULL DEFAULT '',
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -219,6 +219,32 @@ export function killSwitch(action: 'freeze' | 'unfreeze'): Promise<any> {
   return apiPut('/admin/override', { action });
 }
 
+// Sleep Mode
+
+export function getSleepStatus(): Promise<{
+  sleep_mode: { active: boolean; directive?: string; priorities?: string[]; approval_policy?: string; started_at?: string; started_by?: string; auto_wake_at?: string | null };
+  autonomous: boolean;
+  available_operators: number;
+  log: { tasks_completed?: any[]; steps_completed?: any[]; approvals_queued?: any[]; dispatches?: any[]; errors?: any[]; messages_sent?: number } | null;
+}> {
+  return apiGet('/admin/sleep');
+}
+
+export function setSleepMode(config: {
+  action: 'on' | 'off';
+  operator_id?: string;
+  directive?: string;
+  priorities?: string[];
+  approval_policy?: 'queue_high' | 'block_all' | 'auto_all';
+  auto_wake_at?: string | null;
+}): Promise<any> {
+  return apiPut('/admin/sleep', config);
+}
+
+export function setOperatorAvailability(id: string, availability: 'available' | 'away' | 'sleeping', message?: string): Promise<Operator> {
+  return apiPut<Operator>(`/operators/${id}/availability`, { availability, message });
+}
+
 // Approvals
 
 export function castVote(

--- a/studio-react/src/pages/DashboardPage.tsx
+++ b/studio-react/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState, useCallback } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useDashboardStore } from '../stores/dashboardStore'
 import { useLiveStore } from '../stores/liveStore'
@@ -9,6 +9,7 @@ import ActionRequired from '../components/dashboard/ActionRequired'
 import Badge from '../components/shared/Badge'
 import StatusDot from '../components/shared/StatusDot'
 import { useVoiceStore } from '../stores/voiceStore'
+import { getSleepStatus, setSleepMode } from '../api/endpoints'
 
 // -- Event type color mapping --
 const eventBadgeVariant: Record<string, 'accent' | 'blue' | 'green' | 'muted' | 'purple' | 'red'> = {
@@ -65,6 +66,11 @@ const eventBadgeVariant: Record<string, 'accent' | 'blue' | 'green' | 'muted' | 
   config_changed: 'muted',
   admin_frozen: 'red',
   admin_unfrozen: 'green',
+  sleep_mode_on: 'purple',
+  sleep_mode_off: 'green',
+  autonomous_mode_on: 'purple',
+  autonomous_mode_off: 'green',
+  operator_availability: 'blue',
   request_resolved: 'green',
   work_request: 'accent',
   operator_created: 'blue',
@@ -184,6 +190,147 @@ function OnboardingChecklist({
   )
 }
 
+// -- Sleep Mode types --
+interface SleepStatus {
+  sleep_mode: { active: boolean; directive?: string; priorities?: string[]; approval_policy?: string; started_at?: string; started_by?: string };
+  autonomous: boolean;
+  available_operators: number;
+  log: { tasks_completed?: any[]; steps_completed?: any[]; approvals_queued?: any[]; dispatches?: any[]; errors?: any[] } | null;
+}
+
+function SleepModePanel({
+  status,
+  onActivate,
+  onDeactivate,
+}: {
+  status: SleepStatus | null;
+  onActivate: (directive: string, approvalPolicy: string) => void;
+  onDeactivate: () => void;
+}) {
+  const [directive, setDirective] = useState('')
+  const [approvalPolicy, setApprovalPolicy] = useState('queue_high')
+  const [showForm, setShowForm] = useState(false)
+
+  const isActive = status?.sleep_mode?.active ?? false
+  const log = status?.log
+
+  if (isActive) {
+    return (
+      <div className="bg-purple/10 border border-purple/30 rounded-lg p-4">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <span className="text-lg">&#x1F319;</span>
+            <span className="text-sm font-semibold text-purple">Sleep Mode Active</span>
+            {status?.autonomous && <Badge variant="purple">Autonomous</Badge>}
+          </div>
+          <button
+            onClick={onDeactivate}
+            className="text-xs px-3 py-1.5 rounded bg-green/20 text-green hover:bg-green/30 transition-colors font-medium"
+          >
+            Wake Up
+          </button>
+        </div>
+        {status?.sleep_mode?.directive && (
+          <p className="text-xs text-text-dim mb-2">
+            <span className="text-text-muted">Directive:</span> {status.sleep_mode.directive}
+          </p>
+        )}
+        <div className="text-xs text-text-muted">
+          Started by {status?.sleep_mode?.started_by ?? 'unknown'} at {status?.sleep_mode?.started_at ? formatTimestamp(status.sleep_mode.started_at) : '?'}
+          {' | '}{status?.available_operators ?? 0} operator(s) available
+        </div>
+
+        {/* Overnight summary */}
+        {log && (
+          <div className="mt-3 pt-3 border-t border-purple/20 grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+            <div className="bg-surface rounded p-2 text-center">
+              <div className="text-text font-bold tabular-nums">{log.tasks_completed?.length ?? 0}</div>
+              <div className="text-text-muted">Tasks done</div>
+            </div>
+            <div className="bg-surface rounded p-2 text-center">
+              <div className="text-text font-bold tabular-nums">{log.steps_completed?.length ?? 0}</div>
+              <div className="text-text-muted">Steps done</div>
+            </div>
+            <div className="bg-surface rounded p-2 text-center">
+              <div className="text-text font-bold tabular-nums">{log.dispatches?.length ?? 0}</div>
+              <div className="text-text-muted">Dispatches</div>
+            </div>
+            <div className="bg-surface rounded p-2 text-center">
+              <div className="text-text font-bold tabular-nums">{log.approvals_queued?.length ?? 0}</div>
+              <div className="text-text-muted">Queued approvals</div>
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  if (!showForm) {
+    return (
+      <button
+        onClick={() => setShowForm(true)}
+        className="flex items-center gap-2 text-xs text-text-muted hover:text-purple transition-colors px-3 py-1.5 rounded bg-surface-raised hover:ring-1 ring-purple/30"
+        title="Enter sleep mode"
+      >
+        <span>&#x1F319;</span> Sleep Mode
+      </button>
+    )
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="text-lg">&#x1F319;</span>
+          <span className="text-sm font-semibold text-text">Sleep Mode Setup</span>
+        </div>
+        <button onClick={() => setShowForm(false)} className="text-xs text-text-muted hover:text-text">Cancel</button>
+      </div>
+      <div className="space-y-3">
+        <div>
+          <label className="text-xs text-text-muted block mb-1">Night Directive</label>
+          <textarea
+            value={directive}
+            onChange={e => setDirective(e.target.value)}
+            placeholder="e.g. Focus on Plan #21 WS Steam Polish. No deploys. No external comms."
+            rows={2}
+            className="w-full bg-surface-raised border border-border rounded px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-purple/40 resize-none"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-text-muted block mb-1">Approval Policy</label>
+          <div className="flex gap-2">
+            {[
+              { value: 'queue_high', label: 'Queue high-risk', desc: 'Recommended' },
+              { value: 'block_all', label: 'Block all', desc: 'Conservative' },
+              { value: 'auto_all', label: 'Auto-approve all', desc: 'Risky' },
+            ].map(opt => (
+              <button
+                key={opt.value}
+                onClick={() => setApprovalPolicy(opt.value)}
+                className={`flex-1 px-2 py-2 rounded text-xs text-center transition-colors border ${
+                  approvalPolicy === opt.value
+                    ? 'border-purple/50 bg-purple/10 text-purple'
+                    : 'border-border bg-surface-raised text-text-muted hover:text-text'
+                }`}
+              >
+                <div className="font-medium">{opt.label}</div>
+                <div className="text-[10px] mt-0.5 opacity-70">{opt.desc}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+        <button
+          onClick={() => { onActivate(directive, approvalPolicy); setShowForm(false); setDirective(''); }}
+          className="w-full px-4 py-2 rounded bg-purple text-bg text-sm font-medium hover:bg-purple/80 transition-colors"
+        >
+          Go to Sleep
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export default function DashboardPage() {
   const {
     agents,
@@ -203,10 +350,19 @@ export default function DashboardPage() {
   } = useDashboardStore()
 
   const navigate = useNavigate()
+  const [sleepStatus, setSleepStatus] = useState<SleepStatus | null>(null)
+
+  const loadSleepStatus = useCallback(async () => {
+    try {
+      const data = await getSleepStatus()
+      setSleepStatus(data)
+    } catch { /* not critical */ }
+  }, [])
 
   useEffect(() => {
     refresh()
-  }, [refresh])
+    loadSleepStatus()
+  }, [refresh, loadSleepStatus])
 
   // First-boot detection: if no projects and no agents, redirect to onboarding
   useEffect(() => {
@@ -245,6 +401,24 @@ export default function DashboardPage() {
   }, [events, liveEvents])
   const { isConnected: voiceConnected, channelName, peers, join: joinVoice, leave: leaveVoice } = useVoiceStore()
 
+  const handleSleepActivate = useCallback(async (directive: string, approvalPolicy: string) => {
+    try {
+      await setSleepMode({ action: 'on', directive, approval_policy: approvalPolicy as any })
+      loadSleepStatus()
+    } catch (err) {
+      console.error('Failed to activate sleep mode:', err)
+    }
+  }, [loadSleepStatus])
+
+  const handleSleepDeactivate = useCallback(async () => {
+    try {
+      await setSleepMode({ action: 'off' })
+      loadSleepStatus()
+    } catch (err) {
+      console.error('Failed to deactivate sleep mode:', err)
+    }
+  }, [loadSleepStatus])
+
   return (
     <div className="space-y-6">
       {/* Page header */}
@@ -253,15 +427,25 @@ export default function DashboardPage() {
           <h1 className="text-xl font-semibold text-text">Dashboard</h1>
           <p className="text-sm text-text-muted mt-0.5">Mycelium overview</p>
         </div>
-        <button
-          type="button"
-          onClick={() => refresh()}
-          disabled={loading}
-          className="text-xs text-text-muted hover:text-accent transition-colors px-3 py-1.5 rounded bg-surface-raised hover:ring-1 ring-border disabled:opacity-50"
-        >
-          {loading ? 'Refreshing...' : 'Refresh'}
-        </button>
+        <div className="flex items-center gap-2">
+          {!sleepStatus?.sleep_mode?.active && (
+            <SleepModePanel status={sleepStatus} onActivate={handleSleepActivate} onDeactivate={handleSleepDeactivate} />
+          )}
+          <button
+            type="button"
+            onClick={() => refresh()}
+            disabled={loading}
+            className="text-xs text-text-muted hover:text-accent transition-colors px-3 py-1.5 rounded bg-surface-raised hover:ring-1 ring-border disabled:opacity-50"
+          >
+            {loading ? 'Refreshing...' : 'Refresh'}
+          </button>
+        </div>
       </div>
+
+      {/* Sleep Mode Banner (when active) */}
+      {sleepStatus?.sleep_mode?.active && (
+        <SleepModePanel status={sleepStatus} onActivate={handleSleepActivate} onDeactivate={handleSleepDeactivate} />
+      )}
 
       {/* Summary cards */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-9 gap-3">


### PR DESCRIPTION
## Summary
- Adds operator availability tracking (`available`/`away`/`sleeping`) to `dv_operators`
- New `PUT /admin/sleep` endpoint to toggle sleep mode with night directive and approval policy
- New `PUT /operators/:id/availability` endpoint for per-operator presence tracking
- Network enters autonomous mode when ALL operators are away/sleeping
- High/critical approvals queue for morning review instead of blocking agents
- Boot payload includes `sleep_mode`, `autonomous_mode`, `operators_available`
- Sleep log accumulates overnight activity (tasks, steps, dispatches, queued approvals)
- Dashboard: sleep mode panel with directive form, active banner with overnight stats, Wake Up button

## Test plan
- [ ] Start server, verify new columns on `dv_operators` (availability, last_seen_at, away_message)
- [ ] Dashboard: click Sleep Mode button, fill in directive, activate
- [ ] Verify `GET /admin/sleep` returns active config
- [ ] MCP boot shows autonomous mode banner when all operators away
- [ ] Create high-risk approval during autonomous mode — verify it queues
- [ ] Wake up — verify morning summary shows overnight activity
- [ ] Test partial: one operator sleeps, another available → no autonomous mode

Network Plan #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)