### PR TITLE
fix(studio): Polish Pass QA — Plan #25 complete

### DIFF
--- a/studio-react/src/App.tsx
+++ b/studio-react/src/App.tsx
@@ -73,7 +73,6 @@ export default function App() {
           <Route path="plugins" element={<PluginsPage />} />
           <Route path="analytics" element={<AnalyticsPage />} />
           <Route path="feedback" element={<FeedbackPage />} />
-          <Route path="inbox" element={<InboxPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/studio-react/src/layouts/AppLayout.tsx
+++ b/studio-react/src/layouts/AppLayout.tsx
@@ -127,7 +127,7 @@ export default function AppLayout() {
         <main className={
           !showFloatingVoice
             ? 'flex-1 overflow-hidden flex flex-col min-h-0'
-            : `flex-1 overflow-y-auto p-4 md:p-6 ${showFloatingVoice ? 'pb-16' : ''}`
+            : 'flex-1 overflow-y-auto p-4 md:p-6 pb-16'
         }>
           <DirectiveBanner />
           <Outlet />


### PR DESCRIPTION
## Summary

Polish Pass audit (Plan #25) — 21-page review of Studio React UI completed.

- PR #44 (onboarding 404 fix) already merged — confirmed
- Removed duplicate `<Route path="inbox">` in `App.tsx` — dead code after `/feedback` route was cleaned up
- Collapsed redundant inner ternary in `AppLayout.tsx` — the `showFloatingVoice` guard inside an already-truthy branch always evaluated to `pb-16`, replaced template literal with a plain string

## Changes

- `studio-react/src/App.tsx`: removed duplicate inbox route declaration
- `studio-react/src/layouts/AppLayout.tsx`: simplified className conditional

## Test plan

- [ ] Navigate to `/inbox` — confirm route works once, not duplicated
- [ ] Verify `AppLayout` renders correct padding class on mobile/desktop
- [ ] Run full Studio build with no TypeScript errors

Part of Plan #25 Polish Pass audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)