### PR TITLE
perf: lazy-load dashboard pages (608KB → 306KB)

### DIFF
--- a/studio-react/src/App.tsx
+++ b/studio-react/src/App.tsx
@@ -1,30 +1,34 @@
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'sonner'
 import { useAuthStore } from './stores/authStore'
 import AppLayout from './layouts/AppLayout'
+
+// Eager: login is the entry point
 import LoginPage from './pages/LoginPage'
-import DashboardPage from './pages/DashboardPage'
-import TasksPage from './pages/TasksPage'
-import ChannelsPage from './pages/ChannelsPage'
-import MessagesPage from './pages/MessagesPage'
-import PlansPage from './pages/PlansPage'
-import BugsPage from './pages/BugsPage'
-import AssetsPage from './pages/AssetsPage'
-import OperatorsPage from './pages/OperatorsPage'
-import ApprovalsPage from './pages/ApprovalsPage'
-import DronesPage from './pages/DronesPage'
-import ConceptsPage from './pages/ConceptsPage'
-import ContextPage from './pages/ContextPage'
-import WebhooksPage from './pages/WebhooksPage'
-import AdminOpsPage from './pages/AdminOpsPage'
-import NetworkHealthPage from './pages/NetworkHealthPage'
-import OnboardingPage from './pages/OnboardingPage'
-import PluginsPage from './pages/PluginsPage'
-import SpawnsPage from './pages/SpawnsPage'
-import AnalyticsPage from './pages/AnalyticsPage'
-import FeedbackPage from './pages/FeedbackPage'
-import InboxPage from './pages/InboxPage'
+
+// Lazy: all other pages loaded on demand
+const DashboardPage = lazy(() => import('./pages/DashboardPage'))
+const InboxPage = lazy(() => import('./pages/InboxPage'))
+const ChannelsPage = lazy(() => import('./pages/ChannelsPage'))
+const TasksPage = lazy(() => import('./pages/TasksPage'))
+const MessagesPage = lazy(() => import('./pages/MessagesPage'))
+const PlansPage = lazy(() => import('./pages/PlansPage'))
+const BugsPage = lazy(() => import('./pages/BugsPage'))
+const AssetsPage = lazy(() => import('./pages/AssetsPage'))
+const OperatorsPage = lazy(() => import('./pages/OperatorsPage'))
+const ApprovalsPage = lazy(() => import('./pages/ApprovalsPage'))
+const DronesPage = lazy(() => import('./pages/DronesPage'))
+const ConceptsPage = lazy(() => import('./pages/ConceptsPage'))
+const ContextPage = lazy(() => import('./pages/ContextPage'))
+const WebhooksPage = lazy(() => import('./pages/WebhooksPage'))
+const AdminOpsPage = lazy(() => import('./pages/AdminOpsPage'))
+const NetworkHealthPage = lazy(() => import('./pages/NetworkHealthPage'))
+const OnboardingPage = lazy(() => import('./pages/OnboardingPage'))
+const PluginsPage = lazy(() => import('./pages/PluginsPage'))
+const SpawnsPage = lazy(() => import('./pages/SpawnsPage'))
+const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'))
+const FeedbackPage = lazy(() => import('./pages/FeedbackPage'))
 
 export default function App() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
@@ -46,37 +50,39 @@ export default function App() {
           },
         }}
       />
-      <Routes>
-        <Route
-          path="/login"
-          element={isAuthenticated ? <Navigate to="/" replace /> : <LoginPage />}
-        />
-        <Route
-          element={isAuthenticated ? <AppLayout /> : <Navigate to="/login" replace />}
-        >
-          <Route index element={<DashboardPage />} />
-          <Route path="inbox" element={<InboxPage />} />
-          <Route path="channels" element={<ChannelsPage />} />
-          <Route path="tasks" element={<TasksPage />} />
-          <Route path="messages" element={<MessagesPage />} />
-          <Route path="plans" element={<PlansPage />} />
-          <Route path="bugs" element={<BugsPage />} />
-          <Route path="assets" element={<AssetsPage />} />
-          <Route path="operators" element={<OperatorsPage />} />
-          <Route path="approvals" element={<ApprovalsPage />} />
-          <Route path="drones" element={<DronesPage />} />
-          <Route path="concepts" element={<ConceptsPage />} />
-          <Route path="context" element={<ContextPage />} />
-          <Route path="webhooks" element={<WebhooksPage />} />
-          <Route path="ops" element={<AdminOpsPage />} />
-          <Route path="health" element={<NetworkHealthPage />} />
-          <Route path="onboarding" element={<OnboardingPage />} />
-          <Route path="plugins" element={<PluginsPage />} />
-          <Route path="spawns" element={<SpawnsPage />} />
-          <Route path="analytics" element={<AnalyticsPage />} />
-          <Route path="feedback" element={<FeedbackPage />} />
-        </Route>
-      </Routes>
+      <Suspense>
+        <Routes>
+          <Route
+            path="/login"
+            element={isAuthenticated ? <Navigate to="/" replace /> : <LoginPage />}
+          />
+          <Route
+            element={isAuthenticated ? <AppLayout /> : <Navigate to="/login" replace />}
+          >
+            <Route index element={<DashboardPage />} />
+            <Route path="inbox" element={<InboxPage />} />
+            <Route path="channels" element={<ChannelsPage />} />
+            <Route path="tasks" element={<TasksPage />} />
+            <Route path="messages" element={<MessagesPage />} />
+            <Route path="plans" element={<PlansPage />} />
+            <Route path="bugs" element={<BugsPage />} />
+            <Route path="assets" element={<AssetsPage />} />
+            <Route path="operators" element={<OperatorsPage />} />
+            <Route path="approvals" element={<ApprovalsPage />} />
+            <Route path="drones" element={<DronesPage />} />
+            <Route path="concepts" element={<ConceptsPage />} />
+            <Route path="context" element={<ContextPage />} />
+            <Route path="webhooks" element={<WebhooksPage />} />
+            <Route path="ops" element={<AdminOpsPage />} />
+            <Route path="health" element={<NetworkHealthPage />} />
+            <Route path="onboarding" element={<OnboardingPage />} />
+            <Route path="plugins" element={<PluginsPage />} />
+            <Route path="spawns" element={<SpawnsPage />} />
+            <Route path="analytics" element={<AnalyticsPage />} />
+            <Route path="feedback" element={<FeedbackPage />} />
+          </Route>
+        </Routes>
+      </Suspense>
     </BrowserRouter>
   )
 }


### PR DESCRIPTION
## Performance

Converts all 21 page imports in App.tsx to `React.lazy()` with a `Suspense` wrapper. 

**Before**: Single 608KB chunk (Vite warning)
**After**: 306KB main chunk + 21 page chunks (3-25KB each, loaded on demand)

Initial page load is ~50% smaller. Subsequent page navigations load their chunk on demand.

### Test plan
- [ ] Login page loads without flash
- [ ] Dashboard loads after login
- [ ] Navigate between all pages — each should load without errors
- [ ] No blank screens or missing content