### PR TITLE
Token Reduction: Slim Boot + Heartbeat + Overview

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -2356,6 +2356,83 @@ export function getOverview(userId) {
   };
 }
 
+// =============== SLIM OVERVIEW ===============
+
+function timeSince(dateStr) {
+  var diff = Date.now() - new Date(dateStr).getTime();
+  if (diff < 60000) return Math.round(diff / 1000) + 's ago';
+  if (diff < 3600000) return Math.round(diff / 60000) + 'm ago';
+  if (diff < 86400000) return Math.round(diff / 3600000) + 'h ago';
+  return Math.round(diff / 86400000) + 'd ago';
+}
+
+export function getSlimOverview() {
+  // Agent statuses — compact
+  var agents = db.prepare(
+    "SELECT id, status, working_on, last_heartbeat FROM dv_agents ORDER BY created_at"
+  ).all().map(function (a) {
+    var hb = a.last_heartbeat ? timeSince(a.last_heartbeat) : 'never';
+    return { id: a.id, status: a.status, working_on: a.working_on || '', heartbeat: hb };
+  });
+
+  // Counts
+  var counts = {
+    tasks_open: db.prepare("SELECT COUNT(*) as c FROM dv_tasks WHERE status = 'open'").get().c,
+    tasks_in_progress: db.prepare("SELECT COUNT(*) as c FROM dv_tasks WHERE status = 'in_progress'").get().c,
+    bugs_open: db.prepare("SELECT COUNT(*) as c FROM dv_bugs WHERE status = 'open'").get().c,
+    plans_active: db.prepare("SELECT COUNT(*) as c FROM dv_plans WHERE status = 'active'").get().c,
+    requests_pending: db.prepare("SELECT COUNT(*) as c FROM dv_messages WHERE msg_type = 'request' AND status IN ('sent', 'pending')").get().c,
+    approvals_pending: db.prepare("SELECT COUNT(*) as c FROM dv_approvals WHERE status = 'pending'").get().c,
+    drones_online: db.prepare("SELECT COUNT(*) as c FROM dv_agents WHERE agent_type = 'drone' AND status = 'online'").get().c,
+    drone_jobs_pending: db.prepare("SELECT COUNT(*) as c FROM dv_drone_jobs WHERE status = 'pending'").get().c
+  };
+
+  // Attention array — server-side triage
+  var attention = [];
+
+  // Stale requests (>1h unresolved)
+  var staleRequests = db.prepare(
+    "SELECT id, from_agent, content, created_at FROM dv_messages WHERE msg_type = 'request' AND status IN ('sent', 'pending') AND created_at < datetime('now', '-1 hour') ORDER BY created_at ASC LIMIT 5"
+  ).all();
+  for (var r of staleRequests) {
+    attention.push({ type: 'stale_request', id: r.id, from: r.from_agent, title: r.content.slice(0, 80), action: 'respond', age: timeSince(r.created_at) });
+  }
+
+  // Pending approvals
+  var pendingApprovals = db.prepare(
+    "SELECT id, title, created_at FROM dv_approvals WHERE status = 'pending' ORDER BY created_at ASC LIMIT 5"
+  ).all();
+  for (var a of pendingApprovals) {
+    attention.push({ type: 'pending_approval', id: a.id, title: a.title, action: 'approve_or_deny', age: timeSince(a.created_at) });
+  }
+
+  // Stale tasks (in_progress >6h without update)
+  var staleTasks = db.prepare(
+    "SELECT t.id, t.title, t.assignee, t.updated_at FROM dv_tasks t WHERE t.status = 'in_progress' AND t.updated_at < datetime('now', '-6 hours') ORDER BY t.updated_at ASC LIMIT 5"
+  ).all();
+  for (var t of staleTasks) {
+    attention.push({ type: 'stale_task', id: t.id, assignee: t.assignee, title: t.title, action: 'reassign_or_unblock', age: timeSince(t.updated_at) });
+  }
+
+  // Unassigned bugs
+  var unassignedBugs = db.prepare(
+    "SELECT id, title, severity, created_at FROM dv_bugs WHERE status = 'open' AND (assignee IS NULL OR assignee = '') ORDER BY CASE severity WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END, created_at ASC LIMIT 5"
+  ).all();
+  for (var b of unassignedBugs) {
+    attention.push({ type: 'unassigned_bug', id: b.id, title: b.title, severity: b.severity, action: 'assign', age: timeSince(b.created_at) });
+  }
+
+  // Recent activity — 5 one-liners
+  var recentEvents = db.prepare(
+    "SELECT summary, created_at FROM dv_events ORDER BY created_at DESC LIMIT 5"
+  ).all();
+  var recent_activity = recentEvents.map(function (e) {
+    return e.summary + ' (' + timeSince(e.created_at) + ')';
+  });
+
+  return { agents: agents, counts: counts, attention: attention, recent_activity: recent_activity };
+}
+
 // =============== PLUGINS ===============
 
 export function getDB() { return db; }

