### PR TITLE
feat: 4 first-party plugins — github-sync, daily-digest, error-monitor, cost-tracker

### DIFF
--- a/server/plugins/cost-tracker/db.js
+++ b/server/plugins/cost-tracker/db.js
@@ -1,0 +1,167 @@
+// Cost Tracker plugin DB helpers
+
+export default function createCostDB(db) {
+  return {
+    recordUsage(agentId, projectId, taskId, inputTokens, outputTokens, cacheReadTokens, costUsd, sessionId) {
+      var r = db.prepare(
+        'INSERT INTO dv_cost_entries (agent_id, project_id, task_id, input_tokens, output_tokens, cache_read_tokens, cost_usd, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id'
+      ).get(
+        agentId || '', projectId || '', taskId || null,
+        inputTokens || 0, outputTokens || 0, cacheReadTokens || 0,
+        costUsd || 0, sessionId || ''
+      );
+
+      // Upsert daily aggregate
+      var today = new Date().toISOString().split('T')[0];
+      db.prepare(
+        "INSERT INTO dv_cost_daily (date, agent_id, project_id, total_input, total_output, total_cache, total_cost, entry_count) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, 1) " +
+        "ON CONFLICT(date, agent_id, project_id) DO UPDATE SET " +
+        "total_input = total_input + excluded.total_input, " +
+        "total_output = total_output + excluded.total_output, " +
+        "total_cache = total_cache + excluded.total_cache, " +
+        "total_cost = total_cost + excluded.total_cost, " +
+        "entry_count = entry_count + 1, " +
+        "updated_at = datetime('now')"
+      ).run(today, agentId || '', projectId || '', inputTokens || 0, outputTokens || 0, cacheReadTokens || 0, costUsd || 0);
+
+      return r.id;
+    },
+
+    getEntry(id) {
+      return db.prepare('SELECT * FROM dv_cost_entries WHERE id = ?').get(id);
+    },
+
+    listEntries(filters) {
+      var where = ['1=1'];
+      var params = [];
+      if (filters.agent_id) { where.push('agent_id = ?'); params.push(filters.agent_id); }
+      if (filters.project_id) { where.push('project_id = ?'); params.push(filters.project_id); }
+      if (filters.date_from) { where.push('recorded_at >= ?'); params.push(filters.date_from); }
+      if (filters.date_to) { where.push('recorded_at <= ?'); params.push(filters.date_to + 'T23:59:59'); }
+      var limit = Math.min(filters.limit || 50, 200);
+      var offset = filters.offset || 0;
+      params.push(limit, offset);
+      return db.prepare(
+        'SELECT * FROM dv_cost_entries WHERE ' + where.join(' AND ') +
+        ' ORDER BY recorded_at DESC LIMIT ? OFFSET ?'
+      ).all.apply(
+        db.prepare('SELECT * FROM dv_cost_entries WHERE ' + where.join(' AND ') + ' ORDER BY recorded_at DESC LIMIT ? OFFSET ?'),
+        params
+      );
+    },
+
+    getDailySummary(date) {
+      return db.prepare('SELECT * FROM dv_cost_daily WHERE date = ?').all(date);
+    },
+
+    getAgentCosts(agentId, dateFrom, dateTo) {
+      var where = ['agent_id = ?'];
+      var params = [agentId];
+      if (dateFrom) { where.push('date >= ?'); params.push(dateFrom); }
+      if (dateTo) { where.push('date <= ?'); params.push(dateTo); }
+      return db.prepare(
+        'SELECT * FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'
+      ).all.apply(
+        db.prepare('SELECT * FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'),
+        params
+      );
+    },
+
+    getProjectCosts(projectId, dateFrom, dateTo) {
+      var where = ['project_id = ?'];
+      var params = [projectId];
+      if (dateFrom) { where.push('date >= ?'); params.push(dateFrom); }
+      if (dateTo) { where.push('date <= ?'); params.push(dateTo); }
+      return db.prepare(
+        'SELECT * FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'
+      ).all.apply(
+        db.prepare('SELECT * FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'),
+        params
+      );
+    },
+
+    getTotalCosts(dateFrom, dateTo) {
+      var where = ['1=1'];
+      var params = [];
+      if (dateFrom) { where.push('date >= ?'); params.push(dateFrom); }
+      if (dateTo) { where.push('date <= ?'); params.push(dateTo); }
+      var row = db.prepare(
+        'SELECT COALESCE(SUM(total_input), 0) as total_input, COALESCE(SUM(total_output), 0) as total_output, ' +
+        'COALESCE(SUM(total_cache), 0) as total_cache, COALESCE(SUM(total_cost), 0) as total_cost, ' +
+        'COALESCE(SUM(entry_count), 0) as entry_count FROM dv_cost_daily WHERE ' + where.join(' AND ')
+      ).get.apply(
+        db.prepare('SELECT COALESCE(SUM(total_input), 0) as total_input, COALESCE(SUM(total_output), 0) as total_output, ' +
+          'COALESCE(SUM(total_cache), 0) as total_cache, COALESCE(SUM(total_cost), 0) as total_cost, ' +
+          'COALESCE(SUM(entry_count), 0) as entry_count FROM dv_cost_daily WHERE ' + where.join(' AND ')),
+        params
+      );
+      return row;
+    },
+
+    getSpendToday() {
+      var today = new Date().toISOString().split('T')[0];
+      var row = db.prepare(
+        'SELECT COALESCE(SUM(total_cost), 0) as spend FROM dv_cost_daily WHERE date = ?'
+      ).get(today);
+      return row.spend;
+    },
+
+    getSpendThisWeek() {
+      var weekStart = getWeekStart();
+      var row = db.prepare(
+        'SELECT COALESCE(SUM(total_cost), 0) as spend FROM dv_cost_daily WHERE date >= ?'
+      ).get(weekStart);
+      return row.spend;
+    },
+
+    getDailyTrend(days) {
+      var d = days || 14;
+      return db.prepare(
+        'SELECT date, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
+        'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
+        'FROM dv_cost_daily WHERE date >= date("now", "-" || ? || " days") ' +
+        'GROUP BY date ORDER BY date ASC'
+      ).all(d);
+    },
+
+    getTopAgents(dateFrom, dateTo, limit) {
+      var where = ['1=1'];
+      var params = [];
+      if (dateFrom) { where.push('date >= ?'); params.push(dateFrom); }
+      if (dateTo) { where.push('date <= ?'); params.push(dateTo); }
+      var lim = limit || 10;
+      params.push(lim);
+      return db.prepare(
+        'SELECT agent_id, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
+        'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
+        'FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY agent_id ORDER BY total_cost DESC LIMIT ?'
+      ).all.apply(
+        db.prepare('SELECT agent_id, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
+          'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
+          'FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY agent_id ORDER BY total_cost DESC LIMIT ?'),
+        params
+      );
+    },
+
+    logAlert(alertType, thresholdPct, currentSpend, budgetLimit) {
+      db.prepare(
+        'INSERT INTO dv_cost_alerts (alert_type, threshold_pct, current_spend, budget_limit) VALUES (?, ?, ?, ?)'
+      ).run(alertType, thresholdPct, currentSpend, budgetLimit);
+    },
+
+    getAlerts(limit) {
+      var lim = limit || 20;
+      return db.prepare(
+        'SELECT * FROM dv_cost_alerts ORDER BY triggered_at DESC LIMIT ?'
+      ).all(lim);
+    }
+  };
+}
+
+function getWeekStart() {
+  var now = new Date();
+  var day = now.getDay();
+  var diff = now.getDate() - day + (day === 0 ? -6 : 1);
+  return new Date(now.getFullYear(), now.getMonth(), diff).toISOString().split('T')[0];
+}

--- a/server/plugins/cost-tracker/handlers.js
+++ b/server/plugins/cost-tracker/handlers.js
@@ -1,0 +1,107 @@
+// Cost Tracker event handlers
+// Subscribes to agent heartbeats to auto-record token usage.
+
+import createCostDB from './db.js';
+
+function getWeekStart() {
+  var now = new Date();
+  var day = now.getDay();
+  var diff = now.getDate() - day + (day === 0 ? -6 : 1);
+  return new Date(now.getFullYear(), now.getMonth(), diff).toISOString().split('T')[0];
+}
+
+function checkBudgetAlerts(db, core, config) {
+  var alertThreshold = parseFloat(config.alert_threshold_pct || 80) / 100;
+
+  // Daily budget check
+  var dailyBudget = parseFloat(config.budget_daily || 0);
+  if (dailyBudget > 0) {
+    var todaySpend = db.getSpendToday();
+    var pct = todaySpend / dailyBudget;
+    if (pct >= alertThreshold) {
+      var today = new Date().toISOString().split('T')[0];
+      var existing = core.db.prepare(
+        "SELECT id FROM dv_cost_alerts WHERE alert_type = 'daily_budget' AND triggered_at >= ?"
+      ).get(today);
+      if (!existing) {
+        db.logAlert('daily_budget', pct * 100, todaySpend, dailyBudget);
+        core.inbox.createInboxItemForAllOperators(
+          'cost_alert', 'cost_alert', 'daily_' + today,
+          'Daily budget alert: $' + todaySpend.toFixed(2) + ' / $' + dailyBudget.toFixed(2),
+          Math.round(pct * 100) + '% of daily budget used',
+          { spend: todaySpend, budget: dailyBudget, pct: Math.round(pct * 100) },
+          pct >= 1.0 ? 'urgent' : 'normal'
+        );
+      }
+    }
+  }
+
+  // Weekly budget check
+  var weeklyBudget = parseFloat(config.budget_weekly || 0);
+  if (weeklyBudget > 0) {
+    var weekSpend = db.getSpendThisWeek();
+    var weekPct = weekSpend / weeklyBudget;
+    if (weekPct >= alertThreshold) {
+      var weekStart = getWeekStart();
+      var existingWeek = core.db.prepare(
+        "SELECT id FROM dv_cost_alerts WHERE alert_type = 'weekly_budget' AND triggered_at >= ?"
+      ).get(weekStart);
+      if (!existingWeek) {
+        db.logAlert('weekly_budget', weekPct * 100, weekSpend, weeklyBudget);
+        core.inbox.createInboxItemForAllOperators(
+          'cost_alert', 'cost_alert', 'weekly_' + weekStart,
+          'Weekly budget alert: $' + weekSpend.toFixed(2) + ' / $' + weeklyBudget.toFixed(2),
+          Math.round(weekPct * 100) + '% of weekly budget used',
+          { spend: weekSpend, budget: weeklyBudget, pct: Math.round(weekPct * 100) },
+          weekPct >= 1.0 ? 'urgent' : 'normal'
+        );
+      }
+    }
+  }
+}
+
+export function registerHooks(core) {
+  var db = createCostDB(core.db);
+
+  core.onEvent('agent_heartbeat', function (eventData) {
+    try {
+      var data = eventData.data || {};
+      var tokens = data.tokens || data.token_usage;
+      if (!tokens) return;
+      if (!tokens.input && !tokens.output) return;
+
+      // Get pricing config
+      var getConfig = function (key, fallback) {
+        var row = core.db.prepare(
+          "SELECT value FROM dv_plugin_config WHERE plugin_name = 'cost-tracker' AND key = ?"
+        ).get(key);
+        return row ? parseFloat(row.value) : fallback;
+      };
+      var priceInput = getConfig('price_input_mtok', 15) / 1000000;
+      var priceOutput = getConfig('price_output_mtok', 75) / 1000000;
+      var priceCache = getConfig('price_cache_read_mtok', 1.5) / 1000000;
+
+      var input = parseInt(tokens.input) || 0;
+      var output = parseInt(tokens.output) || 0;
+      var cache = parseInt(tokens.cache_read) || 0;
+      var cost = (input * priceInput) + (output * priceOutput) + (cache * priceCache);
+
+      var agentId = data.agent_id || eventData.agent || '';
+      var projectId = data.project_id || eventData.project_id || '';
+
+      db.recordUsage(agentId, projectId, null, input, output, cache, cost, data.session_id || '');
+
+      // Check budgets
+      var config = {};
+      var rows = core.db.prepare(
+        "SELECT key, value FROM dv_plugin_config WHERE plugin_name = 'cost-tracker'"
+      ).all();
+      for (var r of rows) config[r.key] = r.value;
+      checkBudgetAlerts(db, core, config);
+
+      console.log('[cost-tracker] Recorded ' + input + '/' + output + ' tokens for ' + agentId + ' ($' + cost.toFixed(4) + ')');
+    } catch (e) {
+      console.error('[cost-tracker] Heartbeat hook error:', e.message);
+    }
+  });
+}

