### PR TITLE
feat: operator inbox with plan step comments (Step #195)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -488,6 +488,149 @@ export function deleteTaskComment(commentId) {
   return result.changes > 0;
 }
 
+// -- Plan Step Comments --
+
+export function addPlanStepComment(stepId, author, content) {
+  return db.prepare(
+    "INSERT INTO dv_plan_step_comments (step_id, author, content) VALUES (?, ?, ?) RETURNING *"
+  ).get(stepId, author, content);
+}
+
+export function getPlanStepComments(stepId) {
+  return db.prepare(
+    "SELECT * FROM dv_plan_step_comments WHERE step_id = ? ORDER BY created_at ASC"
+  ).all(stepId);
+}
+
+export function deletePlanStepComment(commentId) {
+  var result = db.prepare("DELETE FROM dv_plan_step_comments WHERE id = ?").run(commentId);
+  return result.changes > 0;
+}
+
+// -- Plan Step Lookup --
+
+export function getPlanStep(stepId) {
+  return db.prepare("SELECT * FROM dv_plan_steps WHERE id = ?").get(stepId);
+}
+
+// -- Operator Inbox --
+
+export function getInboxLastRead(operatorId) {
+  var row = db.prepare("SELECT last_read_at FROM dv_inbox_reads WHERE operator_id = ?").get(operatorId);
+  return row ? row.last_read_at : null;
+}
+
+export function markInboxRead(operatorId) {
+  db.prepare(
+    "INSERT INTO dv_inbox_reads (operator_id, last_read_at) VALUES (?, datetime('now')) ON CONFLICT(operator_id) DO UPDATE SET last_read_at = datetime('now')"
+  ).run(operatorId);
+}
+
+export function getInboxItems(operatorId, limit) {
+  limit = limit || 100;
+  var lastRead = getInboxLastRead(operatorId);
+
+  // Source 1: requests/directives addressed to this operator
+  var directMessages = db.prepare(
+    "SELECT id, from_agent, to_agent, content, msg_type, status, created_at FROM dv_messages WHERE to_agent = ? AND msg_type IN ('request', 'directive') AND status IN ('pending', 'sent') ORDER BY created_at DESC LIMIT ?"
+  ).all(operatorId, limit);
+
+  // Source 2: @mentions in recent messages (last 7 days)
+  var mentions = db.prepare(
+    "SELECT id, from_agent, to_agent, content, msg_type, status, created_at FROM dv_messages WHERE content LIKE ? AND from_agent != ? AND msg_type != 'chat' AND created_at > datetime('now', '-7 days') ORDER BY created_at DESC LIMIT ?"
+  ).all('%@' + operatorId + '%', operatorId, limit);
+
+  // Source 3: pending approvals
+  var approvals = db.prepare(
+    "SELECT id, entity_type, entity_id, risk_tier, status, created_by, created_at FROM dv_approvals WHERE status = 'pending' ORDER BY created_at DESC LIMIT ?"
+  ).all(limit);
+
+  // Normalize into inbox items
+  var items = [];
+
+  for (var msg of directMessages) {
+    items.push({
+      id: 'msg_' + msg.id,
+      kind: msg.msg_type === 'directive' ? 'directive' : 'request',
+      source_type: 'message',
+      source_id: msg.id,
+      title: msg.from_agent + (msg.msg_type === 'directive' ? ' sent a directive' : ' sent a request'),
+      preview: (msg.content || '').slice(0, 120),
+      from: msg.from_agent,
+      created_at: msg.created_at,
+      is_unread: !lastRead || msg.created_at > lastRead,
+      link: '/messages'
+    });
+  }
+
+  for (var mention of mentions) {
+    // Skip if already included as direct message
+    if (directMessages.some(function (m) { return m.id === mention.id; })) continue;
+    items.push({
+      id: 'mention_' + mention.id,
+      kind: 'mention',
+      source_type: 'message',
+      source_id: mention.id,
+      title: mention.from_agent + ' mentioned you',
+      preview: (mention.content || '').slice(0, 120),
+      from: mention.from_agent,
+      created_at: mention.created_at,
+      is_unread: !lastRead || mention.created_at > lastRead,
+      link: '/messages'
+    });
+  }
+
+  for (var appr of approvals) {
+    items.push({
+      id: 'approval_' + appr.id,
+      kind: 'approval',
+      source_type: 'approval',
+      source_id: appr.id,
+      title: appr.entity_type + ' approval requested by ' + appr.created_by,
+      preview: appr.entity_type + ' #' + appr.entity_id + ' (' + appr.risk_tier + ' risk)',
+      from: appr.created_by,
+      created_at: appr.created_at,
+      is_unread: !lastRead || appr.created_at > lastRead,
+      link: '/approvals'
+    });
+  }
+
+  // Sort by created_at DESC and limit
+  items.sort(function (a, b) { return b.created_at.localeCompare(a.created_at); });
+  return items.slice(0, limit);
+}
+
+export function countInboxUnread(operatorId) {
+  var lastRead = getInboxLastRead(operatorId);
+  if (!lastRead) {
+    // Never read — count all pending items
+    var msgs = db.prepare(
+      "SELECT COUNT(*) as c FROM dv_messages WHERE to_agent = ? AND msg_type IN ('request', 'directive') AND status IN ('pending', 'sent')"
+    ).get(operatorId);
+    var mentions = db.prepare(
+      "SELECT COUNT(*) as c FROM dv_messages WHERE content LIKE ? AND from_agent != ? AND msg_type != 'chat' AND created_at > datetime('now', '-7 days')"
+    ).get('%@' + operatorId + '%', operatorId);
+    var approvals = db.prepare(
+      "SELECT COUNT(*) as c FROM dv_approvals WHERE status = 'pending'"
+    ).get();
+    return (msgs.c || 0) + (mentions.c || 0) + (approvals.c || 0);
+  }
+  var msgCount = db.prepare(
+    "SELECT COUNT(*) as c FROM dv_messages WHERE to_agent = ? AND msg_type IN ('request', 'directive') AND status IN ('pending', 'sent') AND created_at > ?"
+  ).get(operatorId, lastRead);
+  var mentionCount = db.prepare(
+    "SELECT COUNT(*) as c FROM dv_messages WHERE content LIKE ? AND from_agent != ? AND msg_type != 'chat' AND created_at > datetime('now', '-7 days') AND created_at > ?"
+  ).get('%@' + operatorId + '%', operatorId, lastRead);
+  var approvalCount = db.prepare(
+    "SELECT COUNT(*) as c FROM dv_approvals WHERE status = 'pending' AND created_at > ?"
+  ).get(lastRead);
+  return (msgCount.c || 0) + (mentionCount.c || 0) + (approvalCount.c || 0);
+}
+
+export function getOperatorByStudioUserId(studioUserId) {
+  return db.prepare("SELECT * FROM dv_operators WHERE studio_user_id = ?").get(studioUserId);
+}
+
 // -- Context --
 
 export function getDvContext(projectId) {

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -91,7 +91,10 @@ import {
   listPluginRecords, getPluginRecord, updatePluginEnabled, getDB,
   getIdleAgents, getNextUnassignedTask, getNextUnassignedPlanStep,
   createFeedback, getFeedback, listFeedback, deleteFeedback, getFeedbackSummary,
-  countPendingForAgent
+  countPendingForAgent,
+  addPlanStepComment, getPlanStepComments, deletePlanStepComment, getPlanStep,
+  getInboxItems, countInboxUnread, getInboxLastRead, markInboxRead,
+  getOperatorByStudioUserId
 } from '../db.js';
 import { loadPlugins, getPluginMcpTools } from '../plugins.js';
 import { broadcast, addClient, clientCount } from '../eventBus.js';
@@ -1534,16 +1537,19 @@ router.post('/studio/login', asyncHandler(async function (req, res) {
   if (!(await bcrypt.compare(password, user.password_hash))) {
     return res.status(401).json({ error: 'Invalid username or password' });
   }
+  var operator = getOperatorByStudioUserId(user.id);
+  var operatorId = operator ? operator.id : null;
   var token = jwt.sign({
     studioUser: true,
     userId: user.id,
     username: user.username,
     displayName: user.display_name,
-    role: user.role
+    role: user.role,
+    operatorId: operatorId
   }, JWT_SECRET, { expiresIn: STUDIO_JWT_EXPIRY });
   res.json({
     token: token,
-    user: { id: user.id, username: user.username, display_name: user.display_name, role: user.role }
+    user: { id: user.id, username: user.username, display_name: user.display_name, role: user.role, operator_id: operatorId }
   });
 }));
 
@@ -1943,7 +1949,15 @@ router.post('/agents/:id/savepoint', function (req, res) {
 router.get('/admin/overview', function (req, res) {
   if (!checkAdmin(req, res)) return;
   var who = getAdminDisplayName(req);
-  res.json(getDvOverview(who));
+  var overview = getDvOverview(who);
+  // Include inbox unread count for studio users
+  var studioUser = getStudioUser(req);
+  if (studioUser && studioUser.operatorId) {
+    overview.inbox_unread = countInboxUnread(studioUser.operatorId);
+  } else {
+    overview.inbox_unread = 0;
+  }
+  res.json(overview);
 });
 
 // Actionable items needing decisions (admin only)
@@ -2965,6 +2979,68 @@ router.post('/work/request', function (req, res) {
 
   emitEvent('work_request', who, null, who + ' requested work: ' + type + (target ? ' \u2192 ' + target : ''));
   res.json({ ok: true, message_id: msgId, routed_to: adminAgentId });
+});
+
+// ======== OPERATOR INBOX ========
+
+router.get('/inbox', function (req, res) {
+  var user = getStudioUser(req);
+  if (!user) return res.status(401).json({ error: 'Studio login required' });
+  var operatorId = user.operatorId;
+  if (!operatorId) return res.json({ items: [], unread_count: 0, operator_id: null, last_read_at: null });
+  var items = getInboxItems(operatorId, 100);
+  var lastRead = getInboxLastRead(operatorId);
+  var unreadCount = countInboxUnread(operatorId);
+  res.json({ items: items, unread_count: unreadCount, operator_id: operatorId, last_read_at: lastRead });
+});
+
+router.get('/inbox/unread', function (req, res) {
+  var user = getStudioUser(req);
+  if (!user) return res.status(401).json({ error: 'Studio login required' });
+  var operatorId = user.operatorId;
+  if (!operatorId) return res.json({ count: 0 });
+  res.json({ count: countInboxUnread(operatorId), operator_id: operatorId });
+});
+
+router.put('/inbox/read', function (req, res) {
+  var user = getStudioUser(req);
+  if (!user) return res.status(401).json({ error: 'Studio login required' });
+  var operatorId = user.operatorId;
+  if (!operatorId) return res.json({ ok: true });
+  markInboxRead(operatorId);
+  res.json({ ok: true, operator_id: operatorId });
+});
+
+// ======== PLAN STEP COMMENTS ========
+
+router.get('/plans/:planId/steps/:stepId/comments', function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  var step = getPlanStep(parseIntParam(req.params.stepId));
+  if (!step || step.plan_id !== parseIntParam(req.params.planId))
+    return res.status(404).json({ error: 'Step not found' });
+  res.json(getPlanStepComments(step.id));
+});
+
+router.post('/plans/:planId/steps/:stepId/comments', function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  var step = getPlanStep(parseIntParam(req.params.stepId));
+  if (!step || step.plan_id !== parseIntParam(req.params.planId))
+    return res.status(404).json({ error: 'Step not found' });
+  var author = escapeHtml(req.body.author || who);
+  var content = escapeHtml(req.body.content || '');
+  if (!content) return res.status(400).json({ error: 'content is required' });
+  var comment = addPlanStepComment(step.id, author, content);
+  emitEvent('plan_step_comment', who, null, who + ' commented on plan step #' + step.id, { step_id: step.id, comment_id: comment.id });
+  res.json(comment);
+});
+
+router.delete('/plans/:planId/steps/:stepId/comments/:commentId', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var deleted = deletePlanStepComment(parseIntParam(req.params.commentId));
+  if (!deleted) return res.status(404).json({ error: 'Comment not found' });
+  res.json({ ok: true, deleted: parseIntParam(req.params.commentId) });
 });
 
 // ======== PLUGINS ========

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -454,3 +454,19 @@ CREATE TABLE IF NOT EXISTS dv_feedback (
 CREATE INDEX IF NOT EXISTS idx_dv_feedback_agent ON dv_feedback(agent_id);
 CREATE INDEX IF NOT EXISTS idx_dv_feedback_entity ON dv_feedback(entity_type, entity_id);
 CREATE INDEX IF NOT EXISTS idx_dv_feedback_created ON dv_feedback(created_at DESC);
+
+-- Plan step comments (mirrors dv_task_comments pattern)
+CREATE TABLE IF NOT EXISTS dv_plan_step_comments (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  step_id    INTEGER NOT NULL REFERENCES dv_plan_steps(id) ON DELETE CASCADE,
+  author     TEXT NOT NULL,
+  content    TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_plan_step_comments_step ON dv_plan_step_comments(step_id);
+
+-- Operator inbox read state
+CREATE TABLE IF NOT EXISTS dv_inbox_reads (
+  operator_id  TEXT PRIMARY KEY,
+  last_read_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/studio-react/src/App.tsx
+++ b/studio-react/src/App.tsx
@@ -23,6 +23,7 @@ import OnboardingPage from './pages/OnboardingPage'
 import PluginsPage from './pages/PluginsPage'
 import AnalyticsPage from './pages/AnalyticsPage'
 import FeedbackPage from './pages/FeedbackPage'
+import InboxPage from './pages/InboxPage'
 
 export default function App() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
@@ -53,6 +54,7 @@ export default function App() {
           element={isAuthenticated ? <AppLayout /> : <Navigate to="/login" replace />}
         >
           <Route index element={<DashboardPage />} />
+          <Route path="inbox" element={<InboxPage />} />
           <Route path="channels" element={<ChannelsPage />} />
           <Route path="tasks" element={<TasksPage />} />
           <Route path="messages" element={<MessagesPage />} />

--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -27,6 +27,8 @@ import type {
   Plugin,
   Feedback,
   FeedbackSummary,
+  InboxData,
+  PlanStepComment,
 } from './types';
 
 // Auth
@@ -446,4 +448,28 @@ export function enablePlugin(name: string): Promise<{ ok: boolean }> {
 
 export function disablePlugin(name: string): Promise<{ ok: boolean }> {
   return apiPut<{ ok: boolean }>(`/plugins/${encodeURIComponent(name)}/disable`, {});
+}
+
+// Inbox
+
+export function fetchInbox(): Promise<InboxData> {
+  return apiGet<InboxData>('/inbox');
+}
+
+export function markInboxRead(): Promise<{ ok: boolean }> {
+  return apiPut<{ ok: boolean }>('/inbox/read', {});
+}
+
+// Plan Step Comments
+
+export function fetchPlanStepComments(planId: string, stepId: string): Promise<PlanStepComment[]> {
+  return apiGet<PlanStepComment[]>(`/plans/${planId}/steps/${stepId}/comments`);
+}
+
+export function addPlanStepComment(planId: string, stepId: string, content: string): Promise<PlanStepComment> {
+  return apiPost<PlanStepComment>(`/plans/${planId}/steps/${stepId}/comments`, { content });
+}
+
+export function deletePlanStepComment(planId: string, stepId: string, commentId: number): Promise<{ ok: boolean }> {
+  return apiDelete<{ ok: boolean }>(`/plans/${planId}/steps/${stepId}/comments/${commentId}`);
 }

--- a/studio-react/src/api/types.ts
+++ b/studio-react/src/api/types.ts
@@ -345,6 +345,34 @@ export interface FeedbackSummary {
   recent: Feedback[]
 }
 
+export interface InboxItem {
+  id: string;
+  kind: 'request' | 'directive' | 'mention' | 'approval' | 'step_comment' | 'bip_approval';
+  source_type: 'message' | 'approval' | 'plan_step_comment';
+  source_id: number;
+  title: string;
+  preview: string;
+  from: string;
+  created_at: string;
+  is_unread: boolean;
+  link: string;
+}
+
+export interface InboxData {
+  items: InboxItem[];
+  unread_count: number;
+  operator_id: string | null;
+  last_read_at: string | null;
+}
+
+export interface PlanStepComment {
+  id: number;
+  step_id: number;
+  author: string;
+  content: string;
+  created_at: string;
+}
+
 export interface Overview {
   agents: Agent[];
   events: Event[];
@@ -370,4 +398,5 @@ export interface Overview {
   drones: Agent[];
   drone_jobs: DroneJob[];
   plugins: Plugin[];
+  inbox_unread?: number;
 }

--- a/studio-react/src/components/plans/StepChecklist.tsx
+++ b/studio-react/src/components/plans/StepChecklist.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { PlanStep } from '../../api/types'
 import Badge from '../shared/Badge'
 import { getSenderDisplay } from '../../utils/sender'
+import StepCommentThread from './StepCommentThread'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -27,8 +28,7 @@ interface StepChecklistProps {
   onStepUpdate: (stepId: string, data: Partial<PlanStep>) => void
 }
 
-export default function StepChecklist({ steps, planId: _planId, onStepUpdate }: StepChecklistProps) {
-  void _planId
+export default function StepChecklist({ steps, planId, onStepUpdate }: StepChecklistProps) {
   const [expandedStep, setExpandedStep] = useState<string | null>(null)
   const [updatingStep, setUpdatingStep] = useState<string | null>(null)
 
@@ -205,6 +205,7 @@ export default function StepChecklist({ steps, planId: _planId, onStepUpdate }: 
                     )}
                   </div>
                 )}
+                <StepCommentThread planId={planId} stepId={step.id} />
               </div>
             )}
           </div>

--- a/studio-react/src/components/plans/StepCommentThread.tsx
+++ b/studio-react/src/components/plans/StepCommentThread.tsx
@@ -1,0 +1,97 @@
+import { useState, useEffect, useCallback } from 'react'
+import { fetchPlanStepComments, addPlanStepComment } from '../../api/endpoints'
+import { useAuthStore } from '../../stores/authStore'
+import { getSenderDisplay } from '../../utils/sender'
+import { timeAgo } from '../../utils/time'
+import type { PlanStepComment } from '../../api/types'
+
+interface StepCommentThreadProps {
+  planId: string
+  stepId: string
+}
+
+export default function StepCommentThread({ planId, stepId }: StepCommentThreadProps) {
+  const user = useAuthStore((s) => s.user)
+  const [comments, setComments] = useState<PlanStepComment[]>([])
+  const [loading, setLoading] = useState(true)
+  const [content, setContent] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchPlanStepComments(planId, stepId)
+      setComments(data)
+    } catch {
+      // silent
+    } finally {
+      setLoading(false)
+    }
+  }, [planId, stepId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!content.trim() || submitting) return
+    setSubmitting(true)
+    try {
+      await addPlanStepComment(planId, stepId, content.trim())
+      setContent('')
+      await load()
+    } catch {
+      // silent
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="mt-2 pt-2 border-t border-border/50">
+      <p className="text-xs text-text-muted font-medium mb-2">
+        Comments {comments.length > 0 && `(${comments.length})`}
+      </p>
+
+      {loading && comments.length === 0 && (
+        <p className="text-xs text-text-muted">Loading...</p>
+      )}
+
+      {comments.length > 0 && (
+        <div className="space-y-2 mb-2">
+          {comments.map((c) => (
+            <div key={c.id} className="text-xs">
+              <div className="flex items-center gap-1.5">
+                <span className="w-5 h-5 rounded-full bg-accent/20 text-accent text-[10px] font-bold flex items-center justify-center shrink-0">
+                  {(c.author || '?')[0].toUpperCase()}
+                </span>
+                <span className="text-text-dim font-medium">{getSenderDisplay(c.author)}</span>
+                <span className="text-text-muted">&middot;</span>
+                <span className="text-text-muted">{timeAgo(c.created_at)}</span>
+              </div>
+              <p className="text-text-dim ml-6.5 pl-[26px] whitespace-pre-wrap">{c.content}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Compose */}
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          type="text"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder={user ? `Comment as ${user.display_name}...` : 'Add a comment...'}
+          className="flex-1 bg-surface border border-border/50 rounded-sm px-2 py-1 text-xs text-text placeholder:text-text-muted focus:outline-none focus:border-accent/50"
+        />
+        <button
+          type="submit"
+          disabled={!content.trim() || submitting}
+          className="px-3 py-1 rounded-sm bg-accent/15 text-accent text-xs font-medium hover:bg-accent/25 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? '...' : 'Send'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/studio-react/src/layouts/AppLayout.tsx
+++ b/studio-react/src/layouts/AppLayout.tsx
@@ -11,6 +11,7 @@ import { useMediaQuery } from '../hooks/useMediaQuery'
 
 const routeTitles: Record<string, string> = {
   '/': 'Dashboard',
+  '/inbox': 'Inbox',
   '/channels': 'Channels',
   '/tasks': 'Tasks',
   '/messages': 'Agent Comms',

--- a/studio-react/src/layouts/SideNav.tsx
+++ b/studio-react/src/layouts/SideNav.tsx
@@ -4,7 +4,7 @@ import { useDashboardStore } from '../stores/dashboardStore'
 import { useVoiceStore } from '../stores/voiceStore'
 import {
   LayoutDashboard, CheckSquare, Map, Bug,
-  MessageSquare, Radio, ShieldCheck,
+  MessageSquare, Radio, ShieldCheck, Inbox,
   Users, Cpu, FolderOpen, Lightbulb, Database,
   Settings, Activity, Webhook, Puzzle, BarChart3, Rocket, MessageCircle,
   ChevronRight, PanelLeftClose, PanelLeftOpen, X,
@@ -49,6 +49,7 @@ const navSections: NavSection[] = [
     id: 'communicate',
     label: 'Communicate',
     items: [
+      { to: '/inbox', label: 'Inbox', icon: Inbox },
       { to: '/channels', label: 'Channels', icon: MessageSquare },
       { to: '/messages', label: 'Agent Comms', icon: Radio },
       { to: '/approvals', label: 'Approvals', icon: ShieldCheck },
@@ -114,6 +115,7 @@ export default function SideNav({ mobileOpen, onMobileClose, isMobile }: SideNav
   const [collapsed, setCollapsed] = useState(loadSidebarCollapsed)
   const [collapsedSections, setCollapsedSections] = useState(loadCollapsedSections)
   const agents = useDashboardStore((s) => s.agents)
+  const inboxUnread = useDashboardStore((s) => s.inboxUnread)
   const voiceConnected = useVoiceStore((s) => s.isConnected)
   const voiceChannel = useVoiceStore((s) => s.channelName)
   const voicePeers = useVoiceStore((s) => s.peers)
@@ -229,6 +231,11 @@ export default function SideNav({ mobileOpen, onMobileClose, isMobile }: SideNav
                     >
                       <item.icon size={16} strokeWidth={1.5} className="shrink-0" />
                       {!isNarrow && <span className="truncate">{item.label}</span>}
+                      {item.to === '/inbox' && inboxUnread > 0 && (
+                        <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-accent/20 text-accent text-[10px] font-bold tabular-nums ml-auto shrink-0">
+                          {inboxUnread}
+                        </span>
+                      )}
                     </NavLink>
                   ))}
                 </div>

--- a/studio-react/src/pages/InboxPage.tsx
+++ b/studio-react/src/pages/InboxPage.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { fetchInbox, markInboxRead } from '../api/endpoints'
+import { getSenderDisplay } from '../utils/sender'
+import { timeAgo } from '../utils/time'
+import Badge from '../components/shared/Badge'
+import type { InboxItem } from '../api/types'
+
+type FilterTab = 'all' | 'requests' | 'mentions' | 'approvals'
+
+const TABS: { key: FilterTab; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'requests', label: 'Requests' },
+  { key: 'mentions', label: 'Mentions' },
+  { key: 'approvals', label: 'Approvals' },
+]
+
+const kindConfig: Record<string, { variant: 'accent' | 'blue' | 'red' | 'green' | 'purple'; label: string }> = {
+  request: { variant: 'accent', label: 'request' },
+  directive: { variant: 'red', label: 'directive' },
+  mention: { variant: 'blue', label: 'mention' },
+  approval: { variant: 'red', label: 'approval' },
+  step_comment: { variant: 'green', label: 'comment' },
+  bip_approval: { variant: 'purple', label: 'BIP draft' },
+}
+
+function filterMatch(item: InboxItem, tab: FilterTab): boolean {
+  if (tab === 'all') return true
+  if (tab === 'requests') return item.kind === 'request' || item.kind === 'directive'
+  if (tab === 'mentions') return item.kind === 'mention'
+  if (tab === 'approvals') return item.kind === 'approval' || item.kind === 'bip_approval'
+  return true
+}
+
+export default function InboxPage() {
+  const navigate = useNavigate()
+  const [items, setItems] = useState<InboxItem[]>([])
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [filter, setFilter] = useState<FilterTab>('all')
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchInbox()
+      setItems(data.items)
+      setUnreadCount(data.unread_count)
+    } catch {
+      // silently fail — next poll will retry
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Mark as read on mount, then load
+  useEffect(() => {
+    markInboxRead().catch(() => {})
+    load()
+    const interval = setInterval(load, 10_000)
+    return () => clearInterval(interval)
+  }, [load])
+
+  const filtered = useMemo(
+    () => items.filter((item) => filterMatch(item, filter)),
+    [items, filter],
+  )
+
+  if (loading && items.length === 0) {
+    return (
+      <div className="space-y-6">
+        <h2 className="text-xl font-semibold text-text">Inbox</h2>
+        <div className="bg-surface rounded-lg p-8 text-center">
+          <p className="text-text-muted text-sm">Loading...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <h2 className="text-xl font-semibold text-text">Inbox</h2>
+        {unreadCount > 0 && (
+          <span className="inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 rounded-full bg-accent/15 text-accent text-xs font-bold tabular-nums">
+            {unreadCount}
+          </span>
+        )}
+      </div>
+
+      {/* Filter tabs */}
+      <div className="flex items-center gap-1 bg-surface rounded-sm p-1">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setFilter(tab.key)}
+            className={`px-4 py-1.5 rounded-sm text-sm font-medium transition-colors ${
+              filter === tab.key
+                ? 'bg-surface-raised text-text'
+                : 'text-text-muted hover:text-text-dim'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Items */}
+      {filtered.length === 0 ? (
+        <div className="bg-surface rounded-lg p-8 text-center">
+          <p className="text-text-muted text-sm">
+            {filter === 'all' ? 'Inbox is empty' : `No ${filter} items`}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((item) => {
+            const config = kindConfig[item.kind] ?? kindConfig.request
+            return (
+              <button
+                key={item.id}
+                onClick={() => navigate(item.link)}
+                className="w-full text-left bg-surface-raised rounded-lg p-4 hover:bg-surface-raised/80 transition-colors flex items-start gap-3"
+              >
+                {/* Unread dot */}
+                <div className="mt-1.5 shrink-0">
+                  {item.is_unread ? (
+                    <div className="w-2 h-2 rounded-full bg-accent" />
+                  ) : (
+                    <div className="w-2 h-2" />
+                  )}
+                </div>
+
+                {/* Content */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 mb-1">
+                    <Badge variant={config.variant}>{config.label}</Badge>
+                    <span className="text-sm font-medium text-text truncate">
+                      {item.title}
+                    </span>
+                  </div>
+                  <p className="text-xs text-text-muted truncate">{item.preview}</p>
+                  <div className="flex items-center gap-2 mt-1.5 text-xs text-text-muted">
+                    <span>{getSenderDisplay(item.from)}</span>
+                    <span>&middot;</span>
+                    <span>{timeAgo(item.created_at)}</span>
+                  </div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/studio-react/src/stores/authStore.ts
+++ b/studio-react/src/stores/authStore.ts
@@ -9,6 +9,7 @@ interface User {
   username: string;
   display_name: string;
   role: string;
+  operator_id: string | null;
 }
 
 interface AuthState {

--- a/studio-react/src/stores/dashboardStore.ts
+++ b/studio-react/src/stores/dashboardStore.ts
@@ -46,6 +46,7 @@ interface DashboardState {
   drones: Agent[];
   droneJobs: DroneJob[];
   plugins: Plugin[];
+  inboxUnread: number;
 
   // UI state
   loading: boolean;
@@ -82,6 +83,7 @@ export const useDashboardStore = create<DashboardState>()((set) => ({
   drones: [],
   droneJobs: [],
   plugins: [],
+  inboxUnread: 0,
 
   // UI state defaults
   loading: false,
@@ -117,6 +119,7 @@ export const useDashboardStore = create<DashboardState>()((set) => ({
         drones: data.drones || [],
         droneJobs: data.drone_jobs || [],
         plugins: data.plugins || [],
+        inboxUnread: data.inbox_unread || 0,
         loading: false,
         lastRefresh: new Date(),
       });


### PR DESCRIPTION
## Summary
- New **Operator Inbox** page — human-facing message layer separate from agent traffic
- Aggregates pending approvals, agent requests/directives, @mentions into unified view
- **Plan step comments** — threaded comments on plan steps (like task comments)
- Unread badge on Inbox nav item, mark-as-read on page visit
- operator_id injected into JWT at login for inbox routing

## Changes (13 files, 564 insertions)

**Backend:**
- `server/schema.sql` — 2 new tables: `dv_plan_step_comments`, `dv_inbox_reads`
- `server/db.js` — 8 new functions (inbox aggregation, plan step comments, operator lookup)
- `server/routes/mycelium.js` — 6 new routes (inbox CRUD, plan step comments), login operator_id injection, overview inbox_unread

**Frontend:**
- `InboxPage.tsx` — new page with filter tabs (All/Requests/Mentions/Approvals)
- `StepCommentThread.tsx` — new component for plan step comments
- `StepChecklist.tsx` — integrates comment thread into step expansion
- `SideNav.tsx` — Inbox nav item with unread badge
- Stores, types, endpoints, routing all wired up

## Test plan
- [ ] Server starts, new tables auto-created
- [ ] Login response includes `operator_id`
- [ ] `GET /inbox` returns aggregated items for the logged-in operator
- [ ] `PUT /inbox/read` clears unread count
- [ ] Plan step comment CRUD works via API
- [ ] Dashboard shows Inbox in nav with badge count
- [ ] InboxPage renders and filters correctly
- [ ] Plan step expansion shows comment thread
- [ ] `npx vite build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)