--- a/server/db.js
+++ b/server/db.js
@@ -922,15 +922,19 @@ export function getSlimBootPayload(agentId) {
   // Auto-heartbeat on boot
   updateAgentHeartbeat(agentId, 'online', agent.working_on);
 
-  // Counts only — no full records
+  // Fetch directives and requests first — used for both counts and content
+  var pendingDirectives = db.prepare(
+    "SELECT * FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
+  ).all(agentId);
+  var pendingRequests = listPendingRequests(agentId);
+
+  // Counts — derive from fetched data where possible
   var counts = {
-    directives: db.prepare(
-      "SELECT COUNT(*) as c FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending')"
+    directives: pendingDirectives.length,
+    requests: pendingRequests.length,
+    messages_unread: db.prepare(
+      "SELECT COUNT(*) as c FROM dv_messages WHERE (to_agent = ? OR to_agent IS NULL) AND msg_type IN ('message', 'info') AND status = 'sent'"
     ).get(agentId).c,
-    requests: db.prepare(
-      "SELECT COUNT(*) as c FROM dv_messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('sent', 'pending')"
-    ).get(agentId).c,
-    messages_unread: countPendingForAgent(agentId),
     tasks_mine: db.prepare(
       "SELECT COUNT(*) as c FROM dv_tasks WHERE assignee = ? AND status IN ('open', 'in_progress')"
     ).get(agentId).c,
@@ -944,12 +948,6 @@ export function getSlimBootPayload(agentId) {
 
   // Role contract — small, always needed
   var roleContract = buildRoleContract(agent, agentId);
-
-  // Work queue — top 5, title+type+id only
-  var pendingDirectives = db.prepare(
-    "SELECT * FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
-  ).all(agentId);
-  var pendingRequests = listPendingRequests(agentId);
   var myTasks = db.prepare(
     "SELECT * FROM dv_tasks WHERE assignee = ? AND status IN ('open', 'in_progress') ORDER BY priority DESC, updated_at DESC"
   ).all(agentId);

--- a/server/db.js
+++ b/server/db.js
@@ -915,6 +915,89 @@ export function getBootPayload(agentId) {
   };
 }
 
+export function getSlimBootPayload(agentId) {
+  var agent = getAgent(agentId);
+  if (!agent) return null;
+
+  // Auto-heartbeat on boot
+  updateAgentHeartbeat(agentId, 'online', agent.working_on);
+
+  // Counts only — no full records
+  var counts = {
+    directives: db.prepare(
+      "SELECT COUNT(*) as c FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending')"
+    ).get(agentId).c,
+    requests: db.prepare(
+      "SELECT COUNT(*) as c FROM dv_messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('sent', 'pending')"
+    ).get(agentId).c,
+    messages_unread: countPendingForAgent(agentId),
+    tasks_mine: db.prepare(
+      "SELECT COUNT(*) as c FROM dv_tasks WHERE assignee = ? AND status IN ('open', 'in_progress')"
+    ).get(agentId).c,
+    bugs_open: db.prepare(
+      "SELECT COUNT(*) as c FROM dv_bugs WHERE status = 'open'"
+    ).get().c,
+    plans_active: db.prepare(
+      "SELECT COUNT(*) as c FROM dv_plans WHERE (project_id = ? OR project_id = '') AND status = 'active'"
+    ).get(agent.project_id).c
+  };
+
+  // Role contract — small, always needed
+  var roleContract = buildRoleContract(agent, agentId);
+
+  // Work queue — top 5, title+type+id only
+  var pendingDirectives = db.prepare(
+    "SELECT * FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
+  ).all(agentId);
+  var pendingRequests = listPendingRequests(agentId);
+  var myTasks = db.prepare(
+    "SELECT * FROM dv_tasks WHERE assignee = ? AND status IN ('open', 'in_progress') ORDER BY priority DESC, updated_at DESC"
+  ).all(agentId);
+  var openBugs = listBugs({ status: 'open', limit: 5 });
+  var myPlans = listPlans({ project_id: agent.project_id, limit: 5 });
+  var fullQueue = buildWorkQueue(agentId, agent.project_id, pendingDirectives, pendingRequests, myTasks, openBugs, myPlans);
+  var workQueue = fullQueue.slice(0, 5).map(function (item) {
+    return { type: item.type, id: item.id, title: item.title };
+  });
+
+  // Pending directives and requests — blocking, agents need full content
+  var slimDirectives = pendingDirectives.map(function (d) {
+    return { id: d.id, from: d.from_agent, content: d.content };
+  });
+  var slimRequests = pendingRequests.map(function (r) {
+    return { id: r.id, from: r.from_agent, content: r.content };
+  });
+
+  // Other agents — compact
+  var otherAgents = db.prepare(
+    "SELECT id, status, working_on FROM dv_agents WHERE id != ? AND (project_id = ? OR last_heartbeat > datetime('now', '-7 days')) ORDER BY created_at"
+  ).all(agentId, agent.project_id);
+
+  // Sleep mode + autonomous mode — needed for MCP night directives
+  var sleepMode = getSleepMode();
+  var autonomousMode = isNetworkAutonomous();
+  var operatorsAvailable = getAvailableOperators().length;
+
+  var capabilities = [];
+  try { capabilities = JSON.parse(agent.capabilities || '[]'); } catch (e) { /* */ }
+
+  return {
+    agent: { id: agent.id, role: agent.role, project: agent.project_id, capabilities: capabilities },
+    role_contract: roleContract,
+    counts: counts,
+    work_queue: workQueue,
+    pending_directives: slimDirectives,
+    pending_requests: slimRequests,
+    other_agents: otherAgents.map(function (a) {
+      return { id: a.id, status: a.status, working_on: a.working_on || '' };
+    }),
+    sleep_mode: sleepMode,
+    autonomous_mode: autonomousMode,
+    operators_available: operatorsAvailable,
+    server_time: new Date().toISOString()
+  };
+}
+
 // Build a role contract from agent fields + context keys
 function buildRoleContract(agent, agentId) {
   var capabilities = [];

--- a/server/db.js
+++ b/server/db.js
@@ -1043,7 +1043,7 @@ function buildRoleContract(agent, agentId) {
 }
 
 // Build a prioritized work queue: what should this agent do next?
-function buildWorkQueue(agentId, projectId, directives, requests, tasks, bugs, plans) {
+export function buildWorkQueue(agentId, projectId, directives, requests, tasks, bugs, plans) {
   var queue = [];
 
   // Priority 1: Blocking directives (MUST respond first)

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -102,7 +102,7 @@ import {
   createMessage, createRequest, getMessage,
   acknowledgeMessage, resolveMessage, listPendingRequests,
   listMessages, listThreads, bulkDeleteMessages,
-  getBootPayload, getSlimBootPayload, getOverview,
+  getBootPayload, getSlimBootPayload, getOverview, getSlimOverview, buildWorkQueue,
   createBug, getBug, listBugs, updateBug, deleteBug, countBugs,
   createPlan, getPlan, listPlans, updatePlan, deletePlan,
   createPlanStep, updatePlanStep, deletePlanStep, reorderPlanSteps,
@@ -614,21 +614,31 @@ router.get('/work/:agentId', function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
   var agentId = req.params.agentId;
-  // Agents can only access their own work queue
   if (!req._authIsAdmin && who !== agentId) {
     return res.status(403).json({ error: 'Can only access your own work queue' });
   }
-  var payload = getBootPayload(agentId);
-  if (!payload) return res.status(404).json({ error: 'Agent not found' });
-  var queue = payload.work_queue || [];
+  var agent = getAgent(agentId);
+  if (!agent) return res.status(404).json({ error: 'Agent not found' });
 
-  // Auto-claim: grab the top item and assign it
+  // Build work queue directly — no full boot payload needed
+  var db = getDB();
+  var pendingDirectives = db.prepare(
+    "SELECT * FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
+  ).all(agentId);
+  var pendingRequests = listPendingRequests(agentId);
+  var myTasks = db.prepare(
+    "SELECT * FROM dv_tasks WHERE assignee = ? AND status IN ('open', 'in_progress') ORDER BY priority DESC, updated_at DESC"
+  ).all(agentId);
+  var openBugs = listBugs({ status: 'open', limit: 20 });
+  var myPlans = listPlans({ project_id: agent.project_id, limit: 20 });
+  var queue = buildWorkQueue(agentId, agent.project_id, pendingDirectives, pendingRequests, myTasks, openBugs, myPlans);
+
+  // Auto-claim top item
   if (req.query.auto_claim === 'true' && queue.length > 0) {
     var top = queue[0];
     var claimed = null;
 
     if (top.type === 'directive' || top.type === 'request') {
-      // Directives and requests aren't claimable — just return them
       claimed = top;
     } else if (top.type === 'plan_step' || top.type === 'plan_step_unassigned') {
       updatePlanStep(top.id, { assignee: agentId, status: 'in_progress' });
@@ -2306,8 +2316,11 @@ router.post('/agents/:id/savepoint', function (req, res) {
 // Full studio overview (for dashboard)
 router.get('/admin/overview', function (req, res) {
   if (!checkAdmin(req, res)) return;
-  var who = getAdminDisplayName(req);
-  res.json(getOverview(who));
+  if (req.query.verbose === 'true') {
+    var who = getAdminDisplayName(req);
+    return res.json(getOverview(who));
+  }
+  res.json(getSlimOverview());
 });
 
 // Actionable items needing decisions (admin only)

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -726,9 +726,11 @@ router.post('/agents/heartbeat', function (req, res) {
     try { updateDroneDiagnostics(agentId, stateSnapshot.system_info); } catch (e) { /* non-critical */ }
   }
 
-  // Include pending counts so agents know if they have unread messages
-  var pending = countPendingForAgent(agentId);
-  var response = { ok: true, agent: agentId, status: status, pending: pending };
+  // Slim heartbeat: pending count + wake flag only
+  var pendingCounts = countPendingForAgent(agentId);
+  var pending = pendingCounts.requests + pendingCounts.directives + pendingCounts.unread;
+  var wake = (pendingCounts.directives + pendingCounts.requests) > 0;
+  var response = { ok: true, pending: pending, wake: wake };
 
   // Auto-dispatch: if agent just came online or is idle with no work, try to assign
   if (!workingOn && (status === 'online' || status === 'idle')) {
@@ -737,14 +739,6 @@ router.post('/agents/heartbeat', function (req, res) {
       if (dispatched.length > 0) response.auto_dispatched = dispatched;
     } catch (e) { /* non-critical */ }
   }
-
-  // Include work queue so agents discover new work on heartbeat
-  try {
-    var payload = getBootPayload(agentId);
-    if (payload && payload.work_queue && payload.work_queue.length > 0) {
-      response.work_queue = payload.work_queue;
-    }
-  } catch (e) { /* non-critical */ }
 
   res.json(response);
 });

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -102,7 +102,7 @@ import {
   createMessage, createRequest, getMessage,
   acknowledgeMessage, resolveMessage, listPendingRequests,
   listMessages, listThreads, bulkDeleteMessages,
-  getBootPayload, getOverview,
+  getBootPayload, getSlimBootPayload, getOverview,
   createBug, getBug, listBugs, updateBug, deleteBug, countBugs,
   createPlan, getPlan, listPlans, updatePlan, deletePlan,
   createPlanStep, updatePlanStep, deletePlanStep, reorderPlanSteps,
@@ -156,6 +156,16 @@ import { broadcast, addClient, clientCount } from '../eventBus.js';
 var ADMIN_KEY = process.env.ADMIN_KEY;
 var JWT_SECRET = process.env.JWT_SECRET;
 var STUDIO_JWT_EXPIRY = '7d';
+
+function formatSavepointSummary(diff) {
+  if (!diff || !diff.summary) return 'No changes since last session.';
+  var parts = [];
+  if (diff.new_messages) parts.push(diff.new_messages + ' new message' + (diff.new_messages > 1 ? 's' : ''));
+  if (diff.task_changes) parts.push(diff.task_changes + ' task change' + (diff.task_changes > 1 ? 's' : ''));
+  if (diff.plan_changes) parts.push(diff.plan_changes + ' plan update' + (diff.plan_changes > 1 ? 's' : ''));
+  if (diff.context_changes) parts.push(diff.context_changes + ' context change' + (diff.context_changes > 1 ? 's' : ''));
+  return parts.length > 0 ? parts.join(', ') : diff.summary || 'No changes since last session.';
+}
 
 // ---- MCP Config Helpers ----
 function getInstanceUrl(req) {
@@ -573,18 +583,27 @@ router.get('/waitlist', function (req, res) {
 router.get('/boot/:agentId', function (req, res) {
   var agentId = checkAgent(req, res);
   if (!agentId) return;
-  // Agent can only boot as themselves
   if (agentId !== req.params.agentId) {
     return res.status(403).json({ error: 'Agent key does not match agent ID' });
   }
-  var payload = getBootPayload(agentId);
+
+  // Verbose mode returns legacy full payload
+  if (req.query.verbose === 'true') {
+    var fullPayload = getBootPayload(agentId);
+    if (!fullPayload) return res.status(404).json({ error: 'Agent not found' });
+    fullPayload.savepoint = computeSavepointDiff(agentId);
+    fullPayload.sleep_mode = getSleepMode();
+    fullPayload.autonomous_mode = isNetworkAutonomous();
+    fullPayload.operators_available = getAvailableOperators().length;
+    emitEvent('agent_boot', agentId, null, agentId + ' booted (verbose)');
+    return res.json(fullPayload);
+  }
+
+  // Default: slim boot
+  var payload = getSlimBootPayload(agentId);
   if (!payload) return res.status(404).json({ error: 'Agent not found' });
-  // Attach savepoint diff
   payload.savepoint = computeSavepointDiff(agentId);
-  // Attach sleep mode / autonomous status
-  payload.sleep_mode = getSleepMode();
-  payload.autonomous_mode = isNetworkAutonomous();
-  payload.operators_available = getAvailableOperators().length;
+  payload.changes_since_last = formatSavepointSummary(computeSavepointDiff(agentId));
   emitEvent('agent_boot', agentId, null, agentId + ' booted');
   res.json(payload);
 });


### PR DESCRIPTION
## Summary
- Add `getSlimBootPayload()` — compact boot returning counts + top-5 work queue + blocking items (~300-500 tokens, down from 3-5K)
- Slim heartbeat response: `{ ok, pending, wake }` — removes `getBootPayload()` call that was fetching 3-5K tokens per heartbeat
- Add `getSlimOverview()` with server-side attention array for admin triage (~400-600 tokens, down from 15-25K)
- Default slim, `?verbose=true` for legacy full payloads
- Work route builds queue directly via `buildWorkQueue()` instead of full boot payload

## Design
See `docs/plans/2026-03-05-token-reduction-design.md` (network-approved, Plan #34)

## Test plan
- [ ] Verify `GET /boot/:agentId` returns slim payload
- [ ] Verify `GET /boot/:agentId?verbose=true` returns full payload
- [ ] Verify heartbeat returns `{ ok, pending, wake }`
- [ ] Verify `GET /admin/overview` returns slim with attention array
- [ ] Verify `GET /admin/overview?verbose=true` returns full dump
- [ ] Verify `GET /work/:agentId` builds queue correctly

## Companion PRs
- dioverse-mcp: MCP tool response compression
- mycelium-runner: System prompt compression

🤖 Generated with [Claude Code](https://claude.com/claude-code)