--- a/server/plugins/cost-tracker/mcp-tools.json
+++ b/server/plugins/cost-tracker/mcp-tools.json
@@ -1,0 +1,85 @@
+[
+  {
+    "name": "mycelium_cost_report",
+    "description": "Get cost summary for current period. Returns today's spend, week's spend, budget status, and top agents.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "mycelium_cost_record",
+    "description": "Record token usage for current session. Calculates cost automatically from configured pricing.",
+    "inputSchema": {
+      "type": "object",
+      "required": ["input_tokens", "output_tokens"],
+      "properties": {
+        "input_tokens": {
+          "type": "integer",
+          "description": "Number of input tokens used"
+        },
+        "output_tokens": {
+          "type": "integer",
+          "description": "Number of output tokens used"
+        },
+        "cache_read_tokens": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of cached input tokens used"
+        },
+        "task_id": {
+          "type": "integer",
+          "description": "Optional task ID to associate cost with"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_cost_by_agent",
+    "description": "Get cost breakdown by agent. Shows total tokens and spend per agent for the given period.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "date_from": {
+          "type": "string",
+          "description": "Start date (YYYY-MM-DD). Defaults to all time."
+        },
+        "date_to": {
+          "type": "string",
+          "description": "End date (YYYY-MM-DD). Defaults to today."
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_cost_by_project",
+    "description": "Get cost breakdown by project. Shows total tokens and spend per project for the given period.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "date_from": {
+          "type": "string",
+          "description": "Start date (YYYY-MM-DD). Defaults to all time."
+        },
+        "date_to": {
+          "type": "string",
+          "description": "End date (YYYY-MM-DD). Defaults to today."
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_cost_trends",
+    "description": "Get daily cost trend data. Returns daily totals for the specified number of days.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "days": {
+          "type": "integer",
+          "default": 14,
+          "description": "Number of days of trend data to return (default 14)"
+        }
+      }
+    }
+  }
+]

--- a/server/plugins/cost-tracker/plugin.json
+++ b/server/plugins/cost-tracker/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "cost-tracker",
+  "version": "1.0.0",
+  "displayName": "Cost Tracker",
+  "description": "Tracks AI API token usage and costs per agent, project, and task. Budget alerts and spend dashboards.",
+  "author": "SoftBacon Software",
+  "enabled": false,
+  "routePrefix": "/costs",
+  "schema": "schema.sql",
+  "gatedActions": [],
+  "mcpTools": "mcp-tools.json",
+  "configSchema": [
+    { "key": "budget_daily", "type": "number", "label": "Daily Budget ($)", "description": "Daily spend limit in USD. 0 = no limit.", "default": "0" },
+    { "key": "budget_weekly", "type": "number", "label": "Weekly Budget ($)", "description": "Weekly spend limit in USD. 0 = no limit.", "default": "0" },
+    { "key": "alert_threshold_pct", "type": "number", "label": "Alert Threshold (%)", "description": "Send alert when budget usage exceeds this percentage", "default": "80" },
+    { "key": "price_input_mtok", "type": "number", "label": "Input Price ($/MTok)", "description": "Cost per million input tokens", "default": "15" },
+    { "key": "price_output_mtok", "type": "number", "label": "Output Price ($/MTok)", "description": "Cost per million output tokens", "default": "75" },
+    { "key": "price_cache_read_mtok", "type": "number", "label": "Cache Read Price ($/MTok)", "description": "Cost per million cached input tokens", "default": "1.50" }
+  ]
+}

--- a/server/plugins/cost-tracker/routes.js
+++ b/server/plugins/cost-tracker/routes.js
@@ -1,0 +1,275 @@
+// Cost Tracker plugin routes
+// Record token usage, view spend summaries, budget alerts, and dashboard widgets.
+
+import { Router } from 'express';
+import createCostDB from './db.js';
+
+function getWeekStart() {
+  var now = new Date();
+  var day = now.getDay();
+  var diff = now.getDate() - day + (day === 0 ? -6 : 1);
+  return new Date(now.getFullYear(), now.getMonth(), diff).toISOString().split('T')[0];
+}
+
+function getConfigValue(coreDb, key, fallback) {
+  var row = coreDb.prepare(
+    "SELECT value FROM dv_plugin_config WHERE plugin_name = 'cost-tracker' AND key = ?"
+  ).get(key);
+  return row ? parseFloat(row.value) : fallback;
+}
+
+function getAllConfig(coreDb) {
+  var config = {};
+  var rows = coreDb.prepare(
+    "SELECT key, value FROM dv_plugin_config WHERE plugin_name = 'cost-tracker'"
+  ).all();
+  for (var r of rows) config[r.key] = r.value;
+  return config;
+}
+
+function checkBudgetAlerts(db, core, config) {
+  var alertThreshold = parseFloat(config.alert_threshold_pct || 80) / 100;
+
+  // Daily budget check
+  var dailyBudget = parseFloat(config.budget_daily || 0);
+  if (dailyBudget > 0) {
+    var todaySpend = db.getSpendToday();
+    var pct = todaySpend / dailyBudget;
+    if (pct >= alertThreshold) {
+      var today = new Date().toISOString().split('T')[0];
+      var existing = core.db.prepare(
+        "SELECT id FROM dv_cost_alerts WHERE alert_type = 'daily_budget' AND triggered_at >= ?"
+      ).get(today);
+      if (!existing) {
+        db.logAlert('daily_budget', pct * 100, todaySpend, dailyBudget);
+        core.inbox.createInboxItemForAllOperators(
+          'cost_alert', 'cost_alert', 'daily_' + today,
+          'Daily budget alert: $' + todaySpend.toFixed(2) + ' / $' + dailyBudget.toFixed(2),
+          Math.round(pct * 100) + '% of daily budget used',
+          { spend: todaySpend, budget: dailyBudget, pct: Math.round(pct * 100) },
+          pct >= 1.0 ? 'urgent' : 'normal'
+        );
+      }
+    }
+  }
+
+  // Weekly budget check
+  var weeklyBudget = parseFloat(config.budget_weekly || 0);
+  if (weeklyBudget > 0) {
+    var weekSpend = db.getSpendThisWeek();
+    var weekPct = weekSpend / weeklyBudget;
+    if (weekPct >= alertThreshold) {
+      var weekStart = getWeekStart();
+      var existingWeek = core.db.prepare(
+        "SELECT id FROM dv_cost_alerts WHERE alert_type = 'weekly_budget' AND triggered_at >= ?"
+      ).get(weekStart);
+      if (!existingWeek) {
+        db.logAlert('weekly_budget', weekPct * 100, weekSpend, weeklyBudget);
+        core.inbox.createInboxItemForAllOperators(
+          'cost_alert', 'cost_alert', 'weekly_' + weekStart,
+          'Weekly budget alert: $' + weekSpend.toFixed(2) + ' / $' + weeklyBudget.toFixed(2),
+          Math.round(weekPct * 100) + '% of weekly budget used',
+          { spend: weekSpend, budget: weeklyBudget, pct: Math.round(weekPct * 100) },
+          weekPct >= 1.0 ? 'urgent' : 'normal'
+        );
+      }
+    }
+  }
+}
+
+export default function (core) {
+  var router = Router();
+  var db = createCostDB(core.db);
+  var { checkAgentOrAdmin, checkAdmin } = core.auth;
+  var { apiError } = core;
+
+  // POST /costs/record — Record token usage (agent auth)
+  router.post('/record', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var inputTokens = parseInt(req.body.input_tokens) || 0;
+    var outputTokens = parseInt(req.body.output_tokens) || 0;
+    var cacheReadTokens = parseInt(req.body.cache_read_tokens) || 0;
+    var taskId = req.body.task_id ? parseInt(req.body.task_id) : null;
+    var sessionId = req.body.session_id || '';
+
+    if (inputTokens === 0 && outputTokens === 0) {
+      return apiError(res, 400, 'At least input_tokens or output_tokens must be > 0');
+    }
+
+    // Calculate cost from config pricing
+    var priceInput = getConfigValue(core.db, 'price_input_mtok', 15) / 1000000;
+    var priceOutput = getConfigValue(core.db, 'price_output_mtok', 75) / 1000000;
+    var priceCache = getConfigValue(core.db, 'price_cache_read_mtok', 1.5) / 1000000;
+    var costUsd = (inputTokens * priceInput) + (outputTokens * priceOutput) + (cacheReadTokens * priceCache);
+
+    // Determine agent and project from auth context
+    var agentId = req.agentId || who;
+    var projectId = req.body.project_id || req.projectId || '';
+
+    var id = db.recordUsage(agentId, projectId, taskId, inputTokens, outputTokens, cacheReadTokens, costUsd, sessionId);
+
+    // Check budget alerts
+    var config = getAllConfig(core.db);
+    checkBudgetAlerts(db, core, config);
+
+    res.json({ ok: true, id: id, cost_usd: costUsd });
+  });
+
+  // GET /costs/summary — Current period summary
+  router.get('/summary', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var todaySpend = db.getSpendToday();
+    var weekSpend = db.getSpendThisWeek();
+    var dailyBudget = getConfigValue(core.db, 'budget_daily', 0);
+    var weeklyBudget = getConfigValue(core.db, 'budget_weekly', 0);
+    var today = new Date().toISOString().split('T')[0];
+    var topAgents = db.getTopAgents(today, today, 5);
+
+    res.json({
+      today: {
+        spend: todaySpend,
+        budget: dailyBudget,
+        pct: dailyBudget > 0 ? Math.round((todaySpend / dailyBudget) * 100) : null
+      },
+      week: {
+        spend: weekSpend,
+        budget: weeklyBudget,
+        pct: weeklyBudget > 0 ? Math.round((weekSpend / weeklyBudget) * 100) : null
+      },
+      top_agents: topAgents
+    });
+  });
+
+  // GET /costs/by-agent — Cost breakdown by agent
+  router.get('/by-agent', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var dateFrom = req.query.date_from || null;
+    var dateTo = req.query.date_to || null;
+    var agents = db.getTopAgents(dateFrom, dateTo, 100);
+    res.json({ date_from: dateFrom, date_to: dateTo, agents: agents });
+  });
+
+  // GET /costs/by-project — Cost breakdown by project
+  router.get('/by-project', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var dateFrom = req.query.date_from || null;
+    var dateTo = req.query.date_to || null;
+    var where = ['1=1'];
+    var params = [];
+    if (dateFrom) { where.push('date >= ?'); params.push(dateFrom); }
+    if (dateTo) { where.push('date <= ?'); params.push(dateTo); }
+    var projects = core.db.prepare(
+      'SELECT project_id, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
+      'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
+      'FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY project_id ORDER BY total_cost DESC'
+    ).all.apply(
+      core.db.prepare('SELECT project_id, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
+        'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
+        'FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY project_id ORDER BY total_cost DESC'),
+      params
+    );
+    res.json({ date_from: dateFrom, date_to: dateTo, projects: projects });
+  });
+
+  // GET /costs/trends — Daily cost trend data
+  router.get('/trends', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var days = parseInt(req.query.days) || 14;
+    var trend = db.getDailyTrend(days);
+    res.json({ days: days, data: trend });
+  });
+
+  // GET /costs/entries — Raw cost entries (admin only)
+  router.get('/entries', function (req, res) {
+    var who = checkAdmin(req, res);
+    if (!who) return;
+
+    var entries = db.listEntries({
+      agent_id: req.query.agent_id || undefined,
+      project_id: req.query.project_id || undefined,
+      date_from: req.query.date_from || undefined,
+      date_to: req.query.date_to || undefined,
+      limit: parseInt(req.query.limit) || 50,
+      offset: parseInt(req.query.offset) || 0
+    });
+    res.json(entries);
+  });
+
+  // GET /costs/alerts — Recent budget alerts
+  router.get('/alerts', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var limit = parseInt(req.query.limit) || 20;
+    var alerts = db.getAlerts(limit);
+    res.json(alerts);
+  });
+
+  // GET /costs/widgets/spend-today — Widget data for today's spend
+  router.get('/widgets/spend-today', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var todaySpend = db.getSpendToday();
+    var dailyBudget = getConfigValue(core.db, 'budget_daily', 0);
+    var overBudget = dailyBudget > 0 && todaySpend >= dailyBudget;
+
+    // Calculate yesterday's spend for trend
+    var yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    var yesterdayStr = yesterday.toISOString().split('T')[0];
+    var yesterdaySummary = db.getDailySummary(yesterdayStr);
+    var yesterdaySpend = 0;
+    for (var s of yesterdaySummary) { yesterdaySpend += s.total_cost; }
+    var diff = todaySpend - yesterdaySpend;
+    var trend = (diff >= 0 ? '+$' : '-$') + Math.abs(diff).toFixed(2) + ' vs yesterday';
+
+    res.json({
+      type: 'stat',
+      value: '$' + todaySpend.toFixed(2),
+      label: 'Spend Today',
+      trend: trend,
+      color: overBudget ? 'red' : 'green'
+    });
+  });
+
+  // GET /costs/widgets/budget-status — Widget data for budget usage percentage
+  router.get('/widgets/budget-status', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var todaySpend = db.getSpendToday();
+    var dailyBudget = getConfigValue(core.db, 'budget_daily', 0);
+
+    if (dailyBudget <= 0) {
+      return res.json({
+        type: 'stat',
+        value: 'No limit',
+        label: 'Daily Budget Used',
+        color: 'green'
+      });
+    }
+
+    var pct = Math.round((todaySpend / dailyBudget) * 100);
+    var color = pct > 80 ? 'red' : pct > 50 ? 'yellow' : 'green';
+
+    res.json({
+      type: 'stat',
+      value: pct + '%',
+      label: 'Daily Budget Used',
+      color: color
+    });
+  });
+
+  return router;
+}

