### PR TITLE
feat: plugin page system — sidebar nav injection + page viewer

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -3821,6 +3821,24 @@ router.get('/plugins/all-widgets', function (req, res) {
   res.json(result);
 });
 
+// GET /plugins/nav — lightweight page declarations for all loaded plugins
+router.get('/plugins/nav', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var plugins = getLoadedPlugins();
+  var nav = [];
+  for (var i = 0; i < plugins.length; i++) {
+    var p = plugins[i];
+    if (!p.pages || p.pages.length === 0) continue;
+    nav.push({
+      name: p.name,
+      display_name: p.displayName || p.name,
+      route_prefix: p.routePrefix || ('/' + p.name),
+      pages: p.pages
+    });
+  }
+  res.json(nav);
+});
+
 router.get('/plugins/:name', function (req, res) {
   if (!checkAdmin(req, res)) return;
   var record = getPluginRecord(req.params.name);
@@ -3835,6 +3853,7 @@ router.get('/plugins/:name', function (req, res) {
     mcp_tools: mcpTools.map(function (t) { return { name: t.name, description: t.description || '' }; }),
     hooks: loaded ? (loaded.hooks || []) : [],
     gated_actions: loaded ? (loaded.gatedActions || []) : [],
+    pages: loaded ? (loaded.pages || []) : [],
   });
 });
 

--- a/studio-react/src/App.tsx
+++ b/studio-react/src/App.tsx
@@ -29,6 +29,7 @@ const PluginsPage = lazy(() => import('./pages/PluginsPage'))
 const SpawnsPage = lazy(() => import('./pages/SpawnsPage'))
 const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'))
 const FeedbackPage = lazy(() => import('./pages/FeedbackPage'))
+const PluginPageView = lazy(() => import('./pages/PluginPageView'))
 
 export default function App() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
