### PR TITLE
Channels cleanup — Slack-lite + fix onboarding redirect

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1482,35 +1482,12 @@ export function createChannelMessage(channelId, fromAgent, content, metadata) {
   return result.id;
 }
 
-export function listGeneralChannelMessages(generalChannelId, filters) {
-  var where = ['(channel_id = ? OR channel_id IS NULL)', "msg_type != 'chat'"];
-  var params = [generalChannelId];
-  if (filters.before) { where.push('id < ?'); params.push(filters.before); }
-  if (filters.after) { where.push('id > ?'); params.push(filters.after); }
-  params.push(filters.limit || 50);
-  return db.prepare(
-    'SELECT * FROM dv_messages WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?'
-  ).all(...params);
-}
-
-export function listTeamChatChannelMessages(teamChatChannelId, filters) {
-  var where = ["(channel_id = ? OR (msg_type = 'chat' AND channel_id IS NULL))"];
-  var params = [teamChatChannelId];
-  if (filters.before) { where.push('id < ?'); params.push(filters.before); }
-  if (filters.after) { where.push('id > ?'); params.push(filters.after); }
-  params.push(filters.limit || 50);
-  return db.prepare(
-    'SELECT * FROM dv_messages WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?'
-  ).all(...params);
-}
-
 // -- Channel Seeding + Auto-Creation --
 
 export function ensureDefaultChannels() {
   var defaults = [
     { name: '#general', slug: 'general', type: 'general', description: 'General discussion' },
-    { name: '#admin', slug: 'admin', type: 'announcement', description: 'Admin coordination' },
-    { name: '#team-chat', slug: 'team-chat', type: 'announcement', description: 'Team chat' }
+    { name: '#admin', slug: 'admin', type: 'announcement', description: 'Admin coordination' }
   ];
   for (var def of defaults) {
     var existing = getChannelBySlug(def.slug);

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -84,8 +84,7 @@ import {
   isChannelMember, getChannelsByUser,
   markChannelRead, getUnreadCounts, getLatestChannelMessageId,
   listChannelMessages, createChannelMessage,
-  listGeneralChannelMessages, listTeamChatChannelMessages,
-  autoCreateEntityChannel, getOrCreateDmChannel,
+  getOrCreateDmChannel,
   createSavepoint, getLatestSavepoint, getSavepointHistory,
   updateSavepointNotes, computeSavepointDiff, pruneSavepoints,
   listPluginRecords, getPluginRecord, updatePluginEnabled, getDB,
@@ -720,10 +719,6 @@ router.post('/tasks', function (req, res) {
   var priority = req.body.priority || 'normal';
   var tags = req.body.tags ? JSON.stringify(req.body.tags) : '[]';
   var id = createDvTask(title, description, projectId, agentId, priority, tags);
-  // Auto-create channel for task
-  var taskMembers = [agentId];
-  if (req.body.assignee) taskMembers.push(req.body.assignee);
-  autoCreateEntityChannel('task', id, '#task-' + id + ': ' + title, agentId, taskMembers);
   // Handle optional fields
   var updates = {};
   if (req.body.assignee) updates.assignee = req.body.assignee;
@@ -1406,10 +1401,6 @@ router.post('/plans', function (req, res) {
   var priority = req.body.priority || 'normal';
   var tags = req.body.tags ? JSON.stringify(req.body.tags) : '[]';
   var id = createDvPlan(title, description, projectId, owner, priority, tags, agentId);
-  // Auto-create channel for plan
-  var planMembers = [];
-  if (owner) planMembers.push(owner);
-  autoCreateEntityChannel('plan', id, '#plan-' + id + ': ' + title, agentId, planMembers);
   emitEvent('plan_created', agentId, projectId, agentId + ' created plan: ' + title, { plan_id: id });
   dispatchWebhook('plan_created', agentId, { plan_id: id, title: title, project_id: projectId, owner: owner });
   var result = { id: id, title: title };
@@ -2251,10 +2242,6 @@ router.post('/bugs', function (req, res) {
     diagStr = typeof diagnostic_data === 'string' ? diagnostic_data : JSON.stringify(diagnostic_data);
   }
   var id = createDvBug(projectId, title, description, category, severity, who, assignee, diagStr);
-  // Auto-create channel for bug
-  var bugMembers = [who];
-  if (assignee) bugMembers.push(assignee);
-  autoCreateEntityChannel('bug', id, '#bug-' + id + ': ' + title, who, bugMembers);
   emitEvent('bug_created', who, projectId || '', who + ' filed bug #' + id + ': ' + title, { bug_id: id });
   dispatchWebhook('bug_created', who, { bug_id: id, title: title, project_id: projectId, severity: severity, reporter: who, assignee: assignee });
   res.json({ ok: true, id: id });
@@ -2490,14 +2477,7 @@ router.get('/channels/:id/messages', function (req, res) {
     after: req.query.after ? parseIntParam(req.query.after) : undefined,
     limit: parseLimit(req.query.limit, 50)
   };
-  var messages;
-  if (channel.slug === 'general') {
-    messages = listGeneralChannelMessages(channel.id, filters);
-  } else if (channel.slug === 'team-chat') {
-    messages = listTeamChatChannelMessages(channel.id, filters);
-  } else {
-    messages = listChannelMessages(channel.id, filters);
-  }
+  var messages = listChannelMessages(channel.id, filters);
   res.json(messages);
 });
 

--- a/studio-react/src/api/types.ts
+++ b/studio-react/src/api/types.ts
@@ -222,7 +222,7 @@ export interface Channel {
   id: number;
   name: string;
   slug: string;
-  type: 'general' | 'announcement' | 'dm' | 'plan' | 'bug' | 'task';
+  type: 'general' | 'announcement' | 'dm' | string;
   linked_type: string | null;
   linked_id: string | null;
   description: string;

--- a/studio-react/src/pages/ChannelsPage.tsx
+++ b/studio-react/src/pages/ChannelsPage.tsx
@@ -14,16 +14,19 @@ import { useVoice } from '../hooks/useVoice'
 type ChannelType = Channel['type']
 type BadgeVariant = 'default' | 'green' | 'red' | 'blue' | 'accent' | 'purple' | 'pink' | 'muted'
 
-const CHANNEL_TYPE_CONFIG: Record<ChannelType, { label: string; icon: string; variant: BadgeVariant }> = {
-  general: { label: 'General', icon: '#', variant: 'default' },
-  announcement: { label: 'Announcements', icon: '\u{1F4E2}', variant: 'accent' },
+const CHANNEL_TYPE_CONFIG: Record<string, { label: string; icon: string; variant: BadgeVariant }> = {
+  general: { label: 'Channels', icon: '#', variant: 'default' },
+  announcement: { label: 'Channels', icon: '\u{1F4E2}', variant: 'accent' },
   dm: { label: 'Direct Messages', icon: '\u{1F4AC}', variant: 'purple' },
-  plan: { label: 'Plans', icon: '\u{1F4CB}', variant: 'blue' },
-  bug: { label: 'Bugs', icon: '\u{1F41B}', variant: 'red' },
-  task: { label: 'Tasks', icon: '\u2705', variant: 'green' },
 }
 
-const CHANNEL_TYPE_ORDER: ChannelType[] = ['general', 'announcement', 'dm', 'plan', 'bug', 'task']
+const DEFAULT_TYPE_CONFIG = { label: 'Channels', icon: '#', variant: 'default' as BadgeVariant }
+
+type SidebarGroup = 'channels' | 'dm'
+const SIDEBAR_GROUPS: { key: SidebarGroup; label: string }[] = [
+  { key: 'channels', label: 'Channels' },
+  { key: 'dm', label: 'Direct Messages' },
+]
 
 const TRUNCATE_LENGTH = 300
 
@@ -234,16 +237,18 @@ function ChannelSidebar({
     [unreadMap],
   )
 
-  // Group channels by type in defined order
+  // Group channels into Channels (general/announcement/legacy entity types) and DMs
   const grouped = useMemo(() => {
-    const map = new Map<ChannelType, Channel[]>()
-    for (const t of CHANNEL_TYPE_ORDER) {
-      map.set(t, [])
-    }
+    const map = new Map<SidebarGroup, Channel[]>()
+    map.set('channels', [])
+    map.set('dm', [])
     for (const ch of channels) {
       if (ch.status !== 'active') continue
-      const list = map.get(ch.type)
-      if (list) list.push(ch)
+      if (ch.type === 'dm') {
+        map.get('dm')!.push(ch)
+      } else {
+        map.get('channels')!.push(ch)
+      }
     }
     return map
   }, [channels])
@@ -307,9 +312,6 @@ function ChannelSidebar({
           >
             <option value="general">General</option>
             <option value="announcement">Announcement</option>
-            <option value="plan">Plan</option>
-            <option value="bug">Bug</option>
-            <option value="task">Task</option>
           </select>
           <input
             value={newDesc}
@@ -337,21 +339,21 @@ function ChannelSidebar({
 
       {/* Channel list */}
       <div className="flex-1 overflow-y-auto py-2">
-        {CHANNEL_TYPE_ORDER.map((type) => {
-          const list = grouped.get(type)
+        {SIDEBAR_GROUPS.map(({ key, label }) => {
+          const list = grouped.get(key)
           if (!list || list.length === 0) return null
-          const config = CHANNEL_TYPE_CONFIG[type]
 
           return (
-            <div key={type} className="mb-2">
+            <div key={key} className="mb-2">
               <div className="px-3 py-1">
                 <span className="text-text-muted text-[10px] font-semibold tracking-wider uppercase">
-                  {config.label}
+                  {label}
                 </span>
               </div>
               {list.map((ch) => {
                 const isActive = ch.id === activeId
                 const unread = unreadMap[ch.id] || 0
+                const config = CHANNEL_TYPE_CONFIG[ch.type] || DEFAULT_TYPE_CONFIG
 
                 return (
                   <button
@@ -443,7 +445,7 @@ function ChatArea({
     )
   }
 
-  const config = CHANNEL_TYPE_CONFIG[channel.type]
+  const config = CHANNEL_TYPE_CONFIG[channel.type] || DEFAULT_TYPE_CONFIG
 
   return (
     <div className="flex-1 flex flex-col min-w-0 bg-bg">

--- a/studio-react/src/stores/dashboardStore.ts
+++ b/studio-react/src/stores/dashboardStore.ts
@@ -85,8 +85,8 @@ export const useDashboardStore = create<DashboardState>()((set) => ({
   plugins: [],
   inboxUnread: 0,
 
-  // UI state defaults
-  loading: false,
+  // UI state defaults — start true so first-boot detection waits for data
+  loading: true,
   error: null,
   lastRefresh: null,
 


### PR DESCRIPTION
## Summary
- **Stop auto-creating channels** on task/plan/bug creation — no more noisy entity channels
- **Remove special message aggregation queries** (`listGeneralChannelMessages`, `listTeamChatChannelMessages`) — all channels use standard `listChannelMessages`
- **Drop #team-chat** from default channels (redundant with #general)
- **Simplify channel sidebar** to two groups: Channels + Direct Messages. Old entity channels still render with fallback styling
- **Reduce create channel form** to general/announcement types only
- **Fix onboarding redirect on refresh** — `loading` now defaults to `true` so first-boot detection waits for data before checking

## Files Changed
| File | Change |
|------|--------|
| `server/routes/mycelium.js` | Remove 3 `autoCreateEntityChannel()` calls + special message query branches |
| `server/db.js` | Drop team-chat from defaults; delete 2 special list functions |
| `studio-react/src/pages/ChannelsPage.tsx` | Simplify type config; update create form; clean sidebar grouping |
| `studio-react/src/api/types.ts` | Loosen Channel.type to accept legacy string types |
| `studio-react/src/stores/dashboardStore.ts` | Default loading to true |

## Test plan
- [ ] Create a task, plan, bug — no channels auto-created
- [ ] Send a DM — DM channel still auto-creates
- [ ] Channel sidebar shows: #general, #admin, DMs — clean grouping
- [ ] Old entity channels still accessible if they exist
- [ ] #general messages load normally (standard query, no aggregation)
- [ ] Page refresh stays on dashboard (no onboarding redirect)
- [ ] `npx vite build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)