### PR TITLE
fix: allow agents to read across projects

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -317,11 +317,13 @@ function clearAgentKeyCache() {
 }
 
 // Check if the authenticated caller has access to a resource's project.
-// Admins and studio users bypass. Agents must match project_id OR be the assignee.
+// Admins and studio users bypass. Agents can READ any project but can only
+// WRITE to their own project (or resources assigned to them).
 function checkProjectScope(req, res, resourceProjectId, assignee) {
   if (req._authIsAdmin) return true;
   if (!req._authAgentId) return true; // studio user or admin — no scope restriction
   if (!resourceProjectId) return true; // resource has no project — allow
+  if (req.method === 'GET') return true; // agents can read across projects (shared swarm context)
   if (req._authProjectId === resourceProjectId) return true;
   if (assignee && assignee === req._authAgentId) return true; // assigned agent can update their own work across projects
   res.status(403).json({ error: 'Agent ' + req._authAgentId + ' cannot access resources in project ' + resourceProjectId });


### PR DESCRIPTION
## Summary
- `checkProjectScope()` now allows GET requests across projects
- Agents can read plans, tasks, and bugs from any project (shared swarm context)
- Write operations still scoped to own project or assigned resources

Fixes the "Agent macbook-claude cannot access resources in project willing-sacrifice" error when calling `mycelium_check_plans`.

## Test plan
- [ ] Agent in project A can `GET /plans/:id` for a plan in project B
- [ ] Agent in project A still gets 403 on `PUT /plans/:id` for project B (unless assigned)