--- a/server/plugins/cost-tracker/schema.sql
+++ b/server/plugins/cost-tracker/schema.sql
@@ -1,0 +1,46 @@
+-- Plugin: cost-tracker
+-- Tracks AI API token usage and costs per agent, project, and task.
+
+CREATE TABLE IF NOT EXISTS dv_cost_entries (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id          TEXT NOT NULL DEFAULT '',
+  project_id        TEXT NOT NULL DEFAULT '',
+  task_id           INTEGER,
+  input_tokens      INTEGER NOT NULL DEFAULT 0,
+  output_tokens     INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+  cost_usd          REAL NOT NULL DEFAULT 0,
+  session_id        TEXT NOT NULL DEFAULT '',
+  recorded_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_entries_agent ON dv_cost_entries(agent_id);
+CREATE INDEX IF NOT EXISTS idx_cost_entries_project ON dv_cost_entries(project_id);
+CREATE INDEX IF NOT EXISTS idx_cost_entries_recorded ON dv_cost_entries(recorded_at);
+
+CREATE TABLE IF NOT EXISTS dv_cost_daily (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  date              TEXT NOT NULL DEFAULT '',
+  agent_id          TEXT NOT NULL DEFAULT '',
+  project_id        TEXT NOT NULL DEFAULT '',
+  total_input       INTEGER NOT NULL DEFAULT 0,
+  total_output      INTEGER NOT NULL DEFAULT 0,
+  total_cache       INTEGER NOT NULL DEFAULT 0,
+  total_cost        REAL NOT NULL DEFAULT 0,
+  entry_count       INTEGER NOT NULL DEFAULT 0,
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(date, agent_id, project_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_daily_date ON dv_cost_daily(date);
+CREATE INDEX IF NOT EXISTS idx_cost_daily_agent ON dv_cost_daily(agent_id);
+CREATE INDEX IF NOT EXISTS idx_cost_daily_project ON dv_cost_daily(project_id);
+
+CREATE TABLE IF NOT EXISTS dv_cost_alerts (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  alert_type        TEXT NOT NULL DEFAULT '',
+  threshold_pct     REAL NOT NULL DEFAULT 0,
+  current_spend     REAL NOT NULL DEFAULT 0,
+  budget_limit      REAL NOT NULL DEFAULT 0,
+  triggered_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/server/plugins/daily-digest/db.js
+++ b/server/plugins/daily-digest/db.js
@@ -1,0 +1,70 @@
+// Daily Digest plugin DB helpers
+
+export default function createDigestDB(db) {
+  return {
+    createReport(type, periodStart, periodEnd, content, summary) {
+      var r = db.prepare(
+        'INSERT INTO dv_digest_reports (digest_type, period_start, period_end, content, summary) VALUES (?, ?, ?, ?, ?) RETURNING id'
+      ).get(type, periodStart, periodEnd, JSON.stringify(content), summary);
+      return r.id;
+    },
+
+    getReport(id) {
+      var row = db.prepare('SELECT * FROM dv_digest_reports WHERE id = ?').get(id);
+      if (!row) return null;
+      try { row.content = JSON.parse(row.content); } catch (e) { row.content = {}; }
+      try { row.delivered_to = JSON.parse(row.delivered_to); } catch (e) { row.delivered_to = []; }
+      return row;
+    },
+
+    listReports(filters) {
+      var where = ['1=1'];
+      var params = [];
+      if (filters.type) { where.push('digest_type = ?'); params.push(filters.type); }
+      var limit = Math.min(filters.limit || 50, 200);
+      var offset = filters.offset || 0;
+      var rows = db.prepare(
+        'SELECT * FROM dv_digest_reports WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
+      ).all(...params, limit, offset);
+      return rows.map(function (row) {
+        try { row.content = JSON.parse(row.content); } catch (e) { row.content = {}; }
+        try { row.delivered_to = JSON.parse(row.delivered_to); } catch (e) { row.delivered_to = []; }
+        return row;
+      });
+    },
+
+    getLatestReport(type) {
+      var row = db.prepare(
+        'SELECT * FROM dv_digest_reports WHERE digest_type = ? ORDER BY created_at DESC LIMIT 1'
+      ).get(type);
+      if (!row) return null;
+      try { row.content = JSON.parse(row.content); } catch (e) { row.content = {}; }
+      try { row.delivered_to = JSON.parse(row.delivered_to); } catch (e) { row.delivered_to = []; }
+      return row;
+    },
+
+    updateReportDelivery(id, deliveredTo) {
+      db.prepare('UPDATE dv_digest_reports SET delivered_to = ? WHERE id = ?').run(
+        JSON.stringify(deliveredTo), id
+      );
+    },
+
+    recordMetric(metricType, metricKey, value, period) {
+      db.prepare(
+        'INSERT INTO dv_digest_metrics (metric_type, metric_key, value, period) VALUES (?, ?, ?, ?)'
+      ).run(metricType, metricKey, value, period);
+    },
+
+    getMetrics(metricType, period) {
+      return db.prepare(
+        'SELECT * FROM dv_digest_metrics WHERE metric_type = ? AND period = ? ORDER BY recorded_at DESC'
+      ).all(metricType, period);
+    },
+
+    getTrends(metricType, limit) {
+      return db.prepare(
+        'SELECT period, SUM(value) as total FROM dv_digest_metrics WHERE metric_type = ? GROUP BY period ORDER BY period DESC LIMIT ?'
+      ).all(metricType, limit || 14);
+    }
+  };
+}

--- a/server/plugins/daily-digest/handlers.js
+++ b/server/plugins/daily-digest/handlers.js
@@ -1,0 +1,29 @@
+// Daily Digest event handlers
+// Subscribes to agent events and records metrics for digest generation.
+
+import createDigestDB from './db.js';
+
+export function registerHooks(core) {
+  var db = createDigestDB(core.db);
+
+  var METRIC_EVENTS = [
+    { event: 'task_completed', metric: 'tasks_completed' },
+    { event: 'bug_fixed', metric: 'bugs_fixed' },
+    { event: 'plan_step_completed', metric: 'plan_steps_completed' }
+  ];
+
+  for (var entry of METRIC_EVENTS) {
+    (function (eventType, metricType) {
+      core.onEvent(eventType, function (eventData) {
+        try {
+          var today = new Date().toISOString().substring(0, 10);
+          var agentId = eventData.agent || 'unknown';
+          db.recordMetric(metricType, agentId, 1, today);
+          db.recordMetric(metricType, 'total', 1, today);
+        } catch (e) {
+          console.error('[daily-digest] Error recording metric for ' + eventType + ':', e.message);
+        }
+      });
+    })(entry.event, entry.metric);
+  }
+}

--- a/server/plugins/daily-digest/mcp-tools.json
+++ b/server/plugins/daily-digest/mcp-tools.json
@@ -1,0 +1,71 @@
+[
+  {
+    "name": "mycelium_digest_preview",
+    "description": "Preview the current period's digest without saving. Shows tasks completed, bugs fixed, plan steps advanced, and agent utilization for the current period.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["daily", "weekly"],
+          "default": "daily",
+          "description": "Digest period type. Defaults to daily."
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_digest_generate",
+    "description": "Generate and deliver a digest now. Creates a report, records metrics, and routes to operator inbox and optional Slack webhook.",
+    "inputSchema": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["daily", "weekly"],
+          "description": "Digest period type: daily (last 24h) or weekly (last 7 days)"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_digest_trends",
+    "description": "Get trend data for a metric over recent periods. Useful for dashboard charts and velocity tracking.",
+    "inputSchema": {
+      "type": "object",
+      "required": ["metric"],
+      "properties": {
+        "metric": {
+          "type": "string",
+          "enum": ["tasks_completed", "bugs_fixed", "plan_steps_completed", "messages_sent"],
+          "description": "Which metric to get trends for"
+        },
+        "periods": {
+          "type": "integer",
+          "default": 14,
+          "description": "Number of periods to return (default 14)"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_digest_reports",
+    "description": "List past digest reports. Returns stored daily and weekly digests with summaries and delivery status.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["daily", "weekly"],
+          "description": "Filter by digest type. Omit to get all."
+        },
+        "limit": {
+          "type": "integer",
+          "default": 10,
+          "description": "Max number of reports to return"
+        }
+      }
+    }
+  }
+]

--- a/server/plugins/daily-digest/plugin.json
+++ b/server/plugins/daily-digest/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "daily-digest",
+  "version": "1.0.0",
+  "displayName": "Daily Digest",
+  "description": "Auto-generates daily and weekly summaries of swarm activity — tasks completed, bugs fixed, plans advanced, agent utilization. Routes to operator inbox.",
+  "author": "SoftBacon Software",
+  "enabled": false,
+  "routePrefix": "/digest",
+  "schema": "schema.sql",
+  "gatedActions": [],
+  "mcpTools": "mcp-tools.json",
+  "configSchema": [
+    { "key": "schedule", "type": "select", "label": "Schedule", "description": "How often to generate digests", "options": ["daily", "weekly"], "default": "daily" },
+    { "key": "timezone", "type": "string", "label": "Timezone", "description": "IANA timezone for digest generation (e.g. America/Chicago)", "default": "UTC" },
+    { "key": "digest_hour", "type": "number", "label": "Digest Hour", "description": "Hour of day (0-23) to generate digest", "default": "8" },
+    { "key": "slack_webhook", "type": "secret", "label": "Slack Webhook URL", "description": "Optional: send digests to Slack" },
+    { "key": "include_agent_stats", "type": "boolean", "label": "Include Agent Stats", "description": "Show per-agent breakdown in digest", "default": "true" }
+  ]
+}

--- a/server/plugins/daily-digest/routes.js
+++ b/server/plugins/daily-digest/routes.js
@@ -1,0 +1,295 @@
+// Daily Digest plugin routes
+// Generate, view, and deliver daily/weekly swarm activity summaries.
+
+import { Router } from 'express';
+import createDigestDB from './db.js';
+
+function gatherDigestData(db, coreDb, periodStart, periodEnd) {
+  // Query dv_tasks for completed tasks in period
+  var tasks = coreDb.prepare(
+    "SELECT * FROM dv_tasks WHERE status = 'done' AND updated_at BETWEEN ? AND ?"
+  ).all(periodStart, periodEnd);
+
+  // Query dv_bugs for fixed bugs
+  var bugs = coreDb.prepare(
+    "SELECT * FROM dv_bugs WHERE status = 'fixed' AND updated_at BETWEEN ? AND ?"
+  ).all(periodStart, periodEnd);
+
+  // Query dv_plan_steps for completed steps
+  var steps = coreDb.prepare(
+    "SELECT ps.*, p.title as plan_title FROM dv_plan_steps ps JOIN dv_plans p ON ps.plan_id = p.id WHERE ps.status = 'completed' AND ps.updated_at BETWEEN ? AND ?"
+  ).all(periodStart, periodEnd);
+
+  // Query dv_agents for agent activity (heartbeat counts)
+  var agents = coreDb.prepare(
+    "SELECT id, display_name, status, working_on, last_heartbeat FROM dv_agents"
+  ).all();
+
+  // Query messages sent in period
+  var messageCount = coreDb.prepare(
+    "SELECT COUNT(*) as count FROM dv_messages WHERE created_at BETWEEN ? AND ?"
+  ).get(periodStart, periodEnd).count;
+
+  // Build per-agent stats
+  var agentStats = {};
+  for (var t of tasks) {
+    var a = t.assignee || 'unassigned';
+    if (!agentStats[a]) agentStats[a] = { tasks: 0, bugs: 0, steps: 0 };
+    agentStats[a].tasks++;
+  }
+  for (var b of bugs) {
+    var a2 = b.assignee || 'unassigned';
+    if (!agentStats[a2]) agentStats[a2] = { tasks: 0, bugs: 0, steps: 0 };
+    agentStats[a2].bugs++;
+  }
+  for (var s of steps) {
+    var a3 = s.assignee || 'unassigned';
+    if (!agentStats[a3]) agentStats[a3] = { tasks: 0, bugs: 0, steps: 0 };
+    agentStats[a3].steps++;
+  }
+
+  return {
+    period: { start: periodStart, end: periodEnd },
+    tasks_completed: tasks.length,
+    bugs_fixed: bugs.length,
+    plan_steps_completed: steps.length,
+    messages_sent: messageCount,
+    agent_count: agents.length,
+    agents_online: agents.filter(function (a) { return a.status === 'online'; }).length,
+    agent_stats: agentStats,
+    tasks: tasks.map(function (t) { return { id: t.id, title: t.title, assignee: t.assignee }; }),
+    bugs: bugs.map(function (b) { return { id: b.id, title: b.title, assignee: b.assignee }; }),
+    steps: steps.map(function (s) { return { id: s.id, title: s.title, plan_title: s.plan_title, assignee: s.assignee }; })
+  };
+}
+
+function buildSummary(data) {
+  var lines = [];
+  lines.push('Period: ' + data.period.start + ' to ' + data.period.end);
+  lines.push('');
+  lines.push('Tasks completed: ' + data.tasks_completed);
+  lines.push('Bugs fixed: ' + data.bugs_fixed);
+  lines.push('Plan steps advanced: ' + data.plan_steps_completed);
+  lines.push('Messages sent: ' + data.messages_sent);
+  lines.push('Agents: ' + data.agents_online + '/' + data.agent_count + ' online');
+
+  if (Object.keys(data.agent_stats).length > 0) {
+    lines.push('');
+    lines.push('Agent breakdown:');
+    for (var agent in data.agent_stats) {
+      var s = data.agent_stats[agent];
+      lines.push('  ' + agent + ': ' + s.tasks + ' tasks, ' + s.bugs + ' bugs, ' + s.steps + ' steps');
+    }
+  }
+  return lines.join('\n');
+}
+
+function getPeriodRange(type) {
+  var now = new Date();
+  var end = now.toISOString().replace('T', ' ').substring(0, 19);
+  var start;
+  if (type === 'weekly') {
+    var weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    start = weekAgo.toISOString().replace('T', ' ').substring(0, 19);
+  } else {
+    var dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    start = dayAgo.toISOString().replace('T', ' ').substring(0, 19);
+  }
+  return { start: start, end: end };
+}
+
+function getPeriodLabel(periodStart, periodEnd) {
+  return periodStart.substring(0, 10) + ' to ' + periodEnd.substring(0, 10);
+}
+
+export default function (core) {
+  var router = Router();
+  var db = createDigestDB(core.db);
+  var { apiError, parseIntParam } = core;
+  var { checkAgentOrAdmin, checkAdmin } = core.auth;
+
+  // GET /digest/reports — list digest reports
+  router.get('/reports', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    res.json(db.listReports({
+      type: req.query.type || undefined,
+      limit: parseInt(req.query.limit) || 50,
+      offset: parseInt(req.query.offset) || 0
+    }));
+  });
+
+  // GET /digest/reports/:id — get single report
+  router.get('/reports/:id', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var report = db.getReport(parseIntParam(req.params.id));
+    if (!report) return apiError(res, 404, 'Report not found');
+    res.json(report);
+  });
+
+  // POST /digest/generate — manually trigger digest generation
+  router.post('/generate', async function (req, res) {
+    var who = checkAdmin(req, res);
+    if (!who) return;
+
+    var digestType = req.body.type || 'daily';
+    if (digestType !== 'daily' && digestType !== 'weekly') {
+      return apiError(res, 400, 'type must be daily or weekly');
+    }
+
+    try {
+      var range = getPeriodRange(digestType);
+      var data = gatherDigestData(db, core.db, range.start, range.end);
+      var summary = buildSummary(data);
+      var periodLabel = getPeriodLabel(range.start, range.end);
+
+      // Store report
+      var reportId = db.createReport(digestType, range.start, range.end, data, summary);
+
+      // Record aggregate metrics
+      var today = new Date().toISOString().substring(0, 10);
+      db.recordMetric('tasks_completed', 'total', data.tasks_completed, today);
+      db.recordMetric('bugs_fixed', 'total', data.bugs_fixed, today);
+      db.recordMetric('plan_steps_completed', 'total', data.plan_steps_completed, today);
+      db.recordMetric('messages_sent', 'total', data.messages_sent, today);
+
+      // Deliver to operator inbox
+      var deliveredTo = ['inbox'];
+      core.inbox.createInboxItemForAllOperators(
+        'digest_report', 'digest', String(reportId),
+        digestType + ' digest — ' + periodLabel,
+        summary.substring(0, 300),
+        { report_id: reportId, digest_type: digestType, tasks_completed: data.tasks_completed, bugs_fixed: data.bugs_fixed },
+        'normal'
+      );
+
+      // Optional Slack delivery
+      var slackWebhook = core.db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'daily-digest' AND key = 'slack_webhook'").get();
+      if (slackWebhook && slackWebhook.value) {
+        try {
+          await fetch(slackWebhook.value, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: '*' + digestType + ' Digest*\n' + summary })
+          });
+          deliveredTo.push('slack');
+        } catch (e) {
+          console.error('[daily-digest] Slack delivery failed:', e.message);
+        }
+      }
+
+      // Update delivery record
+      db.updateReportDelivery(reportId, deliveredTo);
+
+      core.emitEvent('digest_generated', who, null,
+        who + ' generated ' + digestType + ' digest #' + reportId,
+        { report_id: reportId, digest_type: digestType });
+
+      res.json({ ok: true, report_id: reportId, digest_type: digestType, summary: summary, delivered_to: deliveredTo });
+    } catch (e) {
+      console.error('[daily-digest] Generation failed:', e.message);
+      return apiError(res, 500, 'Digest generation failed: ' + e.message);
+    }
+  });
+
+  // GET /digest/preview — preview what the next digest would contain
+  router.get('/preview', function (req, res) {
+    var who = checkAdmin(req, res);
+    if (!who) return;
+
+    var digestType = req.query.type || 'daily';
+    if (digestType !== 'daily' && digestType !== 'weekly') {
+      return apiError(res, 400, 'type must be daily or weekly');
+    }
+
+    try {
+      var range = getPeriodRange(digestType);
+      var data = gatherDigestData(db, core.db, range.start, range.end);
+      var summary = buildSummary(data);
+      res.json({ digest_type: digestType, data: data, summary: summary });
+    } catch (e) {
+      console.error('[daily-digest] Preview failed:', e.message);
+      return apiError(res, 500, 'Preview failed: ' + e.message);
+    }
+  });
+
+  // POST /digest/deliver/:id — re-deliver a report to inbox/slack
+  router.post('/deliver/:id', async function (req, res) {
+    var who = checkAdmin(req, res);
+    if (!who) return;
+
+    var report = db.getReport(parseIntParam(req.params.id));
+    if (!report) return apiError(res, 404, 'Report not found');
+
+    try {
+      var periodLabel = getPeriodLabel(report.period_start, report.period_end);
+      var deliveredTo = ['inbox'];
+
+      // Re-deliver to operator inbox
+      core.inbox.createInboxItemForAllOperators(
+        'digest_report', 'digest', String(report.id),
+        report.digest_type + ' digest — ' + periodLabel,
+        report.summary.substring(0, 300),
+        { report_id: report.id, digest_type: report.digest_type, tasks_completed: report.content.tasks_completed, bugs_fixed: report.content.bugs_fixed },
+        'normal'
+      );
+
+      // Optional Slack re-delivery
+      var slackWebhook = core.db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'daily-digest' AND key = 'slack_webhook'").get();
+      if (slackWebhook && slackWebhook.value) {
+        try {
+          await fetch(slackWebhook.value, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: '*' + report.digest_type + ' Digest (re-sent)*\n' + report.summary })
+          });
+          deliveredTo.push('slack');
+        } catch (e) {
+          console.error('[daily-digest] Slack re-delivery failed:', e.message);
+        }
+      }
+
+      db.updateReportDelivery(report.id, deliveredTo);
+      res.json({ ok: true, report_id: report.id, delivered_to: deliveredTo });
+    } catch (e) {
+      console.error('[daily-digest] Re-delivery failed:', e.message);
+      return apiError(res, 500, 'Re-delivery failed: ' + e.message);
+    }
+  });
+
+  // GET /digest/trends — get trend data for dashboard charts
+  router.get('/trends', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var metric = req.query.metric || 'tasks_completed';
+    var validMetrics = ['tasks_completed', 'bugs_fixed', 'plan_steps_completed', 'messages_sent'];
+    if (validMetrics.indexOf(metric) === -1) {
+      return apiError(res, 400, 'metric must be one of: ' + validMetrics.join(', '));
+    }
+
+    var periods = parseInt(req.query.periods) || 14;
+    var trends = db.getTrends(metric, periods);
+    res.json({ metric: metric, periods: periods, data: trends });
+  });
+
+  // GET /digest/widgets/velocity — widget data: today's velocity
+  router.get('/widgets/velocity', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var today = new Date().toISOString().substring(0, 10);
+    var tasksMetrics = db.getMetrics('tasks_completed', today);
+    var bugsMetrics = db.getMetrics('bugs_fixed', today);
+
+    var tasksDone = 0;
+    for (var tm of tasksMetrics) { tasksDone += tm.value; }
+    var bugsDone = 0;
+    for (var bm of bugsMetrics) { bugsDone += bm.value; }
+
+    res.json({ date: today, tasks_completed: tasksDone, bugs_fixed: bugsDone });
+  });
+
+  return router;
+}

