### PR TITLE
fix: allow assigned agents to complete cross-project tasks (Bug #42)

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -757,7 +757,10 @@ router.put('/tasks/:id', function (req, res) {
   if (!agentId) return;
   var task = getDvTask(parseIntParam(req.params.id));
   if (!task) return res.status(404).json({ error: 'Task not found' });
-  if (!checkProjectScope(req, res, task.project_id)) return;
+  // Allow assigned agents to update their own tasks regardless of project scope (Bug #42)
+  if (!(req._authAgentId && task.assignee === req._authAgentId)) {
+    if (!checkProjectScope(req, res, task.project_id)) return;
+  }
   if (!validateEnum(res, req.body.status, TASK_STATUSES, 'status')) return;
   if (!validateEnum(res, req.body.priority, TASK_PRIORITIES, 'priority')) return;
   var fields = {};


### PR DESCRIPTION
## Summary
- Fixes Bug #42: agents assigned tasks from other projects were getting 403 errors when trying to complete them
- `checkProjectScope` in `PUT /tasks/:id` now bypasses scope check when the authenticated agent is the task's assignee
- Unblocks hijack-claude (and any future cross-project task assignments)

## Test plan
- [ ] hijack-claude can now mark task #48 as done from king-city project
- [ ] Non-assigned agents still get 403 on cross-project task updates (scope enforcement intact)
- [ ] Assigned agents can update status, add comments, etc. on their assigned tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)