### PR TITLE
Fix mobile landing page not loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -802,6 +802,8 @@
       .loop-diagram { flex-direction: column; gap: 0.5rem; }
       .loop-arrow { transform: rotate(90deg); }
       footer { flex-direction: column; align-items: flex-start; }
+      body::before { display: none; }
+      .signup-name-grid { grid-template-columns: 1fr !important; }
     }
   </style>
 </head>
@@ -1191,7 +1193,7 @@
       <p style="color:var(--text-dim);margin-bottom:2.5rem;font-size:1.05rem;">$99/mo — we'll spin up your private Mycelium instance. Five minutes to your first coordinating agent.</p>
 
       <form id="waitlist-form" style="display:flex;flex-direction:column;gap:1rem;">
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
+        <div class="signup-name-grid" style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
           <div>
             <label style="display:block;font-size:0.8rem;font-family:'JetBrains Mono',monospace;color:var(--text-dim);margin-bottom:0.4rem;letter-spacing:0.05em;">NAME</label>
             <input type="text" name="name" placeholder="Greatness" style="width:100%;background:var(--surface-raised);border:1px solid var(--border);border-radius:6px;padding:0.65rem 0.9rem;color:var(--text);font-size:0.95rem;outline:none;transition:border-color 0.15s;" onfocus="this.style.borderColor='rgba(212,168,71,0.4)'" onblur="this.style.borderColor='var(--border)'">


### PR DESCRIPTION
## Summary
- Disable `feTurbulence` SVG noise filter on mobile (`body::before { display: none }` at <640px) — this filter causes mobile browsers to hang/blank-screen
- Make signup form name/subdomain grid collapse to single column on mobile

## Test plan
- [ ] Load mycelium.fyi on a mobile device/emulator — page should render immediately
- [ ] Verify signup form is usable on narrow screens (fields stack vertically)
- [ ] Desktop unchanged — noise texture still renders on wider viewports