### PR TITLE
feat: plugin marketplace — registry, install/uninstall, widget endpoints

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -3774,6 +3774,53 @@ router.get('/plugins/workers', function (req, res) {
   res.json(getWorkerStatus());
 });
 
+// ---- Marketplace ----
+
+var registryCache = { data: null, fetched: 0 };
+var REGISTRY_URL = 'https://raw.githubusercontent.com/SoftBacon-Software/mycelium-plugins/main/registry.json';
+var REGISTRY_TTL = 3600000; // 1 hour
+
+router.get('/plugins/registry', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var now = Date.now();
+  if (registryCache.data && (now - registryCache.fetched) < REGISTRY_TTL) {
+    return res.json(registryCache.data);
+  }
+  fetch(REGISTRY_URL)
+    .then(function (r) {
+      if (!r.ok) throw new Error('Registry fetch failed: ' + r.status);
+      return r.json();
+    })
+    .then(function (data) {
+      registryCache.data = data;
+      registryCache.fetched = now;
+      res.json(data);
+    })
+    .catch(function (err) {
+      if (registryCache.data) return res.json(registryCache.data);
+      res.status(502).json({ error: 'Failed to fetch plugin registry: ' + err.message });
+    });
+});
+
+router.get('/plugins/all-widgets', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var result = [];
+  var plugins = getLoadedPlugins();
+  for (var i = 0; i < plugins.length; i++) {
+    var p = plugins[i];
+    var widgets = p.dashboard_widgets || p.dashboardWidgets || [];
+    for (var j = 0; j < widgets.length; j++) {
+      result.push({
+        plugin: p.name,
+        plugin_display_name: p.displayName || p.name,
+        route_prefix: p.routePrefix || ('/' + p.name),
+        widget: widgets[j]
+      });
+    }
+  }
+  res.json(result);
+});
+
 router.get('/plugins/:name', function (req, res) {
   if (!checkAdmin(req, res)) return;
   var record = getPluginRecord(req.params.name);
@@ -3839,6 +3886,52 @@ router.put('/plugins/:name/disable', function (req, res) {
   updatePluginEnabled(req.params.name, 0);
   emitEvent('plugin_disabled', getAdminDisplayName(req), null, 'Disabled plugin: ' + req.params.name);
   res.json({ ok: true, name: req.params.name, enabled: 0 });
+});
+
+router.post('/plugins/install', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var name = req.body.name;
+  if (!name) return res.status(400).json({ error: 'Plugin name required' });
+
+  var record = getPluginRecord(name);
+  if (!record) return res.status(404).json({ error: 'Plugin not found in server/plugins/' });
+
+  if (record.enabled) return res.json({ ok: true, message: 'Plugin already enabled', name: name });
+
+  // Enable the plugin — server restart will load routes/handlers
+  updatePluginEnabled(name, 1);
+  emitEvent('plugin_installed', getAdminDisplayName(req), null, 'Installed plugin: ' + name, { plugin: name });
+  res.json({ ok: true, name: name, message: 'Plugin enabled. Server restart required to fully load.' });
+});
+
+router.delete('/plugins/:name/uninstall', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var record = getPluginRecord(req.params.name);
+  if (!record) return res.status(404).json({ error: 'Plugin not found' });
+
+  // Disable first
+  updatePluginEnabled(req.params.name, 0);
+
+  // Clean up config
+  var configRows = getPluginConfig(req.params.name);
+  for (var row of configRows) {
+    deletePluginConfig(req.params.name, row.key);
+  }
+
+  emitEvent('plugin_uninstalled', getAdminDisplayName(req), null, 'Uninstalled plugin: ' + req.params.name, { plugin: req.params.name });
+  res.json({ ok: true, name: req.params.name, message: 'Plugin disabled and config cleared. Server restart required. Plugin files remain in server/plugins/ for reinstall.' });
+});
+
+router.get('/plugins/:name/widgets', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var record = getPluginRecord(req.params.name);
+  if (!record) return res.status(404).json({ error: 'Plugin not found' });
+
+  var loaded = getLoadedPlugins().find(function (p) { return p.name === req.params.name; });
+  if (!loaded) return res.json({ widgets: [] });
+
+  var widgets = loaded.dashboard_widgets || loaded.dashboardWidgets || [];
+  res.json({ widgets: widgets, route_prefix: loaded.routePrefix || ('/' + loaded.name) });
 });
 
 // ======== BACKUPS ========

