### PR TITLE
Fix channel page scroll

### DIFF
--- a/studio-react/src/pages/ChannelsPage.tsx
+++ b/studio-react/src/pages/ChannelsPage.tsx
@@ -446,7 +446,7 @@ function ChatArea({
   const config = CHANNEL_TYPE_CONFIG[channel.type]
 
   return (
-    <div className="flex-1 flex flex-col min-w-0 bg-bg">
+    <div className="flex-1 flex flex-col min-w-0 min-h-0 bg-bg">
       {/* Channel header */}
       <div className="flex items-center gap-3 px-4 py-3 border-b border-border shrink-0">
         <span className="text-base">{config.icon}</span>
@@ -630,7 +630,7 @@ export default function ChannelsPage() {
           onChannelCreated={() => { useDashboardStore.getState().refresh(); loadUnread() }}
         />
       </div>
-      <div className={`${activeChannelId ? 'flex' : 'hidden sm:flex'} flex-col flex-1 min-w-0`}>
+      <div className={`${activeChannelId ? 'flex' : 'hidden sm:flex'} flex-col flex-1 min-w-0 min-h-0`}>
         {activeChannelId && (
           <button
             onClick={() => handleSelectChannel(null as any)}


### PR DESCRIPTION
## Summary
- Channels page message list doesn't scroll when content overflows
- Root cause: two flex-col parent containers missing `min-h-0`
- Added `min-h-0` to the chat panel container and outer layout container

Bug #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)