### PR TITLE
fix: install.sh port mapping and health check endpoint

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -108,8 +108,8 @@ log "Starting Mycelium on port ${PORT}..."
 docker run -d \
   --name "$CONTAINER_NAME" \
   --restart unless-stopped \
-  -p "${PORT}:${PORT}" \
-  -e PORT="${PORT}" \
+  -p "${PORT}:3002" \
+  -e PORT="3002" \
   -e ADMIN_KEY="${ADMIN_KEY}" \
   -e JWT_SECRET="${JWT_SECRET}" \
   -e DATA_DIR="/data" \
@@ -119,7 +119,7 @@ docker run -d \
 # ── Wait for healthy ──────────────────────────────────────────────────────────
 log "Waiting for Mycelium to start..."
 ATTEMPTS=0
-until curl -sf "http://localhost:${PORT}/api/mycelium/health" &>/dev/null; do
+until curl -sf "http://localhost:${PORT}/health" &>/dev/null; do
   ATTEMPTS=$((ATTEMPTS + 1))
   if [[ $ATTEMPTS -gt 30 ]]; then
     err "Mycelium did not start in time. Check logs: docker logs ${CONTAINER_NAME}"


### PR DESCRIPTION
## Bug Fix

Two issues in `public/install.sh`:

1. **Port mapping**: `-p ${PORT}:${PORT}` breaks when user passes `--port 8080` because the container always listens on 3002 internally. Fixed to `-p ${PORT}:3002`.

2. **Health check URL**: Was hitting `/api/mycelium/health` which doesn't exist. The actual endpoint is `/health` (defined in `server/index.js:101`).

### Test plan
- [ ] Run with default port (3002) — should work as before
- [ ] Run with `--port 8080` — should correctly map 8080→3002