### PR TITLE
Mobile Command View + Push Notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "googleapis": "^171.4.0",
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.1.0",
+        "web-push": "^3.6.7",
         "ws": "^8.19.0"
       }
     },
@@ -143,6 +144,18 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -220,6 +233,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -1002,6 +1021,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1349,6 +1377,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -2190,6 +2224,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "googleapis": "^171.4.0",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.1.0",
+    "web-push": "^3.6.7",
     "ws": "^8.19.0"
   }
 }

--- a/server/db.js
+++ b/server/db.js
@@ -2083,6 +2083,24 @@ export function deleteFeedback(id) {
   db.prepare('DELETE FROM dv_feedback WHERE id = ?').run(id);
 }
 
+// ---- Push subscriptions ----
+
+export function upsertPushSubscription(userId, subscriptionJson, endpoint) {
+  db.prepare(`
+    INSERT INTO dv_push_subscriptions (user_id, subscription, endpoint)
+    VALUES (?, ?, ?)
+    ON CONFLICT(endpoint) DO UPDATE SET subscription = excluded.subscription, user_id = excluded.user_id
+  `).run(userId, subscriptionJson, endpoint);
+}
+
+export function listPushSubscriptions() {
+  return db.prepare('SELECT * FROM dv_push_subscriptions').all();
+}
+
+export function deletePushSubscription(endpoint) {
+  db.prepare('DELETE FROM dv_push_subscriptions WHERE endpoint = ?').run(endpoint);
+}
+
 export function getFeedbackSummary() {
   var total = db.prepare('SELECT COUNT(*) as count FROM dv_feedback').get().count;
   var avgRating = db.prepare('SELECT ROUND(AVG(rating), 2) as avg FROM dv_feedback').get().avg || 0;

--- a/server/push.js
+++ b/server/push.js
@@ -1,0 +1,52 @@
+// =============== MYCELIUM — Web Push Notifications ===============
+import webpush from 'web-push';
+import { listPushSubscriptions, deletePushSubscription } from './db.js';
+
+var VAPID_PUBLIC = process.env.VAPID_PUBLIC_KEY || '';
+var VAPID_PRIVATE = process.env.VAPID_PRIVATE_KEY || '';
+var VAPID_EMAIL = process.env.VAPID_EMAIL || 'mailto:admin@mycelium.fyi';
+
+var configured = false;
+
+if (VAPID_PUBLIC && VAPID_PRIVATE) {
+  webpush.setVapidDetails(VAPID_EMAIL, VAPID_PUBLIC, VAPID_PRIVATE);
+  configured = true;
+  console.log('[push] Web Push configured');
+} else {
+  console.log('[push] VAPID keys not set — push notifications disabled');
+}
+
+// Events that warrant a push notification (high-signal only)
+var NOTIFY_EVENTS = new Set([
+  'approval_created',
+  'approval_requested',
+  'drone_job_failed',
+  'bug_filed',
+  'admin_frozen',
+  'agent_offline',
+  'directive_sent',
+]);
+
+export function shouldNotify(eventType) {
+  return NOTIFY_EVENTS.has(eventType);
+}
+
+export async function sendPushToAll(payload) {
+  if (!configured) return;
+
+  var subs = listPushSubscriptions();
+  if (subs.length === 0) return;
+
+  var payloadStr = JSON.stringify(payload);
+
+  await Promise.allSettled(subs.map(async function (sub) {
+    try {
+      await webpush.sendNotification(JSON.parse(sub.subscription), payloadStr);
+    } catch (err) {
+      if (err.statusCode === 410 || err.statusCode === 404) {
+        // Subscription expired or unsubscribed — clean up
+        deletePushSubscription(sub.endpoint);
+      }
+    }
+  }));
+}

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -91,10 +91,12 @@ import {
   listPluginRecords, getPluginRecord, updatePluginEnabled, getDB,
   getIdleAgents, getNextUnassignedTask, getNextUnassignedPlanStep,
   createFeedback, getFeedback, listFeedback, deleteFeedback, getFeedbackSummary,
-  countPendingForAgent
+  countPendingForAgent,
+  upsertPushSubscription, listPushSubscriptions, deletePushSubscription
 } from '../db.js';
 import { loadPlugins, getPluginMcpTools } from '../plugins.js';
 import { broadcast, addClient, clientCount } from '../eventBus.js';
+import { shouldNotify, sendPushToAll } from '../push.js';
 
 var ADMIN_KEY = process.env.ADMIN_KEY;
 var JWT_SECRET = process.env.JWT_SECRET;
@@ -326,6 +328,15 @@ function emitEvent(type, agentId, projectId, summary, data) {
       } catch (e) { sseClients.delete(client); }
     });
   }
