### PR TITLE
Rename dioverse-mcp → mycelium-mcp references

### DIFF
--- a/admin-claude/api.js
+++ b/admin-claude/api.js
@@ -1,5 +1,5 @@
 // HTTP client for the Mycelium API — admin-claude edition
-// Based on dioverse-mcp/src/api.js pattern
+// Based on mycelium-mcp/src/api.js pattern
 
 import { MYCELIUM_API_URL, MYCELIUM_ADMIN_KEY, AGENT_ID } from './config.js';
 

--- a/docs/plans/2026-03-01-command-structure-v2.md
+++ b/docs/plans/2026-03-01-command-structure-v2.md
@@ -1094,7 +1094,7 @@ cd D:/mycelium && git add public/studio/ && git commit -m "feat: kill switch but
 ### Task 22: MCP — `studio_request_work`
 
 **Files:**
-- Modify: `D:/dioverse-mcp/src/tools.js` (add tool after approval tools, around line 764)
+- Modify: `D:/mycelium-mcp/src/tools.js` (add tool after approval tools, around line 764)
 
 **Step 1: Add tool**
 
@@ -1123,7 +1123,7 @@ cd D:/mycelium && git add public/studio/ && git commit -m "feat: kill switch but
 **Step 2: Commit**
 
 ```bash
-cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_request_work MCP tool"
+cd D:/mycelium-mcp && git add src/tools.js && git commit -m "feat: studio_request_work MCP tool"
 ```
 
 ---
@@ -1131,7 +1131,7 @@ cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_reques
 ### Task 23: MCP — `studio_file_directive`
 
 **Files:**
-- Modify: `D:/dioverse-mcp/src/tools.js`
+- Modify: `D:/mycelium-mcp/src/tools.js`
 
 **Step 1: Add tool**
 
@@ -1160,7 +1160,7 @@ cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_reques
 **Step 2: Commit**
 
 ```bash
-cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_file_directive MCP tool"
+cd D:/mycelium-mcp && git add src/tools.js && git commit -m "feat: studio_file_directive MCP tool"
 ```
 
 ---
@@ -1168,7 +1168,7 @@ cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_file_d
 ### Task 24: MCP — `studio_upload_asset`
 
 **Files:**
-- Modify: `D:/dioverse-mcp/src/tools.js`
+- Modify: `D:/mycelium-mcp/src/tools.js`
 
 **Step 1: Add tool**
 
@@ -1195,7 +1195,7 @@ Note: MCP tool can't directly upload files (no multipart support). Instead, upda
 **Step 2: Commit**
 
 ```bash
-cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_upload_asset MCP tool"
+cd D:/mycelium-mcp && git add src/tools.js && git commit -m "feat: studio_upload_asset MCP tool"
 ```
 
 ---
@@ -1203,7 +1203,7 @@ cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_upload
 ### Task 25: MCP — `studio_download_asset`
 
 **Files:**
-- Modify: `D:/dioverse-mcp/src/tools.js`
+- Modify: `D:/mycelium-mcp/src/tools.js`
 
 **Step 1: Add tool**
 
@@ -1227,7 +1227,7 @@ cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_upload
 **Step 2: Commit**
 
 ```bash
-cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_download_asset MCP tool"
+cd D:/mycelium-mcp && git add src/tools.js && git commit -m "feat: studio_download_asset MCP tool"
 ```
 
 ---
@@ -1235,7 +1235,7 @@ cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: studio_downlo
 ### Task 26: Update Boot Tool for Session Context + Directives
 
 **Files:**
-- Modify: `D:/dioverse-mcp/src/tools.js:72-134` (update boot handler output)
+- Modify: `D:/mycelium-mcp/src/tools.js:72-134` (update boot handler output)
 
 **Step 1: Update boot handler**
 
@@ -1280,7 +1280,7 @@ In `formatOverview` (around line 935), add sections for operators and instance c
 **Step 3: Commit**
 
 ```bash
-cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: boot tool shows directives, operators, instance config"
+cd D:/mycelium-mcp && git add src/tools.js && git commit -m "feat: boot tool shows directives, operators, instance config"
 ```
 
 ---
@@ -1288,11 +1288,11 @@ cd D:/dioverse-mcp && git add src/tools.js && git commit -m "feat: boot tool sho
 ### Task 27: Shutdown Hook for Session Summary
 
 **Files:**
-- Modify: `D:/dioverse-mcp/src/state.js` (update shutdown to write session summary)
+- Modify: `D:/mycelium-mcp/src/state.js` (update shutdown to write session summary)
 
 **Step 1: Read current state.js**
 