--- a/server/plugins/daily-digest/schema.sql
+++ b/server/plugins/daily-digest/schema.sql
@@ -1,0 +1,26 @@
+-- Daily Digest plugin schema
+-- Stores generated digest reports and time-series metrics snapshots.
+
+CREATE TABLE IF NOT EXISTS dv_digest_reports (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  period_start    TEXT NOT NULL,                          -- ISO date start of period
+  period_end      TEXT NOT NULL,                          -- ISO date end of period
+  digest_type     TEXT NOT NULL DEFAULT 'daily',          -- 'daily' or 'weekly'
+  content         TEXT NOT NULL DEFAULT '{}',             -- JSON: full digest data
+  summary         TEXT NOT NULL DEFAULT '',               -- human-readable summary text
+  delivered_to    TEXT NOT NULL DEFAULT '[]',             -- JSON array of delivery targets
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS dv_digest_metrics (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  metric_type     TEXT NOT NULL,                          -- 'tasks_completed', 'bugs_fixed', etc.
+  metric_key      TEXT NOT NULL DEFAULT '',               -- e.g. agent id or 'total'
+  value           REAL NOT NULL DEFAULT 0,
+  period          TEXT NOT NULL,                          -- date string for the period
+  recorded_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_dv_digest_reports_type ON dv_digest_reports(digest_type);
+CREATE INDEX IF NOT EXISTS idx_dv_digest_reports_period ON dv_digest_reports(period_start);
+CREATE INDEX IF NOT EXISTS idx_dv_digest_metrics_type_period ON dv_digest_metrics(metric_type, period);

--- a/server/plugins/error-monitor/db.js
+++ b/server/plugins/error-monitor/db.js
@@ -1,0 +1,120 @@
+// Error Monitor plugin DB helpers — factory receives raw better-sqlite3 handle
+
+export default function createErrorDB(db) {
+  var _stmts = {};
+  function stmt(key, sql) {
+    if (!_stmts[key]) _stmts[key] = db.prepare(sql);
+    return _stmts[key];
+  }
+
+  return {
+    logError(provider, errorKey, title, message, stackTrace, url, payload) {
+      var existing = stmt('emGetByKey',
+        'SELECT id, occurrences FROM dv_error_events WHERE error_key = ?'
+      ).get(errorKey);
+
+      if (existing) {
+        stmt('emBump',
+          "UPDATE dv_error_events SET occurrences = occurrences + 1, last_seen = datetime('now'), payload = ?, updated_at = datetime('now') WHERE id = ?"
+        ).run(JSON.stringify(payload || {}), existing.id);
+        return { id: existing.id, is_new: false, occurrences: existing.occurrences + 1 };
+      }
+
+      var r = stmt('emInsert',
+        'INSERT INTO dv_error_events (provider, error_key, title, message, stack_trace, url, payload) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
+      ).get(
+        provider || '', errorKey || '', title || '', message || '',
+        stackTrace || '', url || '', JSON.stringify(payload || {})
+      );
+      return { id: r.id, is_new: true, occurrences: 1 };
+    },
+
+    getError(id) {
+      var row = stmt('emGet', 'SELECT * FROM dv_error_events WHERE id = ?').get(id);
+      if (row) {
+        try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
+      }
+      return row;
+    },
+
+    getErrorByKey(errorKey) {
+      var row = stmt('emGetByKey2', 'SELECT * FROM dv_error_events WHERE error_key = ?').get(errorKey);
+      if (row) {
+        try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
+      }
+      return row;
+    },
+
+    listErrors(filters) {
+      var where = ['1=1'];
+      var params = [];
+      if (filters.provider) { where.push('provider = ?'); params.push(filters.provider); }
+      if (filters.status) { where.push('status = ?'); params.push(filters.status); }
+      var limit = Math.min(filters.limit || 50, 200);
+      var offset = filters.offset || 0;
+      params.push(limit, offset);
+      var rows = db.prepare(
+        'SELECT * FROM dv_error_events WHERE ' + where.join(' AND ') +
+        ' ORDER BY last_seen DESC LIMIT ? OFFSET ?'
+      ).all(...params);
+      return rows.map(function (row) {
+        try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
+        return row;
+      });
+    },
+
+    updateError(id, fields) {
+      var sets = [];
+      var values = [];
+      if (fields.status !== undefined) { sets.push('status = ?'); values.push(fields.status); }
+      if (fields.bug_id !== undefined) { sets.push('bug_id = ?'); values.push(fields.bug_id); }
+      if (fields.title !== undefined) { sets.push('title = ?'); values.push(fields.title); }
+      if (fields.message !== undefined) { sets.push('message = ?'); values.push(fields.message); }
+      if (fields.stack_trace !== undefined) { sets.push('stack_trace = ?'); values.push(fields.stack_trace); }
+      if (fields.url !== undefined) { sets.push('url = ?'); values.push(fields.url); }
+      if (sets.length === 0) return;
+      sets.push("updated_at = datetime('now')");
+      values.push(id);
+      db.prepare('UPDATE dv_error_events SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+    },
+
+    muteError(id) {
+      stmt('emMute',
+        "UPDATE dv_error_events SET status = 'muted', updated_at = datetime('now') WHERE id = ?"
+      ).run(id);
+    },
+
+    resolveError(id) {
+      stmt('emResolve',
+        "UPDATE dv_error_events SET status = 'resolved', updated_at = datetime('now') WHERE id = ?"
+      ).run(id);
+    },
+
+    getStats() {
+      var byProvider = db.prepare(
+        'SELECT provider, COUNT(*) as count FROM dv_error_events GROUP BY provider'
+      ).all();
+      var byStatus = db.prepare(
+        'SELECT status, COUNT(*) as count FROM dv_error_events GROUP BY status'
+      ).all();
+      var last24h = db.prepare(
+        "SELECT COUNT(*) as count FROM dv_error_events WHERE last_seen >= datetime('now', '-1 day')"
+      ).get();
+      return {
+        by_provider: byProvider,
+        by_status: byStatus,
+        last_24h: last24h ? last24h.count : 0
+      };
+    },
+
+    getTopErrors(limit) {
+      var rows = db.prepare(
+        'SELECT * FROM dv_error_events ORDER BY occurrences DESC LIMIT ?'
+      ).all(limit || 10);
+      return rows.map(function (row) {
+        try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
+        return row;
+      });
+    }
+  };
+}

--- a/server/plugins/error-monitor/handlers.js
+++ b/server/plugins/error-monitor/handlers.js
@@ -1,0 +1,30 @@
+// Error Monitor event handlers — subscribe to platform events
+
+import createErrorDB from './db.js';
+
+export function registerHooks(core) {
+  var db = createErrorDB(core.db);
+
+  // When a bug is fixed, resolve any linked error events
+  core.onEvent('bug_fixed', function (eventData) {
+    try {
+      var data = eventData.data || {};
+      var bugId = data.bug_id || data.id;
+      if (!bugId) return;
+
+      var errors = core.db.prepare(
+        "SELECT id FROM dv_error_events WHERE bug_id = ? AND status = 'open'"
+      ).all(bugId);
+
+      for (var err of errors) {
+        db.resolveError(err.id);
+      }
+
+      if (errors.length > 0) {
+        console.log('[error-monitor] Resolved ' + errors.length + ' error(s) linked to bug #' + bugId);
+      }
+    } catch (e) {
+      console.error('[error-monitor] Hook error:', e.message);
+    }
+  });
+}

--- a/server/plugins/error-monitor/mcp-tools.json
+++ b/server/plugins/error-monitor/mcp-tools.json
@@ -1,0 +1,63 @@
+[
+  {
+    "name": "mycelium_errors_recent",
+    "description": "List recent errors from the error monitor. Returns open errors by default, ordered by most recently seen.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["sentry", "bugsnag", "datadog"],
+          "description": "Filter by error provider"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["open", "muted", "resolved"],
+          "default": "open",
+          "description": "Filter by error status"
+        },
+        "limit": {
+          "type": "integer",
+          "default": 20,
+          "description": "Max errors to return"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_errors_stats",
+    "description": "Get error statistics including counts by provider, by status, errors in last 24 hours, and top errors by occurrence count.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "mycelium_errors_mute",
+    "description": "Mute a noisy error to stop it from auto-filing bugs. Muted errors still track occurrences but won't create new bugs.",
+    "inputSchema": {
+      "type": "object",
+      "required": ["error_id"],
+      "properties": {
+        "error_id": {
+          "type": "integer",
+          "description": "The error event ID to mute"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_errors_file_bug",
+    "description": "Manually file a Mycelium bug from an error event. Creates a bug in dv_bugs and links it to the error.",
+    "inputSchema": {
+      "type": "object",
+      "required": ["error_id"],
+      "properties": {
+        "error_id": {
+          "type": "integer",
+          "description": "The error event ID to file a bug for"
+        }
+      }
+    }
+  }
+]

--- a/server/plugins/error-monitor/plugin.json
+++ b/server/plugins/error-monitor/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "error-monitor",
+  "version": "1.0.0",
+  "displayName": "Error Monitor",
+  "description": "Receives error alerts from Sentry, Bugsnag, and Datadog. Auto-files Mycelium bugs with stack traces and deduplication.",
+  "author": "SoftBacon Software",
+  "enabled": false,
+  "routePrefix": "/errors",
+  "schema": "schema.sql",
+  "gatedActions": [],
+  "mcpTools": "mcp-tools.json",
+  "configSchema": [
+    { "key": "provider", "type": "select", "label": "Error Provider", "description": "Which error tracking service to receive webhooks from", "options": ["sentry", "bugsnag", "datadog"], "required": true },
+    { "key": "webhook_secret", "type": "secret", "label": "Webhook Secret", "description": "Secret for verifying webhook signatures" },
+    { "key": "auto_assign", "type": "boolean", "label": "Auto-assign Bugs", "description": "Automatically assign bugs to agents based on recent task history", "default": "false" },
+    { "key": "auto_file_threshold", "type": "number", "label": "Auto-file Threshold", "description": "Minimum error occurrences before auto-filing a bug (0 = file immediately)", "default": "1" },
+    { "key": "default_project", "type": "string", "label": "Default Project", "description": "Mycelium project ID for new bugs" },
+    { "key": "default_severity", "type": "select", "label": "Default Severity", "description": "Default bug severity for new errors", "options": ["low", "normal", "high", "critical"], "default": "normal" }
+  ]
+}

--- a/server/plugins/error-monitor/routes.js
+++ b/server/plugins/error-monitor/routes.js
@@ -1,0 +1,229 @@
+// Error Monitor plugin routes — receives core context, returns Express Router
+
+import { Router } from 'express';
+import createErrorDB from './db.js';
+
+function getConfig(db, key) {
+  var row = db.prepare(
+    "SELECT value FROM dv_plugin_config WHERE plugin_name = 'error-monitor' AND key = ?"
+  ).get(key);
+  return row ? row.value : null;
+}
+
+function getAllConfig(db) {
+  var rows = db.prepare(
+    "SELECT key, value FROM dv_plugin_config WHERE plugin_name = 'error-monitor'"
+  ).all();
+  var config = {};
+  for (var row of rows) {
+    config[row.key] = row.value;
+  }
+  return config;
+}
+
+function autoFileBug(core, db, errorRecord, config) {
+  var projectId = config.default_project || 'mycelium';
+  var severity = config.default_severity || 'normal';
+
+  var result = core.db.prepare(
+    "INSERT INTO dv_bugs (title, description, project_id, severity, status, reporter) VALUES (?, ?, ?, ?, 'open', '__system__') RETURNING id"
+  ).get(
+    '[' + errorRecord.provider + '] ' + errorRecord.title,
+    'Auto-filed from error monitor.\n\nMessage: ' + errorRecord.message + '\n\nStack trace:\n' + (errorRecord.stack_trace || 'N/A') + '\n\nLink: ' + (errorRecord.url || 'N/A') + '\n\nOccurrences: ' + errorRecord.occurrences,
+    projectId,
+    severity
+  );
+
+  if (result) {
+    db.updateError(errorRecord.id, { bug_id: result.id });
+    core.emitEvent('error_bug_filed', '__system__', projectId,
+      'Auto-filed bug #' + result.id + ' from error: ' + errorRecord.title,
+      { bug_id: result.id, error_id: errorRecord.id, provider: errorRecord.provider });
+
+    core.inbox.createInboxItemForAllOperators(
+      'error_bug', 'bug', String(result.id),
+      'Bug auto-filed: ' + errorRecord.title,
+      errorRecord.provider + ' error with ' + errorRecord.occurrences + ' occurrences',
+      { bug_id: result.id, error_id: errorRecord.id },
+      severity === 'critical' ? 'urgent' : 'normal'
+    );
+  }
+  return result;
+}
+
+function autoAssignBug(core, bugId, projectId) {
+  // Find most recently active agent on the project
+  var agent = core.db.prepare(
+    "SELECT agent_id FROM dv_agents WHERE last_heartbeat >= datetime('now', '-1 hour') ORDER BY last_heartbeat DESC LIMIT 1"
+  ).get();
+  if (agent) {
+    core.db.prepare('UPDATE dv_bugs SET assignee = ? WHERE id = ?').run(agent.agent_id, bugId);
+  }
+  return agent ? agent.agent_id : null;
+}
+
+function processWebhook(core, db, provider, errorKey, title, message, stackTrace, url, payload, res) {
+  try {
+    var config = getAllConfig(core.db);
+    var result = db.logError(provider, errorKey, title, message, stackTrace, url, payload);
+    var threshold = parseInt(config.auto_file_threshold || '1', 10);
+
+    // Auto-file bug if threshold met and no bug linked yet
+    if (result.occurrences >= threshold) {
+      var errorRecord = db.getError(result.id);
+      if (errorRecord && !errorRecord.bug_id && errorRecord.status !== 'muted') {
+        var bugResult = autoFileBug(core, db, errorRecord, config);
+        if (bugResult && config.auto_assign === 'true') {
+          var projectId = config.default_project || 'mycelium';
+          autoAssignBug(core, bugResult.id, projectId);
+        }
+      }
+    }
+
+    // Send inbox notification for new errors
+    if (result.is_new) {
+      core.inbox.createInboxItemForAllOperators(
+        'error_received', 'error_event', String(result.id),
+        'New ' + provider + ' error: ' + title,
+        message || title,
+        { error_id: result.id, provider: provider },
+        'normal'
+      );
+    }
+
+    // Emit event
+    core.emitEvent('error_received', '__system__', config.default_project || null,
+      provider + ' error: ' + title,
+      { error_id: result.id, provider: provider, is_new: result.is_new, occurrences: result.occurrences });
+
+    res.json({ ok: true, error_id: result.id, is_new: result.is_new, occurrences: result.occurrences });
+  } catch (e) {
+    console.error('[error-monitor] Webhook processing failed:', e.message);
+    res.status(500).json({ error: 'Processing failed: ' + e.message });
+  }
+}
+
+export default function (core) {
+  var router = Router();
+  var db = createErrorDB(core.db);
+  var { checkAgentOrAdmin, checkAdmin } = core.auth;
+  var { apiError, parseIntParam } = core;
+
+  // ---- Webhook endpoints (no auth) ----
+
+  // POST /errors/webhook/sentry
+  router.post('/webhook/sentry', function (req, res) {
+    var issue = req.body.data && req.body.data.issue;
+    var errorKey = 'sentry:' + (issue && issue.id);
+    var title = issue && issue.title;
+    var message = issue && issue.metadata && issue.metadata.value;
+    var url = issue && issue.permalink;
+    var stackTrace = '';
+    processWebhook(core, db, 'sentry', errorKey, title || '', message || '', stackTrace, url || '', req.body, res);
+  });
+
+  // POST /errors/webhook/bugsnag
+  router.post('/webhook/bugsnag', function (req, res) {
+    var error = req.body.error;
+    var errorKey = 'bugsnag:' + (error && error.exceptionClass) + ':' + (error && error.message || '').substring(0, 100);
+    var title = error && error.exceptionClass;
+    var message = error && error.message;
+    var stackTrace = error && error.stackTrace || '';
+    var url = error && error.url || '';
+    if (typeof stackTrace !== 'string') stackTrace = JSON.stringify(stackTrace);
+    processWebhook(core, db, 'bugsnag', errorKey, title || '', message || '', stackTrace, url, req.body, res);
+  });
+
+  // POST /errors/webhook/datadog
+  router.post('/webhook/datadog', function (req, res) {
+    var errorKey = 'datadog:' + req.body.id;
+    var title = req.body.title || '';
+    var message = req.body.text || '';
+    var url = req.body.url || '';
+    var tags = req.body.tags || [];
+    processWebhook(core, db, 'datadog', errorKey, title, message, '', url, req.body, res);
+  });
+
+  // ---- Authenticated endpoints ----
+
+  // GET /errors/events — list errors
+  router.get('/events', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    res.json(db.listErrors({
+      provider: req.query.provider || undefined,
+      status: req.query.status || undefined,
+      limit: parseInt(req.query.limit) || 50,
+      offset: parseInt(req.query.offset) || 0
+    }));
+  });
+
+  // GET /errors/events/:id — get single error
+  router.get('/events/:id', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var error = db.getError(parseIntParam(req.params.id));
+    if (!error) return apiError(res, 404, 'Error event not found');
+    res.json(error);
+  });
+
+  // PUT /errors/events/:id — update error (mute, resolve, link bug)
+  router.put('/events/:id', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var id = parseIntParam(req.params.id);
+    var error = db.getError(id);
+    if (!error) return apiError(res, 404, 'Error event not found');
+    var updates = {};
+    if (req.body.status !== undefined) updates.status = req.body.status;
+    if (req.body.bug_id !== undefined) updates.bug_id = req.body.bug_id;
+    db.updateError(id, updates);
+    res.json({ ok: true, error: db.getError(id) });
+  });
+
+  // POST /errors/events/:id/file-bug — manually file a bug from an error (admin only)
+  router.post('/events/:id/file-bug', function (req, res) {
+    var who = checkAdmin(req, res);
+    if (!who) return;
+    var id = parseIntParam(req.params.id);
+    var error = db.getError(id);
+    if (!error) return apiError(res, 404, 'Error event not found');
+    if (error.bug_id) return apiError(res, 400, 'Error already linked to bug #' + error.bug_id);
+
+    var config = getAllConfig(core.db);
+    var bugResult = autoFileBug(core, db, error, config);
+    if (!bugResult) return apiError(res, 500, 'Failed to create bug');
+
+    if (config.auto_assign === 'true') {
+      var projectId = config.default_project || 'mycelium';
+      autoAssignBug(core, bugResult.id, projectId);
+    }
+
+    res.json({ ok: true, bug_id: bugResult.id, error_id: id });
+  });
+
+  // GET /errors/stats — error counts, top errors, by-provider breakdown
+  router.get('/stats', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var stats = db.getStats();
+    stats.top_errors = db.getTopErrors(10);
+    res.json(stats);
+  });
+
+  // GET /errors/widgets/error-count — widget data
+  router.get('/widgets/error-count', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var stats = db.getStats();
+    var count = stats.last_24h;
+    res.json({
+      type: 'stat',
+      value: count,
+      label: 'Errors (24h)',
+      color: count > 10 ? 'red' : 'green'
+    });
+  });
+
+  return router;
+}

--- a/server/plugins/error-monitor/schema.sql
+++ b/server/plugins/error-monitor/schema.sql
@@ -1,0 +1,25 @@
+-- Plugin: error-monitor
+-- Stores raw error events from Sentry, Bugsnag, and Datadog webhooks
+
+CREATE TABLE IF NOT EXISTS dv_error_events (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider    TEXT NOT NULL DEFAULT '',
+  error_key   TEXT NOT NULL DEFAULT '',
+  title       TEXT NOT NULL DEFAULT '',
+  message     TEXT NOT NULL DEFAULT '',
+  stack_trace TEXT NOT NULL DEFAULT '',
+  url         TEXT NOT NULL DEFAULT '',
+  occurrences INTEGER NOT NULL DEFAULT 1,
+  first_seen  TEXT NOT NULL DEFAULT (datetime('now')),
+  last_seen   TEXT NOT NULL DEFAULT (datetime('now')),
+  payload     TEXT NOT NULL DEFAULT '{}',
+  bug_id      INTEGER,
+  status      TEXT NOT NULL DEFAULT 'open',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_error_events_error_key ON dv_error_events(error_key);
+CREATE INDEX IF NOT EXISTS idx_error_events_provider ON dv_error_events(provider);
+CREATE INDEX IF NOT EXISTS idx_error_events_status ON dv_error_events(status);
+CREATE INDEX IF NOT EXISTS idx_error_events_bug_id ON dv_error_events(bug_id);

--- a/server/plugins/github-sync/db.js
+++ b/server/plugins/github-sync/db.js
@@ -1,0 +1,106 @@
+// GitHub Sync plugin DB helpers
+
+export default function createGithubDB(db) {
+  return {
+    logEvent(eventType, action, repo, payload) {
+      var r = db.prepare(
+        'INSERT INTO dv_github_events (event_type, action, repo, payload) VALUES (?, ?, ?, ?) RETURNING id'
+      ).get(
+        eventType || '',
+        action || '',
+        repo || '',
+        JSON.stringify(payload || {})
+      );
+      return r.id;
+    },
+
+    getEvent(id) {
+      var row = db.prepare('SELECT * FROM dv_github_events WHERE id = ?').get(id);
+      if (!row) return null;
+      try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
+      return row;
+    },
+
+    listEvents(filters) {
+      var where = ['1=1'];
+      var params = [];
+      if (filters.event_type) { where.push('event_type = ?'); params.push(filters.event_type); }
+      if (filters.repo) { where.push('repo = ?'); params.push(filters.repo); }
+      if (filters.processed !== undefined) { where.push('processed = ?'); params.push(filters.processed ? 1 : 0); }
+      var limit = Math.min(filters.limit || 50, 200);
+      var offset = filters.offset || 0;
+      var rows = db.prepare(
+        'SELECT * FROM dv_github_events WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
+      ).all(...params, limit, offset);
+      return rows.map(function (row) {
+        try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
+        return row;
+      });
+    },
+
+    markProcessed(id) {
+      db.prepare('UPDATE dv_github_events SET processed = 1 WHERE id = ?').run(id);
+    },
+
+    createLink(githubType, githubRepo, githubNumber, myceliumType, myceliumId) {
+      var r = db.prepare(
+        'INSERT INTO dv_github_links (github_type, github_repo, github_number, mycelium_type, mycelium_id) VALUES (?, ?, ?, ?, ?) RETURNING id'
+      ).get(
+        githubType || '',
+        githubRepo || '',
+        githubNumber || 0,
+        myceliumType || '',
+        myceliumId || 0
+      );
+      return r.id;
+    },
+
+    getLink(githubType, githubRepo, githubNumber) {
+      return db.prepare(
+        'SELECT * FROM dv_github_links WHERE github_type = ? AND github_repo = ? AND github_number = ?'
+      ).get(githubType, githubRepo, githubNumber) || null;
+    },
+
+    getLinkByMycelium(myceliumType, myceliumId) {
+      return db.prepare(
+        'SELECT * FROM dv_github_links WHERE mycelium_type = ? AND mycelium_id = ?'
+      ).get(myceliumType, myceliumId) || null;
+    },
+
+    listLinks(filters) {
+      var where = ['1=1'];
+      var params = [];
+      if (filters.repo) { where.push('github_repo = ?'); params.push(filters.repo); }
+      if (filters.github_type) { where.push('github_type = ?'); params.push(filters.github_type); }
+      if (filters.mycelium_type) { where.push('mycelium_type = ?'); params.push(filters.mycelium_type); }
+      var limit = Math.min(filters.limit || 50, 200);
+      var offset = filters.offset || 0;
+      return db.prepare(
+        'SELECT * FROM dv_github_links WHERE ' + where.join(' AND ') + ' ORDER BY synced_at DESC LIMIT ? OFFSET ?'
+      ).all(...params, limit, offset);
+    },
+
+    deleteLink(id) {
+      db.prepare('DELETE FROM dv_github_links WHERE id = ?').run(id);
+    },
+
+    getStats() {
+      var eventCounts = db.prepare(
+        'SELECT event_type, COUNT(*) as count FROM dv_github_events GROUP BY event_type'
+      ).all();
+      var linkCounts = db.prepare(
+        'SELECT github_type, COUNT(*) as count FROM dv_github_links GROUP BY github_type'
+      ).all();
+      var totalEvents = db.prepare('SELECT COUNT(*) as count FROM dv_github_events').get().count;
+      var totalLinks = db.prepare('SELECT COUNT(*) as count FROM dv_github_links').get().count;
+      var unprocessed = db.prepare('SELECT COUNT(*) as count FROM dv_github_events WHERE processed = 0').get().count;
+      return {
+        total_events: totalEvents,
+        total_links: totalLinks,
+        unprocessed_events: unprocessed,
+        events_by_type: eventCounts,
+        links_by_type: linkCounts
+      };
+    }
+  };
+}

--- a/server/plugins/github-sync/handlers.js
+++ b/server/plugins/github-sync/handlers.js
@@ -1,0 +1,46 @@
+// GitHub Sync event handlers
+// Subscribes to Mycelium events and emits outbound sync events for linked GitHub entities.
+
+import createGithubDB from './db.js';
+
+export function registerHooks(core) {
+  var db = createGithubDB(core.db);
+
+  core.onEvent('task_completed', function (eventData) {
+    try {
+      var data = eventData.data || {};
+      var taskId = data.task_id || data.id;
+      if (!taskId) return;
+
+      var link = db.getLinkByMycelium('task', taskId);
+      if (!link) return;
+
+      core.emitEvent('github_sync_outbound', '__system__', eventData.project_id,
+        'Task #' + taskId + ' completed — linked to ' + link.github_repo + '#' + link.github_number,
+        { link: link, event: 'task_completed', task_id: taskId });
+
+      console.log('[github-sync] Outbound sync: task #' + taskId + ' completed -> ' + link.github_repo + '#' + link.github_number);
+    } catch (e) {
+      console.error('[github-sync] Error in task_completed hook:', e.message);
+    }
+  });
+
+  core.onEvent('bug_fixed', function (eventData) {
+    try {
+      var data = eventData.data || {};
+      var bugId = data.bug_id || data.id;
+      if (!bugId) return;
+
+      var link = db.getLinkByMycelium('bug', bugId);
+      if (!link) return;
+
+      core.emitEvent('github_sync_outbound', '__system__', eventData.project_id,
+        'Bug #' + bugId + ' fixed — linked to ' + link.github_repo + '#' + link.github_number,
+        { link: link, event: 'bug_fixed', bug_id: bugId });
+
+      console.log('[github-sync] Outbound sync: bug #' + bugId + ' fixed -> ' + link.github_repo + '#' + link.github_number);
+    } catch (e) {
+      console.error('[github-sync] Error in bug_fixed hook:', e.message);
+    }
+  });
+}

--- a/server/plugins/github-sync/mcp-tools.json
+++ b/server/plugins/github-sync/mcp-tools.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "mycelium_github_events",
+    "description": "List recent GitHub webhook events received by Mycelium. Shows pushes, PRs, issues, CI runs, and other GitHub activity.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "Filter by event type (e.g. push, pull_request, issues, check_suite, workflow_run)"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Filter by repository (e.g. SoftBacon-Software/mycelium)"
+        },
+        "limit": {
+          "type": "integer",
+          "default": 20,
+          "description": "Max number of events to return"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_github_links",
+    "description": "List entity links between GitHub PRs/issues and Mycelium tasks/bugs. Shows what is synced.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "description": "Filter by GitHub repository"
+        },
+        "github_type": {
+          "type": "string",
+          "enum": ["pr", "issue", "check"],
+          "description": "Filter by GitHub entity type"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_github_link",
+    "description": "Manually link a GitHub PR or issue to a Mycelium task or bug. Creates a bidirectional sync link.",
+    "inputSchema": {
+      "type": "object",
+      "required": ["github_repo", "github_number", "github_type", "mycelium_type", "mycelium_id"],
+      "properties": {
+        "github_repo": {
+          "type": "string",
+          "description": "GitHub repository (e.g. SoftBacon-Software/mycelium)"
+        },
+        "github_number": {
+          "type": "integer",
+          "description": "GitHub PR or issue number"
+        },
+        "github_type": {
+          "type": "string",
+          "enum": ["pr", "issue"],
+          "description": "Type of GitHub entity"
+        },
+        "mycelium_type": {
+          "type": "string",
+          "enum": ["task", "bug"],
+          "description": "Type of Mycelium entity"
+        },
+        "mycelium_id": {
+          "type": "integer",
+          "description": "Mycelium task or bug ID"
+        }
+      }
+    }
+  },
+  {
+    "name": "mycelium_github_stats",
+    "description": "Get GitHub sync statistics — event counts by type, link counts, unprocessed events.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  }
+]

--- a/server/plugins/github-sync/plugin.json
+++ b/server/plugins/github-sync/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "github-sync",
+  "version": "1.0.0",
+  "displayName": "GitHub Sync",
+  "description": "Deep GitHub integration — webhook receiver for PRs, issues, CI status. Bidirectional sync between GitHub and Mycelium tasks/bugs.",
+  "author": "SoftBacon Software",
+  "enabled": false,
+  "routePrefix": "/github",
+  "schema": "schema.sql",
+  "gatedActions": [],
+  "mcpTools": "mcp-tools.json",
+  "configSchema": [
+    { "key": "webhook_secret", "type": "secret", "label": "Webhook Secret", "description": "GitHub webhook secret for signature verification", "required": true },
+    { "key": "default_project", "type": "string", "label": "Default Project", "description": "Mycelium project ID for new items from GitHub", "required": false },
+    { "key": "auto_create_bugs", "type": "boolean", "label": "Auto-create Bugs", "description": "Automatically create Mycelium bugs from GitHub issues", "default": "true" },
+    { "key": "ci_notifications", "type": "boolean", "label": "CI Notifications", "description": "Send CI failure notifications to operator inbox", "default": "true" }
+  ]
+}