+  // Send push notification for high-signal events
+  if (shouldNotify(type)) {
+    sendPushToAll({
+      title: 'Mycelium',
+      body: summary || type.replace(/_/g, ' '),
+      tag: type,
+      data: { url: '/m', type: type, agent: agentId }
+    }).catch(function (e) { console.error('[push] broadcast error:', e.message); });
+  }
 }
 
 // ---- SSE Event Stream ----
@@ -365,6 +376,30 @@ router.get('/events/stream', function (req, res) {
   addClient(res);
   var keepAlive = setInterval(function () { res.write(': ping\n\n'); }, 30000);
   req.on('close', function () { clearInterval(keepAlive); });
+});
+
+// ---- Push notification routes ----
+
+router.get('/push/vapid-key', function (req, res) {
+  res.json({ key: process.env.VAPID_PUBLIC_KEY || '' });
+});
+
+router.post('/push/subscribe', function (req, res) {
+  var user = getStudioUser(req);
+  if (!user) return res.status(401).json({ error: 'Unauthorized' });
+  var sub = req.body.subscription;
+  if (!sub || !sub.endpoint) return res.status(400).json({ error: 'Missing subscription' });
+  upsertPushSubscription(user.studioUser, JSON.stringify(sub), sub.endpoint);
+  res.json({ ok: true });
+});
+
+router.delete('/push/subscribe', function (req, res) {
+  var user = getStudioUser(req);
+  if (!user) return res.status(401).json({ error: 'Unauthorized' });
+  var endpoint = req.query.endpoint;
+  if (!endpoint) return res.status(400).json({ error: 'Missing endpoint' });
+  deletePushSubscription(endpoint);
+  res.json({ ok: true });
 });
 
 // ---- Approval gate helpers ----

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -454,3 +454,14 @@ CREATE TABLE IF NOT EXISTS dv_feedback (
 CREATE INDEX IF NOT EXISTS idx_dv_feedback_agent ON dv_feedback(agent_id);
 CREATE INDEX IF NOT EXISTS idx_dv_feedback_entity ON dv_feedback(entity_type, entity_id);
 CREATE INDEX IF NOT EXISTS idx_dv_feedback_created ON dv_feedback(created_at DESC);
+
+-- Push notification subscriptions (Web Push)
+CREATE TABLE IF NOT EXISTS dv_push_subscriptions (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id         INTEGER NOT NULL,
+  endpoint        TEXT UNIQUE NOT NULL,
+  subscription    TEXT NOT NULL,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_dv_push_subs_user ON dv_push_subscriptions(user_id);
+CREATE INDEX IF NOT EXISTS idx_dv_push_subs_endpoint ON dv_push_subscriptions(endpoint);

--- a/studio-react/index.html
+++ b/studio-react/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#111110" />
+    <meta name="theme-color" content="#D4A847" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <link rel="apple-touch-icon" href="/fungal_horror.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />

--- a/studio-react/public/manifest.json
+++ b/studio-react/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Mycelium Command",
+  "short_name": "Mycelium",
+  "description": "AI agent swarm command center",
+  "start_url": "/m",
+  "display": "standalone",
+  "background_color": "#111110",
+  "theme_color": "#D4A847",
+  "icons": [
+    {
+      "src": "/fungal_horror.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/fungal_horror.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/studio-react/public/sw.js
+++ b/studio-react/public/sw.js
@@ -1,0 +1,49 @@
+// Mycelium Service Worker — Push Notifications
+
+self.addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('push', function (event) {
+  if (!event.data) return;
+
+  var payload;
+  try {
+    payload = event.data.json();
+  } catch (e) {
+    payload = { title: 'Mycelium', body: event.data.text() };
+  }
+
+  event.waitUntil(
+    self.registration.showNotification(payload.title || 'Mycelium', {
+      body: payload.body || '',
+      icon: '/fungal_horror.png',
+      badge: '/fungal_horror.png',
+      tag: payload.tag || 'mycelium',
+      data: payload.data || { url: '/m' },
+    })
+  );
+});
+
+self.addEventListener('notificationclick', function (event) {
+  event.notification.close();
+
+  var url = (event.notification.data && event.notification.data.url) || '/m';
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (clients) {
+      // Focus existing window if available
+      for (var i = 0; i < clients.length; i++) {
+        if (clients[i].url.indexOf('/m') !== -1 && 'focus' in clients[i]) {
+          return clients[i].focus();
+        }
+      }
+      // Open new window
+      return self.clients.openWindow(url);
+    })
+  );
+});

--- a/studio-react/src/App.tsx
+++ b/studio-react/src/App.tsx
@@ -3,6 +3,8 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'sonner'
 import { useAuthStore } from './stores/authStore'
 import AppLayout from './layouts/AppLayout'
+import MobileLayout from './layouts/MobileLayout'
+import MobileCommandPage from './pages/MobileCommandPage'
 import LoginPage from './pages/LoginPage'
 import DashboardPage from './pages/DashboardPage'
 import TasksPage from './pages/TasksPage'
@@ -49,6 +51,11 @@ export default function App() {
           path="/login"
           element={isAuthenticated ? <Navigate to="/" replace /> : <LoginPage />}
         />
+        <Route
+          element={isAuthenticated ? <MobileLayout /> : <Navigate to="/login" replace />}
+        >
+          <Route path="m" element={<MobileCommandPage />} />
+        </Route>
         <Route
           element={isAuthenticated ? <AppLayout /> : <Navigate to="/login" replace />}
         >

--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -447,3 +447,23 @@ export function enablePlugin(name: string): Promise<{ ok: boolean }> {
 export function disablePlugin(name: string): Promise<{ ok: boolean }> {
   return apiPut<{ ok: boolean }>(`/plugins/${encodeURIComponent(name)}/disable`, {});
 }
+
+// Push notifications
+
+export function getVapidKey(): Promise<{ key: string }> {
+  return apiGet<{ key: string }>('/push/vapid-key');
+}
+
+export function subscribePush(subscription: PushSubscriptionJSON): Promise<{ ok: boolean }> {
+  return apiPost<{ ok: boolean }>('/push/subscribe', { subscription });
+}
+
+export function unsubscribePush(endpoint: string): Promise<{ ok: boolean }> {
+  return apiDelete<{ ok: boolean }>(`/push/subscribe?endpoint=${encodeURIComponent(endpoint)}`);
+}
+
+// Directives (convenience)
+
+export function sendDirective(toAgent: string, content: string): Promise<Message> {
+  return apiPost<Message>('/messages', { to_agent: toAgent, content, msg_type: 'directive' });
+}

--- a/studio-react/src/hooks/usePushNotifications.ts
+++ b/studio-react/src/hooks/usePushNotifications.ts
@@ -1,0 +1,73 @@
+import { useState, useEffect, useCallback } from 'react'
+import { getVapidKey, subscribePush, unsubscribePush } from '../api/endpoints'
+
+type PushStatus = 'unsupported' | 'prompt' | 'denied' | 'subscribed' | 'loading'
+
+export function usePushNotifications() {
+  const [status, setStatus] = useState<PushStatus>('loading')
+  const [registration, setRegistration] = useState<ServiceWorkerRegistration | null>(null)
+
+  useEffect(() => {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+      setStatus('unsupported')
+      return
+    }
+
+    navigator.serviceWorker.register('/sw.js').then((reg) => {
+      setRegistration(reg)
+      return reg.pushManager.getSubscription()
+    }).then((sub) => {
+      if (sub) {
+        setStatus('subscribed')
+      } else {
+        const perm = Notification.permission
+        setStatus(perm === 'denied' ? 'denied' : 'prompt')
+      }
+    }).catch(() => {
+      setStatus('unsupported')
+    })
+  }, [])
+
+  const subscribe = useCallback(async () => {
+    if (!registration) return
+    try {
+      const { key } = await getVapidKey()
+      if (!key) return
+
+      const sub = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(key),
+      })
+
+      await subscribePush(sub.toJSON())
+      setStatus('subscribed')
+    } catch {
+      setStatus(Notification.permission === 'denied' ? 'denied' : 'prompt')
+    }
+  }, [registration])
+
+  const unsubscribe = useCallback(async () => {
+    if (!registration) return
+    try {
+      const sub = await registration.pushManager.getSubscription()
+      if (sub) {
+        await unsubscribePush(sub.endpoint)
+        await sub.unsubscribe()
+      }
+      setStatus('prompt')
+    } catch {
+      // ignore
+    }
+  }, [registration])
+
+  return { status, subscribe, unsubscribe }
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const raw = atob(base64)
+  const arr = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i)
+  return arr
+}

