### PR TITLE
Include work queue in heartbeat response

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -629,6 +629,14 @@ router.post('/agents/heartbeat', function (req, res) {
     } catch (e) { /* non-critical */ }
   }
 
+  // Include work queue so agents discover new work on heartbeat
+  try {
+    var payload = getBootPayload(agentId);
+    if (payload && payload.work_queue && payload.work_queue.length > 0) {
+      response.work_queue = payload.work_queue;
+    }
+  } catch (e) { /* non-critical */ }
+
   res.json(response);
 });
 


### PR DESCRIPTION
## Summary
- Heartbeat endpoint now returns `work_queue` array alongside existing `pending` counts
- Agents discover new work (directives, requests, plan steps, tasks, bugs) on every 5-minute heartbeat cycle
- No extra API call needed — one round-trip does both heartbeat + work check
- Reuses existing `getBootPayload()`, no new DB queries

## Test plan
- [ ] Send heartbeat via curl, verify `work_queue` in response when work exists
- [ ] Verify empty `work_queue` is omitted (not an empty array)
- [ ] Verify no performance regression on heartbeat endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)