@@ -80,6 +81,7 @@ export default function App() {
             <Route path="spawns" element={<SpawnsPage />} />
             <Route path="analytics" element={<AnalyticsPage />} />
             <Route path="feedback" element={<FeedbackPage />} />
+            <Route path="plugins/:pluginName/*" element={<Suspense fallback={<div className="p-8 text-text-dim">Loading...</div>}><PluginPageView /></Suspense>} />
           </Route>
         </Routes>
       </Suspense>

--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -27,6 +27,7 @@ import type {
   ThreadSummary,
   WebhookDelivery,
   Plugin,
+  PluginPage,
   Feedback,
   FeedbackSummary,
   InboxItem,
@@ -517,6 +518,17 @@ export function uninstallPlugin(name: string): Promise<{ ok: boolean; message: s
 
 export function fetchAllWidgets(): Promise<any[]> {
   return apiGet<any[]>('/plugins/all-widgets');
+}
+
+export interface PluginNavEntry {
+  name: string
+  display_name: string
+  route_prefix: string
+  pages: PluginPage[]
+}
+
+export function fetchPluginNav(): Promise<PluginNavEntry[]> {
+  return apiGet<PluginNavEntry[]>('/plugins/nav');
 }
 
 // Inbox

--- a/studio-react/src/api/types.ts
+++ b/studio-react/src/api/types.ts
@@ -330,6 +330,13 @@ export interface AdminOps {
 }
 
 
+export interface PluginPage {
+  path: string
+  title: string
+  icon?: string
+  nav_section?: string  // 'pinned' | 'work' | 'communicate' | 'observe' | 'manage' | 'advanced'
+}
+
 export interface PluginMcpTool {
   name: string
   description: string
@@ -352,6 +359,7 @@ export interface Plugin {
   mcp_tools?: PluginMcpTool[]
   hooks?: string[]
   gated_actions?: string[]
+  pages?: PluginPage[]
 }
 
 export interface PluginConfigField {

--- a/studio-react/src/layouts/SideNav.tsx
+++ b/studio-react/src/layouts/SideNav.tsx
@@ -1,8 +1,10 @@
 import { NavLink, useLocation } from 'react-router-dom'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useDashboardStore } from '../stores/dashboardStore'
 import { useAuthStore } from '../stores/authStore'
 import { useVoiceStore } from '../stores/voiceStore'
+import { fetchPluginNav } from '../api/endpoints'
+import type { PluginNavEntry } from '../api/endpoints'
 import {
   LayoutDashboard, CheckSquare, Map, Bug,
   MessageSquare, Radio, ShieldCheck, Inbox,
@@ -30,7 +32,7 @@ interface NavSection {
 
 /* ── Navigation structure ── */
 
-const navSections: NavSection[] = [
+const staticNavSections: NavSection[] = [
   {
     id: 'pinned',
     label: null,
@@ -102,7 +104,7 @@ function loadCollapsedSections(): Record<string, boolean> {
     if (stored) return JSON.parse(stored)
   } catch { /* ignore */ }
   return Object.fromEntries(
-    navSections.filter((s) => s.label).map((s) => [s.id, s.defaultCollapsed ?? false])
+    staticNavSections.filter((s) => s.label).map((s) => [s.id, s.defaultCollapsed ?? false])
   )
 }
 
@@ -132,6 +134,34 @@ export default function SideNav({ mobileOpen, onMobileClose, isMobile }: SideNav
   const voicePeers = useVoiceStore((s) => s.peers)
   const voiceLeave = useVoiceStore((s) => s.leave)
   const location = useLocation()
+
+  // Plugin page nav entries
+  const [pluginNav, setPluginNav] = useState<PluginNavEntry[]>([])
+  useEffect(() => {
+    if (!isAdmin) return
+    fetchPluginNav().then(setPluginNav).catch(() => {})
+  }, [isAdmin])
+
+  // Build nav sections with plugin pages injected
+  const navSections = useMemo(() => {
+    const sections = staticNavSections.map((s) => ({
+      ...s,
+      items: [...s.items],
+    }))
+    for (const entry of pluginNav) {
+      for (const page of entry.pages) {
+        const section = sections.find((s) => s.id === (page.nav_section || 'advanced'))
+        if (section) {
+          section.items.push({
+            to: `/plugins/${entry.name}${page.path}`,
+            label: page.title,
+            icon: Puzzle,
+          })
+        }
+      }
+    }
+    return sections
+  }, [pluginNav])
 
   const onlineCount = agents.filter((a) => a.status === 'online').length
 

--- a/studio-react/src/pages/PluginPageView.tsx
+++ b/studio-react/src/pages/PluginPageView.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { useDashboardStore } from '../stores/dashboardStore'
+
+export default function PluginPageView() {
+  const { pluginName, '*': pagePath } = useParams()
+  const plugins = useDashboardStore((s) => s.plugins)
+  const [data, setData] = useState<unknown>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const plugin = plugins.find((p) => p.name === pluginName)
+  const routePrefix = plugin?.route_prefix || `/${pluginName}`
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    const url = `/api/mycelium${routePrefix}/${pagePath || ''}`
+    fetch(url, {
+      headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
+        return r.json()
+      })
+      .then((d) => {
+        setData(d)
+        setLoading(false)
+      })
+      .catch((e) => {
+        setError(e.message)
+        setLoading(false)
+      })
+  }, [pluginName, pagePath, routePrefix])
+
+  if (loading) return <div className="p-8 text-text-dim">Loading...</div>
+  if (error) return <div className="p-8 text-red">{error}</div>
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold text-text mb-6">
+        {plugin?.display_name || pluginName}
+      </h1>
+      <pre className="bg-surface-raised rounded-lg p-4 text-sm text-text-dim overflow-auto whitespace-pre-wrap">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Plugins can declare `pages` in `plugin.json` that appear in the dashboard sidebar
- `GET /plugins/nav` returns page declarations for all loaded plugins
- Generic `PluginPageView` component fetches and renders plugin API data
- SideNav dynamically injects plugin pages into the appropriate nav section

Completes Plan #36 marketplace infrastructure.

## Test plan
- [ ] Vite build passes (verified)
- [ ] Server syntax check passes (verified)
- [ ] Plugin pages route correctly at /plugins/:name/*
- [ ] SideNav shows plugin pages for enabled plugins with pages declared

🤖 Generated with [Claude Code](https://claude.com/claude-code)