--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -503,6 +503,22 @@ export function disablePlugin(name: string): Promise<{ ok: boolean }> {
   return apiPut<{ ok: boolean }>(`/plugins/${encodeURIComponent(name)}/disable`, {});
 }
 
+export function fetchPluginRegistry(): Promise<any[]> {
+  return apiGet<any[]>('/plugins/registry');
+}
+
+export function installPlugin(name: string): Promise<{ ok: boolean; message: string }> {
+  return apiPost<{ ok: boolean; message: string }>('/plugins/install', { name });
+}
+
+export function uninstallPlugin(name: string): Promise<{ ok: boolean; message: string }> {
+  return apiDelete<{ ok: boolean; message: string }>(`/plugins/${encodeURIComponent(name)}/uninstall`);
+}
+
+export function fetchAllWidgets(): Promise<any[]> {
+  return apiGet<any[]>('/plugins/all-widgets');
+}
+
 // Inbox
 
 export function fetchInbox(status?: string): Promise<InboxItem[]> {

--- a/studio-react/src/pages/PluginsPage.tsx
+++ b/studio-react/src/pages/PluginsPage.tsx
@@ -3,11 +3,12 @@ import { useDashboardStore } from '../stores/dashboardStore'
 import {
   enablePlugin, disablePlugin,
   fetchPlugin, fetchPluginConfig, savePluginConfig,
+  fetchPluginRegistry, installPlugin, uninstallPlugin,
 } from '../api/endpoints'
 import type { Plugin, PluginConfigField } from '../api/types'
 import { toast } from 'sonner'
 
-// ─── Marketplace registry stub ────────────────────────────────────────────────
+// ─── Marketplace registry types ───────────────────────────────────────────────
 interface MarketplacePlugin {
   name: string
   display_name: string
@@ -18,36 +19,6 @@ interface MarketplacePlugin {
   repo_url: string
 }
 
-// Static stub — will be replaced by registry.json fetch once the repo is live
-const MARKETPLACE_STUBS: MarketplacePlugin[] = [
-  {
-    name: 'slack-notifier',
-    display_name: 'Slack Notifier',
-    description: 'Posts agent events to a Slack channel via webhook. Highly configurable — choose which event types get notified.',
-    author: 'SoftBacon Software',
-    version: '1.0.0',
-    trusted: true,
-    repo_url: 'https://github.com/SoftBacon-Software/mycelium-plugins',
-  },
-  {
-    name: 'webhook-forwarder',
-    display_name: 'Webhook Forwarder',
-    description: 'Forwards all platform events to an external HTTP endpoint with HMAC request signing for security.',
-    author: 'SoftBacon Software',
-    version: '1.0.0',
-    trusted: true,
-    repo_url: 'https://github.com/SoftBacon-Software/mycelium-plugins',
-  },
-  {
-    name: 'github-integration',
-    display_name: 'GitHub Integration',
-    description: 'Bridges Mycelium to GitHub. Creates issues from bugs, closes issues on task completion. Adds MCP tools: create/list/close issues.',
-    author: 'SoftBacon Software',
-    version: '1.0.0',
-    trusted: true,
-    repo_url: 'https://github.com/SoftBacon-Software/mycelium-plugins',
-  },
-]
 
 // ─── Config field renderer ────────────────────────────────────────────────────
 function ConfigField({
@@ -155,15 +126,18 @@ function PluginDetailPanel({
   plugin,
   onClose,
   onToggle,
+  onUninstall,
 }: {
   plugin: Plugin
   onClose: () => void
   onToggle: (name: string, enabled: number) => void
+  onUninstall: (name: string) => void
 }) {
   const [detail, setDetail] = useState<Plugin | null>(null)
   const [localConfig, setLocalConfig] = useState<Record<string, string>>({})
   const [saving, setSaving] = useState(false)
   const [loadingDetail, setLoadingDetail] = useState(true)
+  const [uninstalling, setUninstalling] = useState(false)
 
   // Load enriched plugin detail + current config
   useEffect(() => {
@@ -399,6 +373,33 @@ function PluginDetailPanel({
                   </div>
                 </section>
               )}
+
+              {/* Uninstall — only show for disabled plugins */}
+              {!plugin.enabled && (
+                <section className="mt-4 pt-4 border-t border-border/50">
+                  <button
+                    type="button"
+                    disabled={uninstalling}
+                    onClick={async () => {
+                      if (!confirm(`Uninstall "${plugin.display_name || plugin.name}"? This will remove the plugin and its configuration.`)) return
+                      setUninstalling(true)
+                      try {
+                        await uninstallPlugin(plugin.name)
+                        toast.success(`Uninstalled plugin: ${plugin.display_name || plugin.name}`)
+                        onUninstall(plugin.name)
+                        onClose()
+                      } catch (err: any) {
+                        toast.error(`Failed to uninstall: ${err.message}`)
+                      } finally {
+                        setUninstalling(false)
+                      }
+                    }}
+                    className="text-xs text-red hover:text-red/80 transition-colors disabled:opacity-50"
+                  >
+                    {uninstalling ? 'Uninstalling...' : 'Uninstall plugin'}
+                  </button>
+                </section>
+              )}
             </div>
           )}
         </div>
@@ -408,62 +409,120 @@ function PluginDetailPanel({
 }
 
 // ─── Marketplace tab ──────────────────────────────────────────────────────────
-function MarketplaceTab() {
-  return (
-    <div className="flex flex-col gap-4">
-      {/* Coming-soon banner */}
-      <div className="bg-accent/10 border border-accent/20 rounded-lg p-4 flex flex-col gap-1">
-        <p className="text-sm font-medium text-text">
-          🛒 Marketplace is coming soon
-        </p>
-        <p className="text-xs text-text-muted">
-          Browse, install, and publish community plugins. Anyone + their Claude
-          can build a plugin and publish it back to the registry.
-        </p>
+function MarketplaceTab({ installedNames, onInstalled }: { installedNames: Set<string>; onInstalled: () => void }) {
+  const [registry, setRegistry] = useState<MarketplacePlugin[]>([])
+  const [loadingRegistry, setLoadingRegistry] = useState(true)
+  const [registryError, setRegistryError] = useState<string | null>(null)
+  const [installing, setInstalling] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoadingRegistry(true)
+    setRegistryError(null)
+
+    fetchPluginRegistry()
+      .then((data) => {
+        if (!cancelled) setRegistry(data)
+      })
+      .catch((err) => {
+        if (!cancelled) setRegistryError(err?.message || 'Failed to load registry')
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingRegistry(false)
+      })
+
+    return () => { cancelled = true }
+  }, [])
+
+  const handleInstall = useCallback(async (name: string) => {
+    setInstalling(name)
+    try {
+      const result = await installPlugin(name)
+      toast.success(result.message || `Installed plugin: ${name}`)
+      onInstalled()
+    } catch (err: any) {
+      toast.error(`Failed to install: ${err.message}`)
+    } finally {
+      setInstalling(null)
+    }
+  }, [onInstalled])
+
+  if (loadingRegistry) {
+    return (
+      <div className="flex items-center justify-center h-32 text-text-muted text-sm">
+        Loading registry...
+      </div>
+    )
+  }
+
+  if (registryError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-32 gap-2">
+        <p className="text-sm text-text-muted">Registry unavailable</p>
+        <p className="text-xs text-text-dim">{registryError}</p>
         <a
           href="https://github.com/SoftBacon-Software/mycelium-plugins"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-xs text-accent hover:underline mt-1 self-start"
+          className="text-xs text-accent hover:underline mt-1"
         >
-          github.com/SoftBacon-Software/mycelium-plugins →
+          github.com/SoftBacon-Software/mycelium-plugins
         </a>
       </div>
+    )
+  }
 
-      {/* Preview cards */}
-      <p className="text-xs text-text-muted font-medium uppercase tracking-wide">
-        Coming to the registry
-      </p>
+  if (registry.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-32 text-text-muted text-sm">
+        No plugins in registry yet
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-        {MARKETPLACE_STUBS.map((mp) => (
-          <div
-            key={mp.name}
-            className="bg-surface border border-border/60 rounded-lg p-4 flex flex-col gap-2 opacity-75"
-          >
-            <div className="flex items-start justify-between gap-2">
-              <div className="flex flex-col gap-0.5">
-                <div className="flex items-center gap-1.5">
-                  <h3 className="text-sm font-semibold text-text">{mp.display_name}</h3>
-                  {mp.trusted && (
-                    <span className="text-[10px] bg-green/10 text-green px-1.5 py-0.5 rounded font-medium">
-                      trusted
-                    </span>
-                  )}
+        {registry.map((mp) => {
+          const isInstalled = installedNames.has(mp.name)
+          const isInstalling = installing === mp.name
+
+          return (
+            <div
+              key={mp.name}
+              className="bg-surface border border-border/60 rounded-lg p-4 flex flex-col gap-2"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex flex-col gap-0.5">
+                  <div className="flex items-center gap-1.5">
+                    <h3 className="text-sm font-semibold text-text">{mp.display_name}</h3>
+                    {mp.author === 'SoftBacon Software' && (
+                      <span className="text-[10px] bg-green/10 text-green px-1.5 py-0.5 rounded font-medium">
+                        Verified
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-[11px] text-text-muted">by {mp.author} · v{mp.version}</span>
                 </div>
-                <span className="text-[11px] text-text-muted">by {mp.author} · v{mp.version}</span>
+                {isInstalled ? (
+                  <span className="shrink-0 text-[10px] bg-accent/10 text-accent px-2.5 py-1 rounded font-medium">
+                    Installed
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => handleInstall(mp.name)}
+                    disabled={isInstalling}
+                    className="shrink-0 text-xs bg-accent text-white px-3 py-1 rounded hover:bg-accent/90 transition-colors disabled:opacity-50"
+                  >
+                    {isInstalling ? 'Installing...' : 'Install'}
+                  </button>
+                )}
               </div>
-              <button
-                type="button"
-                disabled
-                className="shrink-0 text-xs bg-surface-raised text-text-muted px-3 py-1 rounded cursor-not-allowed"
-                title="Marketplace install coming soon"
-              >
-                Install
-              </button>
+              <p className="text-xs text-text-dim leading-relaxed">{mp.description}</p>
             </div>
-            <p className="text-xs text-text-dim leading-relaxed">{mp.description}</p>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )
@@ -535,9 +594,6 @@ export default function PluginsPage() {
               }`}
             >
               Marketplace
-              <span className="ml-1.5 text-[10px] bg-accent/20 text-accent px-1 py-0.5 rounded font-medium">
-                soon
-              </span>
             </button>
           </div>
 
@@ -555,7 +611,10 @@ export default function PluginsPage() {
       {/* Body */}
       <div className="flex-1 min-h-0 overflow-y-auto pb-2">
         {activeTab === 'marketplace' ? (
-          <MarketplaceTab />
+          <MarketplaceTab
+            installedNames={new Set(plugins.map((p) => p.name))}
+            onInstalled={refresh}
+          />
         ) : (
           <>
             {plugins.length === 0 && !loading && (
@@ -644,6 +703,10 @@ export default function PluginsPage() {
           plugin={selectedPlugin}
           onClose={() => setSelectedPlugin(null)}
           onToggle={handleToggle}
+          onUninstall={() => {
+            setSelectedPlugin(null)
+            refresh()
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Server: 5 new marketplace endpoints (registry fetch, install, uninstall, widget aggregation)
- Dashboard: Real marketplace tab replacing stubs — browse, install, uninstall, verified badges
- Registry cached hourly from GitHub, graceful fallback on failure

Plan #36 steps 1-6 (marketplace infrastructure).

## Test plan
- [ ] GET /plugins/registry returns data (or graceful 502 before repo exists)
- [ ] POST /plugins/install enables a disabled plugin
- [ ] DELETE /plugins/:name/uninstall disables + clears config
- [ ] Dashboard marketplace tab loads without errors
- [ ] Dashboard build succeeds (verified: vite build passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)