### PR TITLE
fix: remove duplicate plan step comment routes

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -59,7 +59,7 @@ import {
   getBootPayload, getOverview,
   createBug, getBug, listBugs, updateBug, deleteBug, countBugs,
   createPlan, getPlan, listPlans, updatePlan, deletePlan,
-  createPlanStep, updatePlanStep, deletePlanStep, reorderPlanSteps, createPlanStepComment, listPlanStepComments,
+  createPlanStep, updatePlanStep, deletePlanStep, reorderPlanSteps,
   completeLinkedPlanSteps,
   createStudioUser, getStudioUserByUsername, getStudioUserById,
   listStudioUsers, deleteStudioUser, updateStudioUser,
@@ -1585,35 +1585,6 @@ router.put('/plans/:id/reorder', function (req, res) {
   if (!Array.isArray(order)) return res.status(400).json({ error: 'order must be an array of step IDs' });
   reorderPlanSteps(parseIntParam(req.params.id), order);
   res.json({ ok: true, plan_id: parseIntParam(req.params.id) });
-});
-
-// -- Plan Step Comments --
-
-router.get('/plans/:id/steps/:stepId/comments', function (req, res) {
-  var who = checkAgentOrAdmin(req, res);
-  if (!who) return;
-  var plan = getPlan(parseIntParam(req.params.id));
-  if (!plan) return res.status(404).json({ error: 'Plan not found' });
-  if (!checkProjectScope(req, res, plan.project_id)) return;
-  var comments = listPlanStepComments(parseIntParam(req.params.stepId));
-  res.json(comments);
-});
-
-router.post('/plans/:id/steps/:stepId/comments', function (req, res) {
-  var who = checkAgentOrAdmin(req, res);
-  if (!who) return;
-  var plan = getPlan(parseIntParam(req.params.id));
-  if (!plan) return res.status(404).json({ error: 'Plan not found' });
-  if (!checkProjectScope(req, res, plan.project_id)) return;
-  var stepId = parseIntParam(req.params.stepId);
-  var step = plan.steps ? plan.steps.find(function (s) { return s.id === stepId; }) : null;
-  if (!step) return res.status(404).json({ error: 'Step not found' });
-  var content = req.body.content;
-  if (!content || !content.trim()) return res.status(400).json({ error: 'content is required' });
-  var author = req.body.author || who;
-  var id = createPlanStepComment(stepId, plan.id, escapeHtml(author), escapeHtml(content.trim()));
-  emitEvent('plan_step_comment', who, plan.project_id, who + ' commented on step #' + stepId + ' of plan #' + plan.id, { plan_id: plan.id, step_id: stepId, comment_id: id });
-  res.status(201).json({ ok: true, id: id });
 });
 
 // ======== STUDIO AUTH ========


### PR DESCRIPTION
## Bug Fix

Plan step comment routes (GET/POST `/plans/:id/steps/:stepId/comments`) were registered twice in `routes/mycelium.js`. The second set was unreachable dead code — Express uses the first matching handler.

Removed the duplicate routes (lines 1590-1617) and cleaned up the unused `createPlanStepComment`/`listPlanStepComments` imports.

### Test plan
- [ ] POST a comment on a plan step — verify it still works
- [ ] GET comments on a plan step — verify response format unchanged