--- a/server/plugins/github-sync/routes.js
+++ b/server/plugins/github-sync/routes.js
@@ -1,0 +1,419 @@
+// GitHub Sync plugin routes
+// Webhook receiver and entity link management.
+
+import { Router } from 'express';
+import { createHmac, timingSafeEqual } from 'crypto';
+import createGithubDB from './db.js';
+
+function verifySignature(secret, payload, signature) {
+  var expected = 'sha256=' + createHmac('sha256', secret).update(payload).digest('hex');
+  try { return timingSafeEqual(Buffer.from(expected), Buffer.from(signature || '')); } catch (e) { return false; }
+}
+
+export default function (core) {
+  var router = Router();
+  var db = createGithubDB(core.db);
+  var { apiError, parseIntParam } = core;
+  var { checkAgentOrAdmin } = core.auth;
+
+  // ---- Webhook receiver (no auth — uses signature verification) ----
+
+  router.post('/webhook', function (req, res) {
+    var secret = getConfig(core.db, 'webhook_secret');
+    if (!secret) {
+      console.error('[github-sync] No webhook_secret configured');
+      return apiError(res, 500, 'Webhook secret not configured');
+    }
+
+    // Verify signature.
+    // NOTE: This requires req.rawBody to be set by the server (raw body string
+    // before JSON parsing). If rawBody is not available, we fall back to
+    // JSON.stringify(req.body) which may differ from the original payload in
+    // whitespace. For production use, ensure the server preserves rawBody.
+    var rawBody = req.rawBody || JSON.stringify(req.body);
+    var signature = req.headers['x-hub-signature-256'] || '';
+
+    if (!verifySignature(secret, rawBody, signature)) {
+      console.warn('[github-sync] Invalid webhook signature');
+      return apiError(res, 401, 'Invalid signature');
+    }
+
+    var eventType = req.headers['x-github-event'] || 'unknown';
+    var payload = req.body || {};
+    var action = payload.action || '';
+    var repo = (payload.repository && payload.repository.full_name) || '';
+
+    // Log the event
+    var eventId = db.logEvent(eventType, action, repo, payload);
+    console.log('[github-sync] Received ' + eventType + '.' + action + ' from ' + repo + ' (event #' + eventId + ')');
+
+    // Process by event type
+    try {
+      switch (eventType) {
+        case 'pull_request':
+          handlePullRequest(core, db, payload, action, repo, eventId);
+          break;
+        case 'issues':
+          handleIssue(core, db, payload, action, repo, eventId);
+          break;
+        case 'check_suite':
+          handleCheckSuite(core, db, payload, action, repo, eventId);
+          break;
+        case 'workflow_run':
+          handleWorkflowRun(core, db, payload, action, repo, eventId);
+          break;
+        case 'push':
+          handlePush(core, db, payload, repo, eventId);
+          break;
+        case 'issue_comment':
+          handleIssueComment(core, db, payload, action, repo, eventId);
+          break;
+        default:
+          // Log but don't process unknown event types
+          break;
+      }
+      db.markProcessed(eventId);
+    } catch (e) {
+      console.error('[github-sync] Error processing ' + eventType + '.' + action + ':', e.message);
+    }
+
+    res.json({ ok: true, event_id: eventId });
+  });
+
+  // ---- Events CRUD (auth required) ----
+
+  router.get('/events', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    res.json(db.listEvents({
+      event_type: req.query.event_type || undefined,
+      repo: req.query.repo || undefined,
+      processed: req.query.processed !== undefined ? req.query.processed === 'true' : undefined,
+      limit: parseInt(req.query.limit) || 50,
+      offset: parseInt(req.query.offset) || 0
+    }));
+  });
+
+  router.get('/events/:id', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var event = db.getEvent(parseIntParam(req.params.id));
+    if (!event) return apiError(res, 404, 'Event not found');
+    res.json(event);
+  });
+
+  // ---- Links CRUD (auth required) ----
+
+  router.get('/links', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    res.json(db.listLinks({
+      repo: req.query.repo || undefined,
+      github_type: req.query.github_type || undefined,
+      mycelium_type: req.query.mycelium_type || undefined,
+      limit: parseInt(req.query.limit) || 50,
+      offset: parseInt(req.query.offset) || 0
+    }));
+  });
+
+  router.post('/links', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var b = req.body;
+    if (!b.github_repo || !b.github_number || !b.github_type || !b.mycelium_type || !b.mycelium_id) {
+      return apiError(res, 400, 'Required: github_repo, github_number, github_type, mycelium_type, mycelium_id');
+    }
+    if (!['pr', 'issue', 'check'].includes(b.github_type)) {
+      return apiError(res, 400, 'github_type must be pr, issue, or check');
+    }
+    if (!['task', 'bug'].includes(b.mycelium_type)) {
+      return apiError(res, 400, 'mycelium_type must be task or bug');
+    }
+
+    // Check for existing link
+    var existing = db.getLink(b.github_type, b.github_repo, b.github_number);
+    if (existing) {
+      return apiError(res, 409, 'Link already exists', { existing: existing });
+    }
+
+    var linkId = db.createLink(b.github_type, b.github_repo, b.github_number, b.mycelium_type, b.mycelium_id);
+
+    core.emitEvent('github_link_created', who, null,
+      who + ' linked ' + b.github_repo + '#' + b.github_number + ' (' + b.github_type + ') to ' + b.mycelium_type + ' #' + b.mycelium_id,
+      { link_id: linkId, github_type: b.github_type, github_repo: b.github_repo, github_number: b.github_number, mycelium_type: b.mycelium_type, mycelium_id: b.mycelium_id });
+
+    res.json({ ok: true, link_id: linkId });
+  });
+
+  router.delete('/links/:id', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    var id = parseIntParam(req.params.id);
+    db.deleteLink(id);
+    res.json({ ok: true });
+  });
+
+  // ---- Stats ----
+
+  router.get('/stats', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+    res.json(db.getStats());
+  });
+
+  // ---- Dashboard widgets ----
+
+  router.get('/widgets/pr-status', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    // Count open PRs from recent events
+    var openPRs = db.listEvents({ event_type: 'pull_request', limit: 200 });
+    var prState = {}; // repo#number -> latest state
+    for (var i = openPRs.length - 1; i >= 0; i--) {
+      var ev = openPRs[i];
+      var pr = ev.payload.pull_request || ev.payload;
+      var key = ev.repo + '#' + (pr.number || ev.payload.number || 0);
+      prState[key] = {
+        repo: ev.repo,
+        number: pr.number || ev.payload.number || 0,
+        title: pr.title || '',
+        state: ev.action,
+        updated: ev.created_at
+      };
+    }
+
+    var open = [];
+    var recentMerges = [];
+    for (var k in prState) {
+      var p = prState[k];
+      if (p.state === 'opened' || p.state === 'synchronize' || p.state === 'reopened') {
+        open.push(p);
+      } else if (p.state === 'closed') {
+        recentMerges.push(p);
+      }
+    }
+
+    res.json({
+      open_prs: open.length,
+      open: open.slice(0, 10),
+      recent_merges: recentMerges.slice(0, 10)
+    });
+  });
+
+  router.get('/widgets/ci-status', function (req, res) {
+    var who = checkAgentOrAdmin(req, res);
+    if (!who) return;
+
+    var checkEvents = db.listEvents({ event_type: 'check_suite', limit: 20 });
+    var workflowEvents = db.listEvents({ event_type: 'workflow_run', limit: 20 });
+
+    var runs = [];
+    for (var ev of checkEvents) {
+      var suite = ev.payload.check_suite || {};
+      runs.push({
+        type: 'check_suite',
+        repo: ev.repo,
+        conclusion: suite.conclusion || ev.action,
+        branch: suite.head_branch || '',
+        created_at: ev.created_at
+      });
+    }
+    for (var ev of workflowEvents) {
+      var wf = ev.payload.workflow_run || {};
+      runs.push({
+        type: 'workflow_run',
+        repo: ev.repo,
+        name: wf.name || '',
+        conclusion: wf.conclusion || ev.action,
+        branch: wf.head_branch || '',
+        created_at: ev.created_at
+      });
+    }
+
+    runs.sort(function (a, b) { return b.created_at < a.created_at ? -1 : 1; });
+
+    res.json({
+      runs: runs.slice(0, 20),
+      latest_pass: runs.find(function (r) { return r.conclusion === 'success'; }) || null,
+      latest_fail: runs.find(function (r) { return r.conclusion === 'failure'; }) || null
+    });
+  });
+
+  return router;
+}
+
+// ---- Event handlers ----
+
+function handlePullRequest(core, db, payload, action, repo, eventId) {
+  var pr = payload.pull_request || {};
+  var number = pr.number || 0;
+  var title = pr.title || '';
+  var defaultProject = getConfig(core.db, 'default_project');
+
+  // Check for existing link
+  var link = db.getLink('pr', repo, number);
+
+  if (action === 'opened') {
+    // Notify operator inbox about new PR
+    if (core.inbox) {
+      core.inbox.createInboxItemForAllOperators(
+        'github_pr',
+        'github_pr',
+        repo + '#' + number,
+        'PR opened: ' + title,
+        repo + '#' + number + ' — ' + (pr.user && pr.user.login || 'unknown') + ': ' + title,
+        { repo: repo, number: number, title: title, url: pr.html_url || '', event_id: eventId },
+        'normal'
+      );
+    }
+    core.emitEvent('github_pr_opened', '__system__', defaultProject,
+      'PR opened: ' + repo + '#' + number + ' — ' + title,
+      { repo: repo, number: number, title: title, url: pr.html_url || '' });
+  } else if (action === 'closed' && pr.merged) {
+    // PR was merged
+    if (link) {
+      // Update linked Mycelium entity
+      core.emitEvent('github_pr_merged', '__system__', defaultProject,
+        'PR merged: ' + repo + '#' + number + ' — linked to ' + link.mycelium_type + ' #' + link.mycelium_id,
+        { repo: repo, number: number, title: title, link: link });
+    } else {
+      core.emitEvent('github_pr_merged', '__system__', defaultProject,
+        'PR merged: ' + repo + '#' + number + ' — ' + title,
+        { repo: repo, number: number, title: title });
+    }
+  } else if (action === 'closed') {
+    core.emitEvent('github_pr_closed', '__system__', defaultProject,
+      'PR closed: ' + repo + '#' + number + ' — ' + title,
+      { repo: repo, number: number, title: title });
+  }
+}
+
+function handleIssue(core, db, payload, action, repo, eventId) {
+  var issue = payload.issue || {};
+  var number = issue.number || 0;
+  var title = issue.title || '';
+  var body = issue.body || '';
+  var defaultProject = getConfig(core.db, 'default_project');
+  var autoCreateBugs = getConfigBool(core.db, 'auto_create_bugs', true);
+
+  if (action === 'opened' && autoCreateBugs) {
+    // Auto-create a Mycelium bug from the GitHub issue
+    try {
+      var bugResult = core.db.prepare(
+        "INSERT INTO dv_bugs (title, description, project_id, category, severity, status) VALUES (?, ?, ?, ?, ?, ?) RETURNING id"
+      ).get(
+        '[GH] ' + title,
+        body + '\n\n---\nSource: ' + repo + '#' + number + (issue.html_url ? '\n' + issue.html_url : ''),
+        defaultProject || 'mycelium',
+        'other',
+        'normal',
+        'open'
+      );
+
+      if (bugResult) {
+        // Create the link
+        db.createLink('issue', repo, number, 'bug', bugResult.id);
+        console.log('[github-sync] Auto-created bug #' + bugResult.id + ' from ' + repo + '#' + number);
+
+        core.emitEvent('github_issue_synced', '__system__', defaultProject,
+          'GitHub issue ' + repo + '#' + number + ' synced as bug #' + bugResult.id + ': ' + title,
+          { repo: repo, number: number, bug_id: bugResult.id, title: title });
+      }
+    } catch (e) {
+      console.error('[github-sync] Failed to create bug from issue:', e.message);
+    }
+  } else if (action === 'labeled') {
+    // Emit event for label changes (useful for triage)
+    var labels = (issue.labels || []).map(function (l) { return l.name; });
+    core.emitEvent('github_issue_labeled', '__system__', defaultProject,
+      'Issue ' + repo + '#' + number + ' labeled: ' + labels.join(', '),
+      { repo: repo, number: number, title: title, labels: labels });
+  }
+}
+
+function handleCheckSuite(core, db, payload, action, repo, eventId) {
+  var suite = payload.check_suite || {};
+  var conclusion = suite.conclusion || '';
+  var branch = suite.head_branch || '';
+  var defaultProject = getConfig(core.db, 'default_project');
+  var ciNotifications = getConfigBool(core.db, 'ci_notifications', true);
+
+  if (action === 'completed' && conclusion === 'failure' && ciNotifications) {
+    if (core.inbox) {
+      core.inbox.createInboxItemForAllOperators(
+        'github_ci',
+        'github_ci',
+        repo + '/check_suite/' + (suite.id || eventId),
+        'CI failed: ' + repo + ' (' + branch + ')',
+        'Check suite failed on ' + branch + ' in ' + repo,
+        { repo: repo, branch: branch, conclusion: conclusion, event_id: eventId },
+        'high'
+      );
+    }
+    core.emitEvent('github_ci_failed', '__system__', defaultProject,
+      'CI check suite failed: ' + repo + ' branch ' + branch,
+      { repo: repo, branch: branch, conclusion: conclusion });
+  }
+}
+
+function handleWorkflowRun(core, db, payload, action, repo, eventId) {
+  var run = payload.workflow_run || {};
+  var conclusion = run.conclusion || '';
+  var branch = run.head_branch || '';
+  var name = run.name || '';
+  var defaultProject = getConfig(core.db, 'default_project');
+  var ciNotifications = getConfigBool(core.db, 'ci_notifications', true);
+
+  if (action === 'completed' && conclusion === 'failure' && ciNotifications) {
+    if (core.inbox) {
+      core.inbox.createInboxItemForAllOperators(
+        'github_ci',
+        'github_ci',
+        repo + '/workflow_run/' + (run.id || eventId),
+        'Workflow failed: ' + name + ' (' + repo + ')',
+        'Workflow "' + name + '" failed on ' + branch + ' in ' + repo,
+        { repo: repo, branch: branch, workflow: name, conclusion: conclusion, event_id: eventId, url: run.html_url || '' },
+        'high'
+      );
+    }
+    core.emitEvent('github_workflow_failed', '__system__', defaultProject,
+      'Workflow "' + name + '" failed: ' + repo + ' branch ' + branch,
+      { repo: repo, branch: branch, workflow: name, conclusion: conclusion });
+  }
+}
+
+function handlePush(core, db, payload, repo, eventId) {
+  var ref = payload.ref || '';
+  var branch = ref.replace('refs/heads/', '');
+  var commits = payload.commits || [];
+  var defaultProject = getConfig(core.db, 'default_project');
+
+  core.emitEvent('github_push', '__system__', defaultProject,
+    'Push to ' + repo + '/' + branch + ': ' + commits.length + ' commit(s)',
+    { repo: repo, branch: branch, commit_count: commits.length, head_commit: payload.head_commit || {} });
+}
+
+function handleIssueComment(core, db, payload, action, repo, eventId) {
+  var issue = payload.issue || {};
+  var comment = payload.comment || {};
+  var number = issue.number || 0;
+  var defaultProject = getConfig(core.db, 'default_project');
+
+  if (action === 'created') {
+    core.emitEvent('github_comment', '__system__', defaultProject,
+      'Comment on ' + repo + '#' + number + ' by ' + (comment.user && comment.user.login || 'unknown'),
+      { repo: repo, number: number, body: (comment.body || '').substring(0, 500), user: comment.user && comment.user.login || '' });
+  }
+}
+
+function getConfig(db, key) {
+  var row = db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'github-sync' AND key = ?").get(key);
+  return row ? row.value : null;
+}
+
+function getConfigBool(db, key, defaultVal) {
+  var val = getConfig(db, key);
+  if (val === null) return defaultVal;
+  return val === 'true' || val === '1';
+}

