### PR TITLE
Remove insider tagline from scripts and comments

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,4 @@
 // =============== MYCELIUM — Distributed Development Platform ===============
-// The printing press of ideas.
 
 // Crash diagnostics — ensure unhandled errors always print before exit
 process.on('uncaughtException', (err) => {

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -1,5 +1,5 @@
 -- =============== MYCELIUM -- Platform Schema ===============
--- Distributed development platform. The printing press of ideas.
+-- Distributed development platform.
 
 -- Registered agents (AI instances, bots, etc.)
 CREATE TABLE IF NOT EXISTS dv_agents (

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -27,7 +27,7 @@ fail()  { echo -e "${RED}[mycelium]${NC} $1"; exit 1; }
 echo ""
 echo -e "${AMBER}${BOLD}  ╔══════════════════════════════════════╗${NC}"
 echo -e "${AMBER}${BOLD}  ║         🍄 MYCELIUM                  ║${NC}"
-echo -e "${AMBER}${BOLD}  ║   The printing press of ideas.       ║${NC}"
+echo -e "${AMBER}${BOLD}  ║   AI Agent Coordination Platform     ║${NC}"
 echo -e "${AMBER}${BOLD}  ╚══════════════════════════════════════╝${NC}"
 echo ""
 


### PR DESCRIPTION
## Summary
- Replace "The printing press of ideas" in install.sh banner with "AI Agent Coordination Platform"
- Remove tagline comment from server/index.js and schema.sql
- Follows up on PR #64 which cleaned the landing page

## Test plan
- [ ] Verify install.sh banner renders correctly
- [ ] Verify server starts without issues (comment-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)