-Read `D:/dioverse-mcp/src/state.js` to find the shutdown handler.
+Read `D:/mycelium-mcp/src/state.js` to find the shutdown handler.
 
 **Step 2: Update shutdown**
 
@@ -1315,7 +1315,7 @@ In the shutdown handler, before the final heartbeat, write session context:
 **Step 3: Commit**
 
 ```bash
-cd D:/dioverse-mcp && git add src/state.js && git commit -m "feat: auto-save session summary on shutdown"
+cd D:/mycelium-mcp && git add src/state.js && git commit -m "feat: auto-save session summary on shutdown"
 ```
 
 ---

--- a/docs/plans/2026-03-01-outreach-pipeline-impl.md
+++ b/docs/plans/2026-03-01-outreach-pipeline-impl.md
@@ -4,7 +4,7 @@
 
 **Goal:** Port wsac-agent outreach pipeline into Mycelium as a first-class platform feature with DB tables, API routes, and MCP tools.
 
-**Architecture:** Add outreach tables to Mycelium SQLite, CRUD + pipeline action routes in Express, external API modules (YouTube, Hunter.io, Claude, Gmail) as server-side JS, and MCP tools in dioverse-mcp.
+**Architecture:** Add outreach tables to Mycelium SQLite, CRUD + pipeline action routes in Express, external API modules (YouTube, Hunter.io, Claude, Gmail) as server-side JS, and MCP tools in mycelium-mcp.
 
 **Tech Stack:** Express, better-sqlite3, googleapis (YouTube + Gmail), @anthropic-ai/sdk, node-fetch
 
@@ -355,7 +355,7 @@ router.get('/outreach/status', function (req, res) {
 ### Task 7: MCP Outreach Tools
 
 **Files:**
-- Modify: `D:/dioverse-mcp/src/tools.js` (add outreach tool registrations)
+- Modify: `D:/mycelium-mcp/src/tools.js` (add outreach tool registrations)
 
 **Step 1: Add outreach tools** — Register 9 tools with registerDual():
 - mycelium_outreach_discover

--- a/docs/plans/2026-03-03-gtm-10-users-design.md
+++ b/docs/plans/2026-03-03-gtm-10-users-design.md
@@ -62,8 +62,8 @@ Manual provisioning is fine for the first 10 — automate once demand exceeds ca
 - Write getting-started guide (15 min to first agent coordinating)
 
 **Branding cleanup (prerequisite):**
-- Rename all `DIOVERSE_*` env vars → `MYCELIUM_*` across all repos
-- Affected: `dioverse-mcp`, `mycelium-runner`, any other references
+- Rename all `MYCELIUM_*` env vars → `MYCELIUM_*` across all repos
+- Affected: `mycelium-mcp`, `mycelium-runner`, any other references
 - Update package names, READMEs, API docs
 
 ---
@@ -126,7 +126,7 @@ Operators need a human-facing layer separate from agent message traffic.
 |------|-------|-------|--------|
 | 190 | Hosted-first onboarding: landing page + instance provisioning | hijack-claude | pending |
 | 191 | Open source: publish mycelium-mcp to npm + make repo public | greatness-claude | pending |
-| 192 | Branding cleanup: rename DIOVERSE_* → MYCELIUM_* | greatness-claude | pending |
+| 192 | Branding cleanup: rename MYCELIUM_* → MYCELIUM_* | greatness-claude | pending |
 | 193 | Build in public: content strategy + first 5 posts | greatness-claude | pending |
 | 194 | Operator feedback: collect input from Hijack + Unakron | all operators | in_progress |
 | 195 | Build operator inbox | macbook-claude | pending |

--- a/docs/plans/2026-03-05-token-reduction-design.md
+++ b/docs/plans/2026-03-05-token-reduction-design.md
@@ -229,7 +229,7 @@ Platform conventions (message types, work priority order, channel types) baked i
 
 1. Merge compaction snapshots PR #2 first (MCP state tracking must be stable)
 2. Ship server changes + MCP updates together (don't break mid-deploy)
-3. Both MCP repos (dioverse-mcp + mycelium-runner/mcp) must update simultaneously
+3. Both MCP repos (mycelium-mcp + mycelium-runner/mcp) must update simultaneously
 
 ## Migration
 


### PR DESCRIPTION
## Summary
- Update all `dioverse-mcp` references to `mycelium-mcp` in plan docs and admin-claude code
- GitHub repo already renamed: `SoftBacon-Software/mycelium-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)