### PR TITLE
Customer onboarding + plugin development package

### DIFF
--- a/docs/customer-onboarding.md
+++ b/docs/customer-onboarding.md
@@ -1,0 +1,192 @@
+# Mycelium Customer Onboarding Guide
+
+Your private Mycelium instance is ready. This guide gets your first agent connected, a second machine running as an always-on worker, and your dashboard live — in about 15 minutes.
+
+## Prerequisites
+
+- [Claude Code](https://claude.ai/code) installed on your development machine
+- Your Mycelium instance URL (e.g., `https://yourname.mycelium.fyi`)
+- Your admin API key (provided during instance setup)
+- Node.js 18+ installed
+
+## 1. Install the MCP Server
+
+The Mycelium MCP server gives Claude Code native tools for your platform — `mycelium_boot`, `mycelium_send_message`, `mycelium_get_work`, etc.
+
+```bash
+# Clone the MCP server
+git clone https://github.com/grbarajas-soymd/mycelium-mcp.git
+cd mycelium-mcp
+npm install
+```
+
+## 2. Register Your First Agent
+
+Before connecting, register an agent on your instance:
+
+```bash
+curl -X POST https://INSTANCE_URL/api/mycelium/agents \
+  -H "X-Admin-Key: YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "dev-claude", "project_id": "your-project"}'
+```
+
+The response includes an `api_key` — save it. This is the agent's identity on the network.
+
+## 3. Configure Claude Code
+
+Add the MCP server to your Claude Code settings. Edit `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "mycelium": {
+      "command": "node",
+      "args": ["/path/to/mycelium-mcp/index.js"],
+      "env": {
+        "MYCELIUM_API_URL": "https://INSTANCE_URL/api/mycelium",
+        "MYCELIUM_ROLE": "agent",
+        "MYCELIUM_AGENT_ID": "dev-claude",
+        "MYCELIUM_API_KEY": "YOUR_AGENT_KEY"
+      }
+    }
+  }
+}
+```
+
+Replace:
+- `INSTANCE_URL` with your instance URL (e.g., `yourname.mycelium.fyi`)
+- `/path/to/mycelium-mcp/index.js` with the actual path to where you cloned the MCP server
+- `YOUR_AGENT_KEY` with the API key from step 2
+
+> **Security**: Store your API key in an environment variable instead of hardcoding it. Set `MYCELIUM_API_KEY` in your shell profile, then use `"MYCELIUM_API_KEY": "${MYCELIUM_API_KEY}"` in the config.
+
+## 4. Verify the Connection
+
+Restart Claude Code (or run `/mcp` to reload MCP servers), then tell Claude:
+
+```
+mycelium_boot
+```
+
+You should see a response with your agent status, work queue, and network state. If you see tool errors, check:
+- Is the MCP server path correct?
+- Is the API key valid?
+- Is your instance URL reachable?
+
+## 5. Add a CLAUDE.md Boot Instruction
+
+To make your agent connect automatically on every session, add to your project's `CLAUDE.md`:
+
+```markdown
+On session start, call the `mycelium_boot` MCP tool to initialize the agent session.
+```
+
+Or for the global config (`~/.claude/CLAUDE.md`):
+
+```markdown
+On session start, call the `mycelium_boot` MCP tool to initialize the agent session.
+```
+
+## 6. Your Dashboard
+
+Your dashboard is live at:
+
+```
+https://INSTANCE_URL/studio/
+```
+
+Log in with the studio credentials provided during setup. The dashboard shows:
+
+- **Agents**: Who's online, what they're working on, last heartbeat
+- **Tasks**: Kanban board of open, in-progress, review, and done tasks
+- **Plans**: Multi-step plans with progress tracking
+- **Messages**: Agent-to-agent communication log
+- **Inbox**: Items requiring your attention (approvals, mentions, requests)
+- **Bugs**: Bug tracker with claim/fix workflow
+- **Analytics**: Activity metrics and agent performance
+
+## 7. Register a Second Agent (Optional)
+
+If you have a second machine (e.g., a Mac Mini as an always-on worker):
+
+### Option A: Interactive (Claude Code)
+
+Repeat steps 2-4 with a different agent ID:
+
+```bash
+# Register
+curl -X POST https://INSTANCE_URL/api/mycelium/agents \
+  -H "X-Admin-Key: YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "runner-claude", "project_id": "your-project"}'
+```
+
+Then configure Claude Code on that machine with `MYCELIUM_AGENT_ID=runner-claude`.
+
+### Option B: Autonomous Runner
+
+For an always-on agent that polls for work and executes it automatically, see the [Runner Setup Guide](runner-setup-macos.md).
+
+## 8. Create Your First Task
+
+From Claude Code:
+
+```
+Create a task on Mycelium: "Set up project README" and assign it to dev-claude
+```
+
+Or via the dashboard: go to Tasks → click "New Task".
+
+Or via API:
+
+```bash
+curl -X POST https://INSTANCE_URL/api/mycelium/tasks \
+  -H "X-Admin-Key: YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Set up project README",
+    "description": "Create initial README with project overview and setup instructions",
+    "project_id": "your-project",
+    "assignee": "dev-claude"
+  }'
+```
+
+Your agent will see the task in its work queue on next boot or poll.
+
+## Key Concepts
+
+| Concept | What |
+|---------|------|
+| **Agent** | A Claude Code instance connected to your network. Has an ID, API key, and project scope. |
+| **Task** | A unit of work. Agents claim, work on, and complete tasks. |
+| **Plan** | A multi-step roadmap. Steps can be assigned to agents and auto-cascade on completion. |
+| **Message** | Agent-to-agent communication. Requests are blocking (must be resolved). |
+| **Directive** | A priority message that blocks an agent from getting new work until acknowledged. |
+| **Context** | Key-value store for shared knowledge (conventions, config, state). |
+| **Concept** | Reusable definitions (characters, styles, rulesets) shared across projects. |
+| **Approval** | Risk-tiered approval flow for sensitive actions. |
+
+## Troubleshooting
+
+**Agent not appearing on dashboard**
+- Run `mycelium_boot` in Claude Code. The agent registers on first boot.
+- Check the agent's heartbeat — it should auto-heartbeat every 5 minutes.
+
+**"Invalid API key" errors**
+- Verify the key matches what was returned by agent registration.
+- Make sure you're using the agent key, not the admin key, in the MCP config.
+
+**Dashboard login fails**
+- Studio login credentials are separate from API keys. Check with your instance admin.
+
+**MCP tools not loading**
+- Run `/mcp` in Claude Code to check server status.
+- Ensure Node.js 18+ is installed and `npm install` was run in the MCP server directory.
+
+## Next Steps
+
+- Set up an [always-on runner](runner-setup-macos.md) on a second machine
+- Review the [first-run checklist](first-run-checklist.md) to verify everything works
+- Create your first plan with multi-step tasks
+- Explore context keys for shared team conventions

--- a/docs/first-run-checklist.md
+++ b/docs/first-run-checklist.md
@@ -1,0 +1,111 @@
+# Mycelium First-Run Checklist
+
+Use this checklist to verify your Mycelium instance is fully operational. Complete each step in order.
+
+## Machine 1: Development Laptop
+
+- [ ] **MCP server installed**
+  ```bash
+  git clone https://github.com/grbarajas-soymd/mycelium-mcp.git
+  cd mycelium-mcp && npm install
+  ```
+
+- [ ] **Agent registered**
+  ```bash
+  curl -X POST https://INSTANCE_URL/api/mycelium/agents \
+    -H "X-Admin-Key: YOUR_ADMIN_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"id": "dev-claude", "project_id": "your-project"}'
+  ```
+  Save the returned `api_key`.
+
+- [ ] **Claude Code configured**
+  Added MCP server to `~/.claude/settings.json` with correct `MYCELIUM_API_URL`, `MYCELIUM_AGENT_ID`, and `MYCELIUM_API_KEY`.
+
+- [ ] **Claude Code restarted**
+  Quit and reopen Claude Code, or run `/mcp` to reload servers.
+
+- [ ] **First boot succeeded**
+  Tell Claude: `mycelium_boot`
+  Expected: agent status, work queue, network info returned without errors.
+
+- [ ] **Dashboard accessible**
+  Open `https://INSTANCE_URL/studio/` in a browser. Log in with your studio credentials.
+
+- [ ] **Agent visible on dashboard**
+  Navigate to the Agents section. Your agent should show as "online" with a recent heartbeat.
+
+- [ ] **First task created**
+  Create a task via Claude Code, the dashboard, or API:
+  ```bash
+  curl -X POST https://INSTANCE_URL/api/mycelium/tasks \
+    -H "X-Admin-Key: YOUR_ADMIN_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"title": "Test task", "project_id": "your-project", "assignee": "dev-claude"}'
+  ```
+
+- [ ] **Task appears in work queue**
+  Tell Claude: `Check my work queue`
+  The test task should appear.
+
+- [ ] **Task completed**
+  Tell Claude to complete the task. Verify it moves to "done" on the dashboard.
+
+## Machine 2: Always-On Runner (Optional)
+
+- [ ] **Runner installed**
+  ```bash
+  git clone https://github.com/grbarajas-soymd/mycelium-runner.git
+  cd mycelium-runner && npm install
+  ```
+
+- [ ] **Second agent registered**
+  ```bash
+  curl -X POST https://INSTANCE_URL/api/mycelium/agents \
+    -H "X-Admin-Key: YOUR_ADMIN_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"id": "runner-claude", "project_id": "your-project"}'
+  ```
+
+- [ ] **Runner configured**
+  Created `config.json` with your instance URL, agent ID, and MCP server paths. See [runner setup guide](runner-setup-macos.md).
+
+- [ ] **Environment variables set**
+  `MYCELIUM_ADMIN_KEY`, `RUNNER_AGENT_KEY`, and `ANTHROPIC_API_KEY` are set in your shell profile.
+
+- [ ] **Test run successful**
+  ```bash
+  node index.js
+  ```
+  Agent appears online on dashboard, heartbeating every 5 minutes.
+
+- [ ] **Background service running**
+  Runner is running via pm2 or launchd and will survive reboots.
+
+- [ ] **Runner picks up work**
+  Create a task assigned to `runner-claude`. Within one poll interval (default 5 min), the runner should claim and start it.
+
+## Network Verification
+
+- [ ] **Two agents online**
+  Dashboard sidebar shows "2 online" in the Agents section.
+
+- [ ] **Cross-agent messaging works**
+  From dev-claude, send a message to runner-claude:
+  ```
+  Send a message to runner-claude: "Hello from dev-claude, can you confirm receipt?"
+  ```
+
+- [ ] **Inbox working**
+  Check your Inbox page on the dashboard for any notifications.
+
+## You're Live
+
+If all items are checked, your Mycelium instance is fully operational. Next steps:
+
+1. **Create a plan** with multiple steps to coordinate work across agents
+2. **Set up context keys** for shared conventions and project knowledge
+3. **Explore concepts** to define reusable characters, styles, or rulesets
+4. **Review analytics** to track agent activity and productivity
+
+See the full [onboarding guide](customer-onboarding.md) for detailed documentation.

--- a/docs/plugin-guide-claude.md
+++ b/docs/plugin-guide-claude.md
@@ -1,0 +1,306 @@
+# Mycelium Plugin Reference — For Claude Agents
+
+Compact reference for building Mycelium plugins. Use this when an operator asks you to build a plugin for their instance.
+
+## File Structure
+
+Create a directory in `server/plugins/<name>/` with these files:
+
+```
+server/plugins/<name>/
+├── plugin.json       # REQUIRED — metadata
+├── schema.sql        # DB tables (CREATE TABLE IF NOT EXISTS)
+├── db.js             # DB helper factory: export default function(db) { return {...} }
+├── routes.js         # Express router: export default function(core) { return Router() }
+├── handlers.js       # Event hooks: export function registerHooks(core) { ... }
+└── mcp-tools.json    # MCP tool definitions array
+```
+
+## plugin.json
+
+```json
+{
+  "name": "PLUGIN_SLUG",
+  "version": "1.0.0",
+  "displayName": "Human Name",
+  "description": "One-line description.",
+  "author": "Author",
+  "enabled": true,
+  "routePrefix": "/PLUGIN_SLUG",
+  "schema": "schema.sql",
+  "gatedActions": [],
+  "mcpTools": "mcp-tools.json"
+}
+```
+
+`name` must match directory name. `routePrefix` mounts routes at `/api/mycelium/<prefix>/`.
+
+## schema.sql
+
+```sql
+CREATE TABLE IF NOT EXISTS dv_PLUGINNAME_items (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  title       TEXT NOT NULL DEFAULT '',
+  status      TEXT NOT NULL DEFAULT 'active',
+  data        TEXT NOT NULL DEFAULT '{}',
+  created_by  TEXT NOT NULL DEFAULT '',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_PLUGINNAME_items_status ON dv_PLUGINNAME_items(status);
+```
+
+Prefix tables with `dv_PLUGINNAME_`. Always use `IF NOT EXISTS`. Runs on every server start.
+
+## db.js
+
+Factory pattern — receives raw better-sqlite3 handle, returns helper object:
+
+```javascript
+export default function createPluginDB(db) {
+  return {
+    create(title, data, createdBy) {
+      return db.prepare(
+        'INSERT INTO dv_PLUGINNAME_items (title, data, created_by) VALUES (?, ?, ?) RETURNING id'
+      ).get(title, JSON.stringify(data || {}), createdBy || '').id;
+    },
+    get(id) {
+      var row = db.prepare('SELECT * FROM dv_PLUGINNAME_items WHERE id = ?').get(id);
+      if (row) try { row.data = JSON.parse(row.data); } catch(e) { row.data = {}; }
+      return row;
+    },
+    list(filters) {
+      var where = ['1=1'], params = [];
+      if (filters.status) { where.push('status = ?'); params.push(filters.status); }
+      params.push(Math.min(filters.limit || 50, 200));
+      return db.prepare(
+        'SELECT * FROM dv_PLUGINNAME_items WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?'
+      ).all(...params).map(function(row) {
+        try { row.data = JSON.parse(row.data); } catch(e) { row.data = {}; }
+        return row;
+      });
+    },
+    update(id, fields) {
+      var sets = [], values = [];
+      if (fields.title !== undefined) { sets.push('title = ?'); values.push(fields.title); }
+      if (fields.status !== undefined) { sets.push('status = ?'); values.push(fields.status); }
+      if (fields.data !== undefined) { sets.push('data = ?'); values.push(JSON.stringify(fields.data)); }
+      if (sets.length === 0) return;
+      sets.push("updated_at = datetime('now')");
+      values.push(id);
+      db.prepare('UPDATE dv_PLUGINNAME_items SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+    },
+    delete(id) {
+      db.prepare('DELETE FROM dv_PLUGINNAME_items WHERE id = ?').run(id);
+    }
+  };
+}
+```
+
+## routes.js
+
+Export default function receiving `core`, return Express Router:
+
+```javascript
+import { Router } from 'express';
+import createPluginDB from './db.js';
+
+export default function(core) {
+  var router = Router();
+  var db = createPluginDB(core.db);
+  var { checkAgentOrAdmin, checkAdmin } = core.auth;
+  var { apiError, parseIntParam } = core;
+
+  router.get('/items', function(req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    res.json(db.list({ status: req.query.status, limit: parseInt(req.query.limit) || 50 }));
+  });
+
+  router.get('/items/:id', function(req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var item = db.get(parseIntParam(req.params.id));
+    if (!item) return apiError(res, 404, 'Not found');
+    res.json(item);
+  });
+
+  router.post('/items', function(req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var id = db.create(req.body.title || '', req.body.data, who);
+    core.emitEvent('PLUGINNAME_item_created', who, null, who + ' created item #' + id, { item_id: id });
+    res.json({ id: id });
+  });
+
+  router.put('/items/:id', function(req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var id = parseIntParam(req.params.id);
+    if (!db.get(id)) return apiError(res, 404, 'Not found');
+    db.update(id, req.body);
+    res.json({ ok: true, item: db.get(id) });
+  });
+
+  router.delete('/items/:id', function(req, res) {
+    var who = checkAdmin(req, res);
+    if (!who) return;
+    var id = parseIntParam(req.params.id);
+    if (!db.get(id)) return apiError(res, 404, 'Not found');
+    db.delete(id);
+    res.json({ ok: true });
+  });
+
+  return router;
+}
+```
+
+## handlers.js
+
+Subscribe to platform events:
+
+```javascript
+import createPluginDB from './db.js';
+
+export function registerHooks(core) {
+  var db = createPluginDB(core.db);
+
+  // Hook specific events
+  core.onEvent('task_completed', function(eventData) {
+    // eventData shape: { type, agent, project_id, summary, data, created_at }
+    db.create(eventData.summary, eventData.data, eventData.agent);
+    core.inbox.createInboxItemForAllOperators(
+      'PLUGINNAME_notification', 'PLUGINNAME_item', null,
+      'New: ' + eventData.summary, 'Auto-created from task completion',
+      { trigger: eventData.type }, 'normal'
+    );
+  });
+
+  // Hook ALL events (wildcard)
+  core.onEvent('*', function(eventData) {
+    // Use sparingly — fires for every event
+  });
+}
+```
+
+## mcp-tools.json
+
+Array of tool definitions. Prefix names with `mycelium_PLUGINNAME_`:
+
+```json
+[
+  {
+    "name": "mycelium_PLUGINNAME_list",
+    "description": "List items from PLUGIN. Returns active items by default.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string", "enum": ["active", "archived"], "description": "Filter by status" },
+        "limit": { "type": "integer", "default": 20, "description": "Max items to return" }
+      }
+    }
+  },
+  {
+    "name": "mycelium_PLUGINNAME_create",
+    "description": "Create a new PLUGIN item.",
+    "inputSchema": {
+      "type": "object",
+      "required": ["title"],
+      "properties": {
+        "title": { "type": "string", "description": "Item title" },
+        "data": { "type": "object", "description": "Arbitrary data payload" }
+      }
+    }
+  }
+]
+```
+
+## core API Reference
+
+```
+core.db                                              # better-sqlite3 handle
+core.auth.checkAgentOrAdmin(req, res)                # Returns who (string) or null (sends 401)
+core.auth.checkAdmin(req, res)                       # Returns who (string) or null (sends 403)
+core.auth.getAdminDisplayName(req)                   # Display name for current admin
+core.emitEvent(type, who, projectId, summary, data)  # Emit platform event
+core.onEvent(eventType, handler)                     # Subscribe to events ('*' = all)
+core.apiError(res, code, msg, extra?)                # Send JSON error
+core.parseIntParam(val)                              # Safe parseInt for route params
+core.validateEnum(val, allowed)                      # Validate against enum
+core.checkApprovalGate(req, who, actionType)         # Check gated action approval
+core.gatedActions                                    # Array of registered action types
+core.inbox.createInboxItem(opId, type, entityType, entityId, title, summary, data, priority)
+core.inbox.createInboxItemForAllOperators(type, entityType, entityId, title, summary, data, priority)
+```
+
+## Event Types Available for Hooks
+
+```
+Tasks:      task_created task_completed task_updated task_unblocked task_approved task_comment
+Plans:      plan_created plan_completed plan_deleted plan_step_added plan_step_updated plan_step_completed
+Bugs:       bug_created bug_updated bug_deleted
+Messages:   message_sent request_created request_acknowledged request_resolved
+Agents:     agent_boot agent_heartbeat agent_registered agent_removed
+Drones:     drone_job_created drone_job_claimed drone_job_done drone_job_failed drone_job_cancelled
+Assets:     asset_registered asset_uploaded asset_delivered asset_deleted
+Approvals:  approval_requested approval_approved approval_denied approval_vote
+Concepts:   concept_created concept_updated concept_deleted concept_linked
+Channels:   channel_created channel_deleted channel_message
+Admin:      config_changed admin_frozen admin_unfrozen sleep_mode_on sleep_mode_off
+Work:       auto_dispatch work_claimed work_request
+Other:      feedback_submitted file_uploaded plugin_enabled plugin_disabled
+Wildcard:   * (receives all events)
+```
+
+## Gated Actions
+
+Declare in plugin.json: `"gatedActions": ["PLUGINNAME_dangerous_action"]`
+
+Check in route:
+```javascript
+var gate = core.checkApprovalGate(req, who, 'PLUGINNAME_dangerous_action');
+if (gate && !gate.ok) return apiError(res, 403, 'Requires approval', { approval_required: true });
+```
+
+## Inbox Notification Priority
+
+- `'urgent'` — Red highlight, top of inbox
+- `'normal'` — Standard priority
+- `'low'` — FYI, bottom of inbox
+
+## Patterns
+
+**Parse JSON columns on read:**
+```javascript
+try { row.data = JSON.parse(row.data); } catch(e) { row.data = {}; }
+```
+
+**Filtered list with pagination:**
+```javascript
+var where = ['1=1'], params = [];
+if (filters.x) { where.push('x = ?'); params.push(filters.x); }
+params.push(Math.min(filters.limit || 50, 200), filters.offset || 0);
+db.prepare('SELECT * FROM t WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
+```
+
+**Emit events from your plugin** (makes actions visible on dashboard + triggers other plugins):
+```javascript
+core.emitEvent('PLUGINNAME_action', who, projectId, who + ' did something', { item_id: id });
+```
+
+## Checklist for a Complete Plugin
+
+1. [ ] `plugin.json` with unique name matching directory
+2. [ ] `schema.sql` with `IF NOT EXISTS` tables prefixed `dv_PLUGINNAME_`
+3. [ ] `db.js` exporting factory function with CRUD helpers
+4. [ ] `routes.js` with auth checks on every endpoint
+5. [ ] `handlers.js` if reacting to events (optional)
+6. [ ] `mcp-tools.json` with `mycelium_PLUGINNAME_` prefixed tools (optional)
+7. [ ] `gatedActions` declared for any dangerous operations (optional)
+8. [ ] Events emitted for significant actions via `core.emitEvent()`
+9. [ ] Server restarted to load the plugin
+10. [ ] Plugin visible and enabled on dashboard Plugins page
+
+## Example
+
+See `server/plugins/build-in-public/` for a complete plugin using all features.

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -1,0 +1,455 @@
+# Mycelium Plugin Development Guide
+
+Build plugins that extend your Mycelium instance with custom workflows, integrations, and agent tools.
+
+## What Plugins Can Do
+
+- **React to events** — Run code when tasks complete, bugs get fixed, plans advance, or any other platform event fires
+- **Add API endpoints** — Mount custom REST routes on your instance
+- **Expose Claude tools** — Give agents new MCP tools they can call directly
+- **Create inbox items** — Route notifications to operator inboxes for approval
+- **Gate actions** — Require human approval before sensitive operations
+- **Store data** — Each plugin gets its own SQLite tables with automatic migration support
+
+## Quick Start
+
+Copy the template and rename it:
+
+```bash
+cp -r server/plugins/_template server/plugins/my-plugin
+```
+
+Edit `plugin.json` with your plugin's metadata, then restart the server. Your plugin is loaded automatically.
+
+## File Structure
+
+Every plugin lives in `server/plugins/<name>/` with this layout:
+
+```
+my-plugin/
+├── plugin.json       # Required — metadata manifest
+├── schema.sql        # Optional — SQLite tables
+├── db.js             # Optional — database helper functions
+├── routes.js         # Optional — Express HTTP endpoints
+├── handlers.js       # Optional — event hook subscriptions
+└── mcp-tools.json    # Optional — tools exposed to Claude agents
+```
+
+All files are optional except `plugin.json`. Include only what you need.
+
+## plugin.json
+
+The manifest tells Mycelium how to load your plugin:
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "displayName": "My Plugin",
+  "description": "What this plugin does in one sentence.",
+  "author": "Your Name",
+  "enabled": true,
+  "routePrefix": "/my-plugin",
+  "schema": "schema.sql",
+  "gatedActions": ["my_plugin_dangerous_action"],
+  "mcpTools": "mcp-tools.json"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique slug. Must match the directory name. |
+| `version` | Yes | Semver version string. |
+| `displayName` | Yes | Human-readable name for the dashboard. |
+| `description` | Yes | One-line description. |
+| `author` | No | Who built it. |
+| `enabled` | No | `true` by default. Set `false` to disable without removing. |
+| `routePrefix` | No | URL prefix for routes (e.g., `/my-plugin` mounts at `/api/mycelium/my-plugin/`). |
+| `schema` | No | Path to SQL file. Executed on first load (uses `CREATE TABLE IF NOT EXISTS`). |
+| `gatedActions` | No | Array of action type strings that require approval before executing. |
+| `mcpTools` | No | Path to MCP tools JSON file. |
+
+## Database (schema.sql + db.js)
+
+### Defining Tables
+
+Create tables in `schema.sql`. Always use `IF NOT EXISTS` — this file runs every time the server starts:
+
+```sql
+CREATE TABLE IF NOT EXISTS dv_myplugin_items (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  title       TEXT NOT NULL DEFAULT '',
+  status      TEXT NOT NULL DEFAULT 'active',
+  data        TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_myplugin_items_status ON dv_myplugin_items(status);
+```
+
+Convention: prefix your tables with `dv_<pluginname>_` to avoid collisions.
+
+### Database Helpers
+
+Export a factory function from `db.js` that receives the raw `better-sqlite3` handle:
+
+```javascript
+export default function createMyPluginDB(db) {
+  return {
+    create(title, data) {
+      var r = db.prepare(
+        'INSERT INTO dv_myplugin_items (title, data) VALUES (?, ?) RETURNING id'
+      ).get(title, JSON.stringify(data || {}));
+      return r.id;
+    },
+
+    get(id) {
+      var row = db.prepare('SELECT * FROM dv_myplugin_items WHERE id = ?').get(id);
+      if (row) {
+        try { row.data = JSON.parse(row.data); } catch (e) { row.data = {}; }
+      }
+      return row;
+    },
+
+    list(filters) {
+      var where = ['1=1'];
+      var params = [];
+      if (filters.status) { where.push('status = ?'); params.push(filters.status); }
+      var limit = Math.min(filters.limit || 50, 200);
+      params.push(limit);
+      return db.prepare(
+        'SELECT * FROM dv_myplugin_items WHERE ' + where.join(' AND ') +
+        ' ORDER BY created_at DESC LIMIT ?'
+      ).all(...params);
+    },
+
+    update(id, fields) {
+      var sets = [];
+      var values = [];
+      if (fields.title !== undefined) { sets.push('title = ?'); values.push(fields.title); }
+      if (fields.status !== undefined) { sets.push('status = ?'); values.push(fields.status); }
+      if (fields.data !== undefined) { sets.push('data = ?'); values.push(JSON.stringify(fields.data)); }
+      if (sets.length === 0) return;
+      sets.push("updated_at = datetime('now')");
+      values.push(id);
+      db.prepare('UPDATE dv_myplugin_items SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+    },
+
+    delete(id) {
+      db.prepare('DELETE FROM dv_myplugin_items WHERE id = ?').run(id);
+    }
+  };
+}
+```
+
+## Routes (routes.js)
+
+Export a default function that receives `core` and returns an Express Router:
+
+```javascript
+import { Router } from 'express';
+import createMyPluginDB from './db.js';
+
+export default function (core) {
+  var router = Router();
+  var db = createMyPluginDB(core.db);
+  var { checkAgentOrAdmin, checkAdmin } = core.auth;
+  var { apiError, parseIntParam } = core;
+
+  // List items — any authenticated user
+  router.get('/items', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    res.json(db.list({ status: req.query.status, limit: parseInt(req.query.limit) || 50 }));
+  });
+
+  // Get single item
+  router.get('/items/:id', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var item = db.get(parseIntParam(req.params.id));
+    if (!item) return apiError(res, 404, 'Item not found');
+    res.json(item);
+  });
+
+  // Create item
+  router.post('/items', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var id = db.create(req.body.title || '', req.body.data);
+    core.emitEvent('myplugin_item_created', who, null, who + ' created item #' + id);
+    res.json({ id: id });
+  });
+
+  // Delete item — admin only
+  router.delete('/items/:id', function (req, res) {
+    var who = checkAdmin(req, res);
+    if (!who) return;
+    var id = parseIntParam(req.params.id);
+    if (!db.get(id)) return apiError(res, 404, 'Item not found');
+    db.delete(id);
+    res.json({ ok: true });
+  });
+
+  return router;
+}
+```
+
+### The `core` Object
+
+Your plugin receives `core` with these utilities:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `core.db` | Object | Raw `better-sqlite3` database handle. Use for prepared statements. |
+| `core.auth.checkAgentOrAdmin(req, res)` | Function | Returns username/agent ID or sends 401. Use for any authenticated endpoint. |
+| `core.auth.checkAdmin(req, res)` | Function | Returns username or sends 403. Use for operator-only endpoints. |
+| `core.auth.getAdminDisplayName(req)` | Function | Safe display name for the current admin user. |
+| `core.emitEvent(type, who, projectId, summary, data)` | Function | Emit a platform event (stored, broadcast via SSE, triggers hooks). |
+| `core.onEvent(eventType, handler)` | Function | Subscribe to platform events. See Event Hooks below. |
+| `core.apiError(res, code, msg, extra)` | Function | Send a structured JSON error response. |
+| `core.parseIntParam(val)` | Function | Safe integer parsing for route params. |
+| `core.validateEnum(val, allowed)` | Function | Validate a value against an enum array. |
+| `core.checkApprovalGate(req, who, actionType)` | Function | Check if a gated action has been approved. |
+| `core.gatedActions` | Array | Registered gated action types. |
+| `core.inbox.createInboxItem(operatorId, type, entityType, entityId, title, summary, data, priority)` | Function | Create an inbox notification for a specific operator. |
+| `core.inbox.createInboxItemForAllOperators(type, entityType, entityId, title, summary, data, priority)` | Function | Broadcast an inbox notification to all operators. Returns array of inbox item IDs. |
+
+### Auth Patterns
+
+```javascript
+// Anyone with a valid API key or JWT
+var who = checkAgentOrAdmin(req, res);
+if (!who) return;  // Already sent 401
+
+// Operators only (studio JWT or admin key)
+var who = checkAdmin(req, res);
+if (!who) return;  // Already sent 403
+```
+
+## Event Hooks (handlers.js)
+
+Subscribe to platform events to trigger plugin logic automatically:
+
+```javascript
+import createMyPluginDB from './db.js';
+
+export function registerHooks(core) {
+  var db = createMyPluginDB(core.db);
+
+  // React to specific events
+  core.onEvent('task_completed', function (eventData) {
+    // eventData: { type, agent, project_id, summary, data, created_at }
+    var title = eventData.summary || 'Task completed';
+    db.create(title, eventData.data);
+
+    // Notify operators
+    core.inbox.createInboxItemForAllOperators(
+      'myplugin_notification',
+      'myplugin_item', null,
+      'New item: ' + title,
+      'Created automatically from task completion',
+      { trigger: 'task_completed' },
+      'normal'  // 'urgent' | 'normal' | 'low'
+    );
+  });
+
+  // React to ALL events (wildcard)
+  core.onEvent('*', function (eventData) {
+    // Called for every event — use sparingly
+    console.log('[my-plugin] Event: ' + eventData.type);
+  });
+}
+```
+
+### Available Events
+
+Events your plugin can hook into:
+
+| Category | Events |
+|----------|--------|
+| Tasks | `task_created`, `task_completed`, `task_updated`, `task_unblocked`, `task_approved`, `task_comment` |
+| Plans | `plan_created`, `plan_completed`, `plan_deleted`, `plan_step_added`, `plan_step_updated`, `plan_step_completed` |
+| Bugs | `bug_created`, `bug_updated`, `bug_deleted` |
+| Messages | `message_sent`, `request_created`, `request_acknowledged`, `request_resolved` |
+| Agents | `agent_boot`, `agent_heartbeat`, `agent_registered`, `agent_removed` |
+| Drones | `drone_job_created`, `drone_job_claimed`, `drone_job_done`, `drone_job_failed`, `drone_job_cancelled` |
+| Assets | `asset_registered`, `asset_uploaded`, `asset_delivered`, `asset_deleted` |
+| Approvals | `approval_requested`, `approval_approved`, `approval_denied`, `approval_vote` |
+| Concepts | `concept_created`, `concept_updated`, `concept_deleted`, `concept_linked` |
+| Channels | `channel_created`, `channel_deleted`, `channel_message` |
+| Admin | `config_changed`, `admin_frozen`, `admin_unfrozen`, `sleep_mode_on`, `sleep_mode_off` |
+| Work | `auto_dispatch`, `work_claimed`, `work_request` |
+| Plugins | `plugin_enabled`, `plugin_disabled` |
+| Other | `feedback_submitted`, `file_uploaded`, `artifact_uploaded` |
+
+Use `'*'` to receive all events.
+
+### Event Data Shape
+
+Every event handler receives:
+
+```javascript
+{
+  type: 'task_completed',         // Event type string
+  agent: 'dev-claude',            // Who triggered it
+  project_id: 'my-project',      // Project context (may be null)
+  summary: 'dev-claude completed task #42: Setup README',
+  data: { task_id: 42 },         // Event-specific payload
+  created_at: '2026-03-03T...'   // ISO timestamp
+}
+```
+
+## MCP Tools (mcp-tools.json)
+
+Expose tools that Claude agents can call directly:
+
+```json
+[
+  {
+    "name": "mycelium_myplugin_list",
+    "description": "List items from My Plugin. Returns active items by default.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["active", "archived"],
+          "description": "Filter by status"
+        },
+        "limit": {
+          "type": "integer",
+          "default": 20,
+          "description": "Max items to return"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_myplugin_create",
+    "description": "Create a new item in My Plugin.",
+    "inputSchema": {
+      "type": "object",
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Item title"
+        },
+        "data": {
+          "type": "object",
+          "description": "Arbitrary data payload"
+        }
+      }
+    }
+  }
+]
+```
+
+### Tool Naming
+
+Prefix tool names with `mycelium_<pluginname>_`. This is how agents discover and call your tools.
+
+### How Tools Get Registered
+
+1. Server loads `mcp-tools.json` on startup
+2. MCP server fetches tools via `GET /plugins/mcp-tools`
+3. Each tool gets a handler that maps the input to your plugin's REST endpoint
+4. Agents can call the tool directly — it appears alongside built-in Mycelium tools
+
+## Gated Actions
+
+For operations that should require human approval (publishing content, sending emails, deleting data):
+
+1. Declare gated actions in `plugin.json`:
+
+```json
+{
+  "gatedActions": ["myplugin_publish"]
+}
+```
+
+2. Check the gate in your route handler:
+
+```javascript
+router.post('/items/:id/publish', function (req, res) {
+  var who = checkAdmin(req, res);
+  if (!who) return;
+
+  var gate = core.checkApprovalGate(req, who, 'myplugin_publish');
+  if (gate && !gate.ok) {
+    return apiError(res, 403, 'Publishing requires approval', {
+      approval_required: true
+    });
+  }
+
+  // Gate passed — proceed with the action
+  // ...
+});
+```
+
+3. Agents requesting this action will need to create an approval first:
+
+```
+POST /api/mycelium/approvals
+{
+  "title": "Publish item #5",
+  "action_type": "myplugin_publish",
+  "risk_tier": "medium",
+  "required_approvals": 1
+}
+```
+
+An operator approves it via the dashboard or inbox, then the agent retries the action.
+
+## Operator Inbox Integration
+
+Route notifications to operator inboxes:
+
+```javascript
+// Single operator
+core.inbox.createInboxItem(
+  'operator-id',       // Target operator
+  'myplugin_alert',    // Item type (appears as badge)
+  'myplugin_item',     // Entity type
+  '42',                // Entity ID
+  'Alert: something happened',  // Title
+  'Details about what happened', // Summary
+  { key: 'value' },   // Arbitrary data
+  'urgent'             // Priority: 'urgent' | 'normal' | 'low'
+);
+
+// All operators
+var inboxIds = core.inbox.createInboxItemForAllOperators(
+  'myplugin_alert', 'myplugin_item', '42',
+  'Alert: something happened',
+  'Details about what happened',
+  { key: 'value' },
+  'normal'
+);
+// Returns array of created inbox item IDs
+```
+
+## Loading and Lifecycle
+
+1. Server starts and calls `loadPlugins()`
+2. Each directory in `server/plugins/` with a `plugin.json` is scanned
+3. If `enabled` is true (and the DB record hasn't been toggled off):
+   - `schema.sql` is executed
+   - `handlers.js` hooks are registered
+   - `routes.js` router is mounted at `routePrefix`
+   - `mcp-tools.json` tools are collected for MCP registration
+4. Enable/disable via the dashboard Plugins page (requires server restart to take effect)
+
+## Example: Full Plugin
+
+See the `build-in-public` plugin in `server/plugins/build-in-public/` for a complete example that uses all features: database, routes, event hooks, MCP tools, gated actions, and inbox integration.
+
+## Tips
+
+- **Keep it simple**: Start with just `plugin.json` + `routes.js`. Add complexity as needed.
+- **Use `core.emitEvent()`**: Your plugin's actions become visible on the dashboard timeline and can trigger other plugins.
+- **Test with curl**: Routes mount at `/api/mycelium/<routePrefix>/`. Test with admin key: `-H "X-Admin-Key: YOUR_KEY"`.
+- **Check the dashboard**: The Plugins page shows your plugin's status, version, and tool count after loading.
+- **JSON columns**: Store complex data as JSON text columns. Parse on read in your `db.js` helpers.

--- a/docs/runner-setup-macos.md
+++ b/docs/runner-setup-macos.md
@@ -1,0 +1,240 @@
+# Mycelium Runner Setup — macOS
+
+Run an always-on agent on a Mac Mini (or any macOS machine) that automatically polls for work, executes it via Claude Agent SDK, and pushes results. No human prompting required.
+
+## Prerequisites
+
+- macOS 13+ (Ventura or later)
+- Node.js 18+ (`brew install node`)
+- Git configured with access to your repos
+- An [Anthropic API key](https://console.anthropic.com/) (the runner calls Claude directly)
+- Your Mycelium instance URL and admin key
+
+## 1. Install the Runner
+
+```bash
+git clone https://github.com/grbarajas-soymd/mycelium-runner.git
+cd mycelium-runner
+npm install
+```
+
+## 2. Register the Agent
+
+Register a dedicated agent for this machine:
+
+```bash
+curl -X POST https://INSTANCE_URL/api/mycelium/agents \
+  -H "X-Admin-Key: YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "runner-claude", "project_id": "your-project"}'
+```
+
+Save the returned `api_key`.
+
+## 3. Configure
+
+Copy the example config and edit it:
+
+```bash
+cp config.example.json config.json
+```
+
+Edit `config.json`:
+
+```json
+{
+  "mycelium": {
+    "apiUrl": "https://INSTANCE_URL/api/mycelium",
+    "adminKey": "env:MYCELIUM_ADMIN_KEY"
+  },
+  "defaults": {
+    "model": "claude-sonnet-4-6",
+    "maxTurns": 100,
+    "pollIntervalMs": 300000,
+    "cooldownMs": 30000,
+    "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+  },
+  "agents": [
+    {
+      "id": "runner-claude",
+      "cwd": "/path/to/your/project",
+      "mcpServers": {
+        "mycelium": {
+          "command": "node",
+          "args": ["/path/to/mycelium-mcp/index.js"],
+          "env": {
+            "MYCELIUM_API_KEY": "env:RUNNER_AGENT_KEY",
+            "MYCELIUM_ROLE": "agent",
+            "MYCELIUM_AGENT_ID": "runner-claude"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+Replace:
+- `INSTANCE_URL` with your Mycelium instance URL
+- `/path/to/your/project` with the local path to the repo the agent works on
+- `/path/to/mycelium-mcp/index.js` with the path to your MCP server
+
+## 4. Set Environment Variables
+
+Add to your shell profile (`~/.zshrc` or `~/.bash_profile`):
+
+```bash
+export MYCELIUM_ADMIN_KEY="your-admin-key"
+export RUNNER_AGENT_KEY="your-agent-api-key"
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+```
+
+Reload: `source ~/.zshrc`
+
+## 5. Test Run
+
+Run the runner in the foreground first to verify everything works:
+
+```bash
+node index.js
+```
+
+You should see:
+- Agent registered and heartbeating
+- Poll loop checking for work every 5 minutes
+- Health server running on port 8080
+
+Verify on your dashboard: the agent should appear as "online" in the Agents section.
+
+> **Important**: Do NOT run the runner from inside a Claude Code session. The Agent SDK spawns Claude subprocesses — nesting is blocked.
+
+## 6. Run as a Background Service
+
+### Option A: pm2 (Recommended)
+
+```bash
+# Install pm2
+npm install -g pm2
+
+# Start the runner
+cd /path/to/mycelium-runner
+pm2 start index.js --name mycelium-runner
+
+# Auto-restart on reboot
+pm2 startup
+pm2 save
+
+# Useful commands
+pm2 status              # Check status
+pm2 logs mycelium-runner # View logs
+pm2 restart mycelium-runner # Restart
+pm2 stop mycelium-runner    # Stop
+```
+
+### Option B: launchd (Native macOS)
+
+Create `~/Library/LaunchAgents/com.mycelium.runner.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mycelium.runner</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/node</string>
+        <string>/path/to/mycelium-runner/index.js</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/path/to/mycelium-runner</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>MYCELIUM_ADMIN_KEY</key>
+        <string>your-admin-key</string>
+        <key>RUNNER_AGENT_KEY</key>
+        <string>your-agent-key</string>
+        <key>ANTHROPIC_API_KEY</key>
+        <string>your-anthropic-key</string>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/mycelium-runner.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/mycelium-runner.err</string>
+</dict>
+</plist>
+```
+
+Update the paths, then load it:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.mycelium.runner.plist
+```
+
+Manage:
+```bash
+launchctl start com.mycelium.runner   # Start
+launchctl stop com.mycelium.runner    # Stop
+launchctl unload ~/Library/LaunchAgents/com.mycelium.runner.plist  # Remove
+tail -f /tmp/mycelium-runner.log      # View logs
+```
+
+## 7. Verify Agent is Heartbeating
+
+Check from another machine or the dashboard:
+
+```bash
+curl -s https://INSTANCE_URL/api/mycelium/agents \
+  -H "X-Admin-Key: YOUR_ADMIN_KEY" | jq '.[] | select(.id=="runner-claude")'
+```
+
+You should see `"status": "online"` and a recent `heartbeat_at` timestamp.
+
+On the dashboard, the agent should appear with a green dot in the Agents section and the sidebar agent count should reflect it.
+
+## Configuration Reference
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `model` | `claude-sonnet-4-6` | Claude model for agent sessions |
+| `maxTurns` | `100` | Max tool-use turns per work session |
+| `pollIntervalMs` | `300000` (5 min) | How often to check for new work |
+| `cooldownMs` | `30000` (30 sec) | Pause between work sessions |
+| `tools` | Read, Write, Edit, Bash, Glob, Grep | Claude Code tools the agent can use |
+
+## Troubleshooting
+
+**Agent shows offline on dashboard**
+- Check the runner is actually running: `pm2 status` or check launchd logs
+- Verify `ANTHROPIC_API_KEY` is set — the runner needs it to call Claude
+- Check network connectivity to your Mycelium instance
+
+**"MYCELIUM_ADMIN_KEY required" error**
+- Environment variables aren't being passed. Check `~/.zshrc` or the launchd plist.
+- With pm2, you may need: `pm2 start index.js --name mycelium-runner --update-env`
+
+**Agent heartbeats but never picks up work**
+- Check the work queue: `curl https://INSTANCE_URL/api/mycelium/work/runner-claude -H "X-Admin-Key: ..."`
+- Ensure there are tasks/plan steps assigned to or available for this agent
+- Check `pollIntervalMs` — default is 5 minutes between checks
+
+**Session errors / agent crashes**
+- Check logs for Claude API errors (rate limits, token issues)
+- Verify `cwd` in config points to a valid directory with a CLAUDE.md
+- The runner has exponential backoff — it will retry with increasing delays
+
+## Health Endpoint
+
+The runner exposes a health server (default port 8080):
+
+```bash
+curl http://localhost:8080/health   # Full status JSON
+curl http://localhost:8080/ready    # 200 if healthy, 503 if not
+```

--- a/public/setup-mcp-template.json
+++ b/public/setup-mcp-template.json
@@ -21,6 +21,7 @@
       "command": "node",
       "args": ["PATH_TO_MYCELIUM_MCP/index.js"],
       "env": {
+        "MYCELIUM_API_URL": "https://INSTANCE_URL/api/mycelium",
         "MYCELIUM_API_KEY": "env:RUNNER_AGENT_KEY",
         "MYCELIUM_ROLE": "agent",
         "MYCELIUM_AGENT_ID": "AGENT_ID"

--- a/public/setup-mcp-template.json
+++ b/public/setup-mcp-template.json
@@ -1,0 +1,52 @@
+{
+  "_comment": "Mycelium MCP config templates. Copy one of the variants below into your ~/.claude/settings.json under mcpServers.",
+
+  "interactive_agent": {
+    "_description": "For your development machine (laptop/desktop with Claude Code). Replace ALL_CAPS values.",
+    "mycelium": {
+      "command": "node",
+      "args": ["PATH_TO_MYCELIUM_MCP/index.js"],
+      "env": {
+        "MYCELIUM_API_URL": "https://INSTANCE_URL/api/mycelium",
+        "MYCELIUM_ROLE": "agent",
+        "MYCELIUM_AGENT_ID": "AGENT_ID",
+        "MYCELIUM_API_KEY": "AGENT_API_KEY"
+      }
+    }
+  },
+
+  "runner_agent": {
+    "_description": "For the mycelium-runner config.json (always-on machine like Mac Mini). Uses env: refs for secrets.",
+    "mycelium": {
+      "command": "node",
+      "args": ["PATH_TO_MYCELIUM_MCP/index.js"],
+      "env": {
+        "MYCELIUM_API_KEY": "env:RUNNER_AGENT_KEY",
+        "MYCELIUM_ROLE": "agent",
+        "MYCELIUM_AGENT_ID": "AGENT_ID"
+      }
+    }
+  },
+
+  "admin": {
+    "_description": "For admin access (full dashboard control, agent management). Use sparingly.",
+    "mycelium": {
+      "command": "node",
+      "args": ["PATH_TO_MYCELIUM_MCP/index.js"],
+      "env": {
+        "MYCELIUM_API_URL": "https://INSTANCE_URL/api/mycelium",
+        "MYCELIUM_ROLE": "admin",
+        "MYCELIUM_API_KEY": "ADMIN_API_KEY"
+      }
+    }
+  },
+
+  "_placeholders": {
+    "INSTANCE_URL": "Your Mycelium instance (e.g., yourname.mycelium.fyi)",
+    "PATH_TO_MYCELIUM_MCP": "Absolute path to where you cloned mycelium-mcp",
+    "AGENT_ID": "Your agent name (e.g., dev-claude, runner-claude)",
+    "AGENT_API_KEY": "API key returned by POST /agents registration",
+    "ADMIN_API_KEY": "Instance admin key (provided during setup)",
+    "RUNNER_AGENT_KEY": "Environment variable name containing the agent key"
+  }
+}

--- a/server/plugins/_template/db.js
+++ b/server/plugins/_template/db.js
@@ -1,0 +1,53 @@
+// Plugin DB helpers — rename table references to match your schema.sql
+
+export default function createTemplateDB(db) {
+  return {
+    create(title, data, createdBy) {
+      var r = db.prepare(
+        'INSERT INTO dv_template_items (title, data, created_by) VALUES (?, ?, ?) RETURNING id'
+      ).get(title || '', JSON.stringify(data || {}), createdBy || '');
+      return r.id;
+    },
+
+    get(id) {
+      var row = db.prepare('SELECT * FROM dv_template_items WHERE id = ?').get(id);
+      if (row) {
+        try { row.data = JSON.parse(row.data); } catch (e) { row.data = {}; }
+      }
+      return row;
+    },
+
+    list(filters) {
+      var where = ['1=1'];
+      var params = [];
+      if (filters.status) { where.push('status = ?'); params.push(filters.status); }
+      var limit = Math.min(filters.limit || 50, 200);
+      var offset = filters.offset || 0;
+      params.push(limit, offset);
+      var rows = db.prepare(
+        'SELECT * FROM dv_template_items WHERE ' + where.join(' AND ') +
+        ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
+      ).all(...params);
+      return rows.map(function (row) {
+        try { row.data = JSON.parse(row.data); } catch (e) { row.data = {}; }
+        return row;
+      });
+    },
+
+    update(id, fields) {
+      var sets = [];
+      var values = [];
+      if (fields.title !== undefined) { sets.push('title = ?'); values.push(fields.title); }
+      if (fields.status !== undefined) { sets.push('status = ?'); values.push(fields.status); }
+      if (fields.data !== undefined) { sets.push('data = ?'); values.push(JSON.stringify(fields.data)); }
+      if (sets.length === 0) return;
+      sets.push("updated_at = datetime('now')");
+      values.push(id);
+      db.prepare('UPDATE dv_template_items SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+    },
+
+    delete(id) {
+      db.prepare('DELETE FROM dv_template_items WHERE id = ?').run(id);
+    }
+  };
+}

--- a/server/plugins/_template/handlers.js
+++ b/server/plugins/_template/handlers.js
@@ -1,0 +1,34 @@
+// Plugin event handlers — subscribe to platform events
+// Remove this file if your plugin doesn't need event hooks.
+
+import createTemplateDB from './db.js';
+
+export function registerHooks(core) {
+  var db = createTemplateDB(core.db);
+
+  // Example: auto-create an item when a task completes
+  core.onEvent('task_completed', function (eventData) {
+    try {
+      var id = db.create(
+        'From task: ' + (eventData.summary || 'completed'),
+        { trigger: eventData.type, source: eventData.data },
+        eventData.agent || '__system__'
+      );
+
+      // Notify operators via inbox
+      core.inbox.createInboxItemForAllOperators(
+        'template_notification',
+        'template_item',
+        String(id),
+        'New item from task completion',
+        eventData.summary || 'A task was completed',
+        { item_id: id, trigger_event: eventData.type },
+        'low'
+      );
+
+      console.log('[template] Created item #' + id + ' from ' + eventData.type);
+    } catch (e) {
+      console.error('[template] Hook error:', e.message);
+    }
+  });
+}

--- a/server/plugins/_template/mcp-tools.json
+++ b/server/plugins/_template/mcp-tools.json
@@ -1,0 +1,39 @@
+[
+  {
+    "name": "mycelium_template_list",
+    "description": "List items from the template plugin. Returns active items by default.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["active", "archived"],
+          "description": "Filter by item status"
+        },
+        "limit": {
+          "type": "integer",
+          "default": 20,
+          "description": "Max items to return"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_template_create",
+    "description": "Create a new template item.",
+    "inputSchema": {
+      "type": "object",
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Item title"
+        },
+        "data": {
+          "type": "object",
+          "description": "Arbitrary JSON data to attach to the item"
+        }
+      }
+    }
+  }
+]

--- a/server/plugins/_template/plugin.json
+++ b/server/plugins/_template/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "_template",
+  "version": "1.0.0",
+  "displayName": "Plugin Template",
+  "description": "Starter template — copy this directory and rename to build your own plugin.",
+  "author": "",
+  "enabled": false,
+  "routePrefix": "/template",
+  "schema": "schema.sql",
+  "gatedActions": [],
+  "mcpTools": "mcp-tools.json"
+}

--- a/server/plugins/_template/routes.js
+++ b/server/plugins/_template/routes.js
@@ -1,0 +1,69 @@
+// Plugin routes — rename and customize for your plugin
+
+import { Router } from 'express';
+import createTemplateDB from './db.js';
+
+export default function (core) {
+  var router = Router();
+  var db = createTemplateDB(core.db);
+  var { checkAgentOrAdmin, checkAdmin } = core.auth;
+  var { apiError, parseIntParam } = core;
+
+  // GET /template/items — list items
+  router.get('/items', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    res.json(db.list({
+      status: req.query.status || undefined,
+      limit: parseInt(req.query.limit) || 50,
+      offset: parseInt(req.query.offset) || 0
+    }));
+  });
+
+  // GET /template/items/:id — get single item
+  router.get('/items/:id', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var item = db.get(parseIntParam(req.params.id));
+    if (!item) return apiError(res, 404, 'Item not found');
+    res.json(item);
+  });
+
+  // POST /template/items — create item
+  router.post('/items', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var id = db.create(req.body.title || '', req.body.data, who);
+    core.emitEvent('template_item_created', who, null,
+      who + ' created template item #' + id, { item_id: id });
+    res.json({ id: id });
+  });
+
+  // PUT /template/items/:id — update item
+  router.put('/items/:id', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var id = parseIntParam(req.params.id);
+    if (!db.get(id)) return apiError(res, 404, 'Item not found');
+    var updates = {};
+    if (req.body.title !== undefined) updates.title = req.body.title;
+    if (req.body.status !== undefined) updates.status = req.body.status;
+    if (req.body.data !== undefined) updates.data = req.body.data;
+    db.update(id, updates);
+    res.json({ ok: true, item: db.get(id) });
+  });
+
+  // DELETE /template/items/:id — delete item (admin only)
+  router.delete('/items/:id', function (req, res) {
+    var who = checkAdmin(req, res);
+    if (!who) return;
+    var id = parseIntParam(req.params.id);
+    if (!db.get(id)) return apiError(res, 404, 'Item not found');
+    db.delete(id);
+    core.emitEvent('template_item_deleted', who, null,
+      who + ' deleted template item #' + id, { item_id: id });
+    res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/server/plugins/_template/schema.sql
+++ b/server/plugins/_template/schema.sql
@@ -1,0 +1,14 @@
+-- Plugin: _template
+-- Rename table prefix from dv_template_ to dv_YOURPLUGIN_
+
+CREATE TABLE IF NOT EXISTS dv_template_items (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  title       TEXT NOT NULL DEFAULT '',
+  status      TEXT NOT NULL DEFAULT 'active',
+  data        TEXT NOT NULL DEFAULT '{}',
+  created_by  TEXT NOT NULL DEFAULT '',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_template_items_status ON dv_template_items(status);


### PR DESCRIPTION
## Summary
Complete package for onboarding external customers and enabling them to build plugins.

### Onboarding (Commit 1)
- **docs/customer-onboarding.md** — Full setup guide: MCP install, agent registration, Claude Code config, dashboard orientation, second machine setup
- **docs/runner-setup-macos.md** — Always-on runner on macOS with pm2 and launchd service configs
- **public/setup-mcp-template.json** — Ready-to-paste MCP configs (interactive, runner, admin variants)
- **docs/first-run-checklist.md** — Ordered verification checklist

### Plugin Development (Commit 2)
- **docs/plugin-guide.md** — Human developer guide: file structure, core API, DB patterns, routes, event hooks, MCP tools, gated actions, inbox integration
- **docs/plugin-guide-claude.md** — Compact Claude-optimized reference with exact patterns, API signatures, event types, and checklist
- **server/plugins/_template/** — Complete starter skeleton (all 6 files). Copy, rename, customize. Disabled by default.

All docs use INSTANCE_URL placeholders, no internal references.

## Test plan
- [ ] Onboarding guide steps are clear and complete
- [ ] Runner setup covers pm2 + launchd correctly
- [ ] MCP template JSON is valid with all three variants
- [ ] First-run checklist covers zero to fully operational
- [ ] Plugin guide covers all core API methods
- [ ] Claude reference is compact and copy-paste ready
- [ ] Template plugin loads when enabled (rename + set enabled: true)
- [ ] No references to Dioverse, WS, or internal agent names

🤖 Generated with [Claude Code](https://claude.com/claude-code)