--- a/server/plugins/github-sync/schema.sql
+++ b/server/plugins/github-sync/schema.sql
@@ -1,0 +1,30 @@
+-- GitHub Sync plugin schema
+-- Webhook event log and entity link mapping between GitHub and Mycelium.
+
+CREATE TABLE IF NOT EXISTS dv_github_events (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_type  TEXT NOT NULL DEFAULT '',           -- 'push', 'pull_request', 'issues', etc.
+  action      TEXT NOT NULL DEFAULT '',           -- 'opened', 'closed', 'merged', etc.
+  repo        TEXT NOT NULL DEFAULT '',           -- 'owner/repo'
+  payload     TEXT NOT NULL DEFAULT '{}',         -- full webhook payload JSON
+  processed   INTEGER NOT NULL DEFAULT 0,         -- 0=pending, 1=processed
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_dv_github_events_repo ON dv_github_events(repo);
+CREATE INDEX IF NOT EXISTS idx_dv_github_events_type ON dv_github_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_dv_github_events_created ON dv_github_events(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS dv_github_links (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  github_type     TEXT NOT NULL DEFAULT '',        -- 'pr', 'issue', 'check'
+  github_repo     TEXT NOT NULL DEFAULT '',        -- 'owner/repo'
+  github_number   INTEGER NOT NULL DEFAULT 0,      -- PR/issue number
+  mycelium_type   TEXT NOT NULL DEFAULT '',        -- 'task', 'bug'
+  mycelium_id     INTEGER NOT NULL DEFAULT 0,      -- Mycelium task/bug ID
+  synced_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_dv_github_links_repo ON dv_github_links(github_repo);
+CREATE INDEX IF NOT EXISTS idx_dv_github_links_github ON dv_github_links(github_type, github_number);
+CREATE INDEX IF NOT EXISTS idx_dv_github_links_mycelium ON dv_github_links(mycelium_type, mycelium_id);


### PR DESCRIPTION
## Summary
- **github-sync**: Webhook receiver for GitHub PRs, issues, CI status. Bidirectional entity linking. Auto-creates bugs from issues, CI failure notifications to operator inbox.
- **daily-digest**: Auto-generates daily/weekly swarm activity summaries. Delivers to operator inbox + optional Slack webhook. Trend tracking for velocity metrics.
- **error-monitor**: Receives webhooks from Sentry, Bugsnag, Datadog. Auto-files Mycelium bugs with deduplication. Severity mapping and auto-assignment.
- **cost-tracker**: Tracks token usage per agent/project/task. Budget alerts (daily/weekly). Spend dashboards with trend data.

Each plugin: `plugin.json`, `schema.sql`, `db.js`, `routes.js`, `handlers.js`, `mcp-tools.json`
All ship disabled — enable via dashboard after configuring.

Plan #36 steps 9, 10, 14, 15 (macbook-claude assignments).

## Test plan
- [ ] Each plugin loads without errors when enabled
- [ ] Schema migrations run cleanly on fresh DB
- [ ] MCP tools appear in `GET /plugins/mcp-tools`
- [ ] Config forms render in dashboard plugin detail panel
- [ ] Webhook endpoints accept and process payloads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)