--- a/studio-react/src/layouts/MobileLayout.tsx
+++ b/studio-react/src/layouts/MobileLayout.tsx
@@ -1,0 +1,58 @@
+import { Outlet, Link } from 'react-router-dom'
+import { useAuthStore } from '../stores/authStore'
+import { useLiveEvents } from '../hooks/useLiveEvents'
+import { useLiveStore } from '../stores/liveStore'
+
+export default function MobileLayout() {
+  const user = useAuthStore((s) => s.user)
+  const logout = useAuthStore((s) => s.logout)
+  useLiveEvents()
+  const connected = useLiveStore((s) => s.connected)
+
+  return (
+    <div
+      className="flex flex-col min-h-screen bg-bg text-text"
+      style={{
+        paddingTop: 'env(safe-area-inset-top)',
+        paddingBottom: 'env(safe-area-inset-bottom)',
+      }}
+    >
+      {/* Header */}
+      <header className="flex items-center justify-between px-4 h-12 border-b border-border bg-surface shrink-0">
+        <div className="flex items-center gap-2">
+          <img
+            src="/fungal_horror.png"
+            alt="Mycelium"
+            className="w-7 h-7 rounded-lg object-cover"
+            style={{ filter: 'drop-shadow(0 0 4px rgba(212,168,71,0.4))' }}
+          />
+          <span className="font-mono text-accent text-xs font-bold tracking-[0.15em]">
+            MYCELIUM
+          </span>
+          <span
+            className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-green' : 'bg-text-muted'}`}
+            title={connected ? 'Connected' : 'Disconnected'}
+          />
+        </div>
+        <div className="flex items-center gap-3">
+          <Link to="/" className="text-[10px] text-text-muted font-mono hover:text-text-dim">
+            DESKTOP
+          </Link>
+          {user && (
+            <button
+              onClick={logout}
+              className="text-[10px] text-text-muted font-mono hover:text-red"
+            >
+              OUT
+            </button>
+          )}
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className="flex-1 overflow-y-auto">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/studio-react/src/pages/MobileCommandPage.tsx
+++ b/studio-react/src/pages/MobileCommandPage.tsx
@@ -1,0 +1,354 @@
+import { useState, useCallback, useMemo } from 'react'
+import { useDashboardStore } from '../stores/dashboardStore'
+import { useLiveStore } from '../stores/liveStore'
+import { useAuthStore } from '../stores/authStore'
+import { usePolling } from '../hooks/usePolling'
+import { usePushNotifications } from '../hooks/usePushNotifications'
+import { castVote, resolveApproval, killSwitch, sendDirective } from '../api/endpoints'
+import { toast } from 'sonner'
+import type { Approval } from '../api/types'
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  if (diff < 60000) return 'now'
+  if (diff < 3600000) return Math.floor(diff / 60000) + 'm'
+  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h'
+  return Math.floor(diff / 86400000) + 'd'
+}
+
+function safeVotes(raw: unknown): Array<{ vote: string }> {
+  if (Array.isArray(raw)) return raw
+  if (typeof raw === 'string') {
+    try { const p = JSON.parse(raw); if (Array.isArray(p)) return p } catch { /* */ }
+  }
+  return []
+}
+
+const riskColors: Record<string, string> = {
+  critical: 'bg-red/20 text-red',
+  high: 'bg-red/15 text-red',
+  medium: 'bg-accent/15 text-accent',
+  low: 'bg-green/15 text-green',
+}
+
+const eventTypeColors: Record<string, string> = {
+  task_completed: 'text-green',
+  task_created: 'text-blue',
+  bug_filed: 'text-red',
+  approval_created: 'text-accent',
+  approval_approved: 'text-green',
+  approval_denied: 'text-red',
+  agent_boot: 'text-blue',
+  agent_heartbeat: 'text-text-muted',
+  drone_job_failed: 'text-red',
+  plan_completed: 'text-purple',
+}
+
+export default function MobileCommandPage() {
+  const agents = useDashboardStore((s) => s.agents)
+  const pendingApprovals = useDashboardStore((s) => s.pendingApprovals)
+  const instanceConfig = useDashboardStore((s) => s.instanceConfig)
+  const events = useDashboardStore((s) => s.events)
+  const refresh = useDashboardStore((s) => s.refresh)
+  const user = useAuthStore((s) => s.user)
+  const liveEvents = useLiveStore((s) => s.events)
+  const { status: pushStatus, subscribe: pushSubscribe, unsubscribe: pushUnsubscribe } = usePushNotifications()
+
+  usePolling(15000)
+
+  const [directiveAgent, setDirectiveAgent] = useState('')
+  const [directiveText, setDirectiveText] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const isFrozen = useMemo(() => {
+    const s = instanceConfig.find((c) => c.key === 'admin_status')
+    return s?.value === 'frozen'
+  }, [instanceConfig])
+
+  const onlineAgents = useMemo(() => agents.filter((a) => a.status === 'online'), [agents])
+  const pending = useMemo(() => pendingApprovals.filter((a) => a.status === 'pending'), [pendingApprovals])
+
+  // Merge polled + live events, dedupe, sort newest first
+  const recentEvents = useMemo(() => {
+    const seen = new Set<string>()
+    const all = [...liveEvents.map((e) => ({ ...e, id: String(e.id) })), ...events]
+    return all.filter((e) => {
+      if (seen.has(e.id)) return false
+      seen.add(e.id)
+      return true
+    }).sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()).slice(0, 15)
+  }, [events, liveEvents])
+
+  const handleVote = useCallback(async (approval: Approval, vote: 'approve' | 'deny') => {
+    if (!user) return
+    try {
+      await castVote(approval.id, vote, null as any, user.username, 'operator')
+      const existing = safeVotes(approval.votes)
+      const total = existing.length + 1
+      if (total >= approval.quorum_required) {
+        const approves = existing.filter((v) => v.vote === 'approve').length + (vote === 'approve' ? 1 : 0)
+        await resolveApproval(approval.id, approves > total / 2 ? 'approved' : 'rejected', user.username)
+      }
+      toast.success(vote === 'approve' ? 'Approved' : 'Denied')
+      refresh()
+    } catch (e) {
+      toast.error('Vote failed')
+    }
+  }, [user, refresh])
+
+  const handleKillSwitch = useCallback(async () => {
+    try {
+      await killSwitch(isFrozen ? 'unfreeze' : 'freeze')
+      toast.success(isFrozen ? 'Unfrozen' : 'Frozen')
+      refresh()
+    } catch {
+      toast.error('Kill switch failed')
+    }
+  }, [isFrozen, refresh])
+
+  const handleDirective = useCallback(async () => {
+    if (!directiveAgent || !directiveText.trim()) return
+    setSending(true)
+    try {
+      await sendDirective(directiveAgent, directiveText.trim())
+      toast.success('Directive sent')
+      setDirectiveText('')
+    } catch {
+      toast.error('Failed to send')
+    } finally {
+      setSending(false)
+    }
+  }, [directiveAgent, directiveText])
+
+  return (
+    <div className="flex flex-col gap-4 p-4 pb-8">
+      {/* Frozen banner */}
+      {isFrozen && (
+        <div className="px-3 py-2 rounded-lg bg-red/15 text-red text-sm font-mono font-bold text-center animate-pulse">
+          NETWORK FROZEN
+        </div>
+      )}
+
+      {/* Agent cards — horizontal scroll */}
+      <section>
+        <h2 className="text-[10px] uppercase tracking-widest font-semibold text-text-muted mb-2">
+          Agents
+        </h2>
+        <div className="flex gap-2 overflow-x-auto pb-1 -mx-4 px-4">
+          {agents.map((agent) => (
+            <div
+              key={agent.id}
+              className="shrink-0 w-36 p-3 rounded-lg bg-surface border border-border"
+            >
+              <div className="flex items-center gap-2 mb-1.5">
+                <span
+                  className={`w-2 h-2 rounded-full shrink-0 ${
+                    agent.status === 'online' ? 'bg-green' : 'bg-text-muted'
+                  }`}
+                />
+                <span className="text-xs font-semibold text-text truncate">
+                  {agent.name}
+                </span>
+              </div>
+              <span className="text-[10px] text-text-muted leading-tight line-clamp-2">
+                {agent.working_on || (agent.status === 'online' ? 'Idle' : 'Offline')}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Pending approvals */}
+      {pending.length > 0 && (
+        <section>
+          <h2 className="text-[10px] uppercase tracking-widest font-semibold text-text-muted mb-2">
+            Approvals
+            <span className="ml-2 px-1.5 py-0.5 rounded text-[10px] bg-accent/15 text-accent">
+              {pending.length}
+            </span>
+          </h2>
+          <div className="flex flex-col gap-2">
+            {pending.map((approval) => (
+              <div
+                key={approval.id}
+                className="p-3 rounded-lg bg-surface border border-border"
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <span className={`px-1.5 py-0.5 rounded text-[10px] font-semibold ${riskColors[approval.risk_tier] || 'bg-surface-raised text-text-dim'}`}>
+                    {approval.risk_tier}
+                  </span>
+                  <span className="text-xs text-text-dim truncate flex-1">
+                    {(approval as any).title || approval.entity_type}
+                  </span>
+                  <span className="text-[10px] text-text-muted">
+                    {timeAgo(approval.created_at)}
+                  </span>
+                </div>
+                {/* Quorum progress */}
+                <div className="flex items-center gap-2 mb-2">
+                  <div className="flex-1 h-1 rounded-full bg-surface-raised overflow-hidden">
+                    <div
+                      className="h-full bg-accent rounded-full transition-all"
+                      style={{ width: `${(safeVotes(approval.votes).length / approval.quorum_required) * 100}%` }}
+                    />
+                  </div>
+                  <span className="text-[10px] text-text-muted font-mono">
+                    {safeVotes(approval.votes).length}/{approval.quorum_required}
+                  </span>
+                </div>
+                {/* Vote buttons */}
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handleVote(approval, 'approve')}
+                    className="flex-1 py-2 rounded-lg bg-green/15 text-green text-sm font-semibold active:bg-green/25 transition-colors"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => handleVote(approval, 'deny')}
+                    className="flex-1 py-2 rounded-lg bg-red/15 text-red text-sm font-semibold active:bg-red/25 transition-colors"
+                  >
+                    Deny
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Kill switch */}
+      <section>
+        <h2 className="text-[10px] uppercase tracking-widest font-semibold text-text-muted mb-2">
+          Kill Switch
+        </h2>
+        <button
+          onClick={handleKillSwitch}
+          className={`w-full py-3 rounded-lg text-sm font-bold font-mono transition-colors ${
+            isFrozen
+              ? 'bg-green/15 text-green active:bg-green/25'
+              : 'bg-red/15 text-red active:bg-red/25'
+          }`}
+        >
+          {isFrozen ? 'UNFREEZE NETWORK' : 'FREEZE NETWORK'}
+        </button>
+      </section>
+
+      {/* Quick directive */}
+      <section>
+        <h2 className="text-[10px] uppercase tracking-widest font-semibold text-text-muted mb-2">
+          Send Directive
+        </h2>
+        <div className="flex flex-col gap-2 p-3 rounded-lg bg-surface border border-border">
+          <select
+            value={directiveAgent}
+            onChange={(e) => setDirectiveAgent(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm text-text"
+          >
+            <option value="">Select agent...</option>
+            {onlineAgents.map((a) => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </select>
+          <textarea
+            value={directiveText}
+            onChange={(e) => setDirectiveText(e.target.value)}
+            placeholder="Directive content..."
+            rows={2}
+            className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm text-text resize-none"
+          />
+          <button
+            onClick={handleDirective}
+            disabled={!directiveAgent || !directiveText.trim() || sending}
+            className="w-full py-2 rounded-lg bg-accent/15 text-accent text-sm font-semibold disabled:opacity-40 active:bg-accent/25 transition-colors"
+          >
+            {sending ? 'Sending...' : 'Send'}
+          </button>
+        </div>
+      </section>
+
+      {/* Events feed */}
+      <section>
+        <h2 className="text-[10px] uppercase tracking-widest font-semibold text-text-muted mb-2">
+          Recent Events
+        </h2>
+        <div className="flex flex-col gap-0.5">
+          {recentEvents.map((event) => (
+            <div
+              key={event.id}
+              className="flex items-start gap-2 py-1.5 px-2 rounded hover:bg-surface-raised/50"
+            >
+              <span className="text-[10px] text-text-muted font-mono w-8 shrink-0 pt-0.5">
+                {timeAgo(event.created_at)}
+              </span>
+              <span className={`text-[10px] font-mono shrink-0 pt-0.5 ${eventTypeColors[event.type] || 'text-text-muted'}`}>
+                {event.type.replace(/_/g, ' ')}
+              </span>
+              <span className="text-xs text-text-dim leading-snug flex-1 min-w-0 truncate">
+                {event.summary}
+              </span>
+            </div>
+          ))}
+          {recentEvents.length === 0 && (
+            <span className="text-xs text-text-muted py-2">No recent events</span>
+          )}
+        </div>
+      </section>
+
+      {/* Push notifications toggle */}
+      <section>
+        <h2 className="text-[10px] uppercase tracking-widest font-semibold text-text-muted mb-2">
+          Notifications
+        </h2>
+        <div className="p-3 rounded-lg bg-surface border border-border">
+          {pushStatus === 'unsupported' && (
+            <p className="text-xs text-text-muted">
+              Push notifications not supported. Add to Home Screen on iOS for push support.
+            </p>
+          )}
+          {pushStatus === 'denied' && (
+            <p className="text-xs text-red">
+              Notifications blocked. Enable in browser/system settings.
+            </p>
+          )}
+          {pushStatus === 'prompt' && (
+            <button
+              onClick={pushSubscribe}
+              className="w-full py-2 rounded-lg bg-accent/15 text-accent text-sm font-semibold active:bg-accent/25 transition-colors"
+            >
+              Enable Push Notifications
+            </button>
+          )}
+          {pushStatus === 'subscribed' && (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="w-2 h-2 rounded-full bg-green" />
+                <span className="text-xs text-text-dim">Push notifications active</span>
+              </div>
+              <button
+                onClick={pushUnsubscribe}
+                className="text-[10px] text-text-muted hover:text-red font-mono"
+              >
+                Disable
+              </button>
+            </div>
+          )}
+          {pushStatus === 'loading' && (
+            <span className="text-xs text-text-muted">Checking...</span>
+          )}
+        </div>
+      </section>
+
+      {/* iOS install prompt */}
+      {typeof navigator !== 'undefined' &&
+        /iPhone|iPad/.test(navigator.userAgent) &&
+        !window.matchMedia('(display-mode: standalone)').matches && (
+        <section className="p-3 rounded-lg bg-accent/10 border border-accent/20">
+          <p className="text-xs text-accent">
+            For push notifications on iOS, tap the share button and "Add to Home Screen" to install Mycelium as an app.
+          </p>
+        </section>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New `/m` route: purpose-built mobile command screen for controlling the swarm from your phone
- Agent status cards, tap-to-approve/deny, kill switch, quick directives, events feed
- Web Push notifications via Service Worker + `web-push` npm package
- PWA manifest for "Add to Home Screen" on iOS/Android
- New `dv_push_subscriptions` table + server push module
- Push triggers on high-signal events only (approvals, failures, bugs, freezes)

## Environment Variables (new)
- `VAPID_PUBLIC_KEY` — generate with `npx web-push generate-vapid-keys`
- `VAPID_PRIVATE_KEY` — from same command
- `VAPID_EMAIL` — e.g. `mailto:admin@mycelium.fyi`

Push notifications gracefully no-op if VAPID keys are not configured.

## Test plan
- [ ] Visit `/m` on mobile — verify agents, approvals, kill switch, events render
- [ ] Resize desktop browser to <768px — verify mobile layout works
- [ ] Test approve/deny on a pending approval
- [ ] Test kill switch toggle
- [ ] Test sending a directive
- [ ] Add to Home Screen on iOS — standalone mode launches
- [ ] Generate VAPID keys + subscribe to push — verify notifications fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)