### PR TITLE
fix: replace game-specific bug categories with platform-agnostic ones

### DIFF
--- a/studio-react/src/components/bugs/BugCard.tsx
+++ b/studio-react/src/components/bugs/BugCard.tsx
@@ -30,12 +30,12 @@ const statusBadgeVariant: Record<string, 'red' | 'blue' | 'green' | 'muted' | 'd
 }
 
 const categoryBadgeVariant: Record<string, 'purple' | 'pink' | 'accent' | 'blue' | 'red' | 'default'> = {
-  gameplay: 'purple',
+  bug: 'purple',
+  feature: 'accent',
   ui: 'pink',
   crash: 'red',
   api: 'blue',
   infrastructure: 'accent',
-  balance: 'green' as any,
   other: 'default',
 }
 

--- a/studio-react/src/pages/BugsPage.tsx
+++ b/studio-react/src/pages/BugsPage.tsx
@@ -24,7 +24,7 @@ const SEVERITY_OPTIONS = ['all', 'critical', 'high', 'normal', 'low']
 // ─── File Bug Modal ──────────────────────────────────────────────────────────
 
 const SEVERITY_CHOICES = ['normal', 'high', 'critical', 'low']
-const CATEGORY_OPTIONS = ['other', 'gameplay', 'ui', 'crash', 'api', 'infrastructure', 'balance']
+const CATEGORY_OPTIONS = ['bug', 'feature', 'ui', 'crash', 'api', 'infrastructure', 'other']
 
 interface FileBugModalProps {
   isOpen: boolean


### PR DESCRIPTION
## Cleanup — Strip Game-Dev DNA remnant

Replace hardcoded `gameplay`/`balance` bug categories with `bug`/`feature` in the dashboard. Matches conventions v2.1 which defines categories as dynamic per project.

### Changes
- `BugsPage.tsx` — category options: gameplay/balance → bug/feature
- `BugCard.tsx` — badge color map updated to match

Build passes clean.