### PR TITLE
Add README docs for all 14 plugins

### DIFF
--- a/server/plugins/build-in-public/README.md
+++ b/server/plugins/build-in-public/README.md
@@ -1,0 +1,69 @@
+# Build in Public
+
+Auto-generates social media draft posts from agent milestones and routes them to operator inbox for approval before publishing.
+
+Watches for task completions, bug fixes, plan step completions, and drone job completions. When triggered, it creates a draft post with templated content and sends it to all operator inboxes for review. Approved drafts can be handed off to the `social-posting` plugin for publishing.
+
+## Configuration
+
+No config schema fields. The plugin reads `instance_url` from `dv_instance_config` to include in draft content.
+
+## Gated Actions
+
+- `bip_post_publish` -- approval gate required when approving drafts for publishing.
+
+## API Endpoints
+
+All routes are prefixed with `/bip`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/bip/drafts` | Agent/Admin | List drafts. Filter by `?status=` and `?trigger_event=`. Supports `limit` and `offset`. |
+| GET | `/bip/drafts/:id` | Agent/Admin | Get a single draft by ID. |
+| PUT | `/bip/drafts/:id` | Agent/Admin | Edit draft `title`, `content`, or `platforms`. |
+| POST | `/bip/drafts/:id/approve` | Admin | Approve a pending draft. Checks `bip_post_publish` gate. Marks linked inbox items as actioned. |
+| POST | `/bip/drafts/:id/reject` | Admin | Reject a pending draft. Accepts optional `note` in body. |
+| DELETE | `/bip/drafts/:id` | Admin | Delete a draft. |
+| GET | `/bip/stats` | Agent/Admin | Draft counts grouped by status. |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_bip_list` | List drafts. Filter by `status` (pending/approved/rejected/published/skipped), `trigger_event`, and `limit`. |
+| `mycelium_bip_draft` | Manually create a draft post. Requires `title` and `content`. Optional `platforms` (twitter/instagram/tiktok) and `trigger_event`. |
+| `mycelium_bip_approve` | Approve a draft by `draft_id`. Optional `approval_id` for pre-obtained gate approval. |
+
+## Events
+
+**Listens to:**
+- `task_completed` -- creates draft from completed task
+- `plan_step_completed` -- creates draft from completed plan step
+- `bug_fixed` -- creates draft from fixed bug
+- `drone_job_completed` -- creates draft from completed drone job
+
+**Emits:**
+- `bip_draft_created` -- when a new draft is auto-generated
+- `bip_draft_approved` -- when an admin approves a draft
+- `bip_draft_rejected` -- when an admin rejects a draft
+
+## Database Tables
+
+### `dv_bip_drafts`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| trigger_event | TEXT | Event type that triggered the draft |
+| trigger_data | TEXT (JSON) | Original event payload |
+| title | TEXT | Draft headline |
+| content | TEXT | Draft post content |
+| platforms | TEXT (JSON) | Target platforms array (default: `["twitter"]`) |
+| status | TEXT | `pending`, `approved`, `rejected`, `published`, `skipped` |
+| approval_id | INTEGER | Linked approval entry |
+| inbox_item_id | TEXT (JSON) | Array of linked operator inbox IDs |
+| rejection_note | TEXT | Reason for rejection |
+| posted_at | TEXT | When the post was published |
+| post_ids | TEXT (JSON) | Platform-to-post-ID mapping |
+| created_at | TEXT | Creation timestamp |
+| updated_at | TEXT | Last update timestamp |

--- a/server/plugins/cost-tracker/README.md
+++ b/server/plugins/cost-tracker/README.md
@@ -1,0 +1,95 @@
+# Cost Tracker
+
+Tracks AI API token usage and costs per agent, project, and task. Provides budget alerts and spend dashboards.
+
+Records token usage both manually (via API/MCP) and automatically from agent heartbeats. Aggregates costs into daily summaries by agent and project. When daily or weekly spend exceeds a configurable threshold percentage of budget, sends alerts to all operator inboxes.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `budget_daily` | number | 0 | Daily spend limit in USD. 0 = no limit. |
+| `budget_weekly` | number | 0 | Weekly spend limit in USD. 0 = no limit. |
+| `alert_threshold_pct` | number | 80 | Alert when budget usage exceeds this percentage. |
+| `price_input_mtok` | number | 15 | Cost per million input tokens (USD). |
+| `price_output_mtok` | number | 75 | Cost per million output tokens (USD). |
+| `price_cache_read_mtok` | number | 1.50 | Cost per million cached input tokens (USD). |
+
+## API Endpoints
+
+All routes are prefixed with `/costs`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/costs/record` | Agent/Admin | Record token usage. Requires `input_tokens` and/or `output_tokens`. Optional: `cache_read_tokens`, `task_id`, `session_id`, `project_id`. Auto-calculates cost and checks budgets. |
+| GET | `/costs/summary` | Agent/Admin | Current period summary: today's spend, week's spend, budget status, top agents. |
+| GET | `/costs/by-agent` | Agent/Admin | Cost breakdown by agent. Optional `?date_from=` and `?date_to=`. |
+| GET | `/costs/by-project` | Agent/Admin | Cost breakdown by project. Optional `?date_from=` and `?date_to=`. |
+| GET | `/costs/trends` | Agent/Admin | Daily cost trend data. Optional `?days=` (default 14). |
+| GET | `/costs/entries` | Admin | Raw cost entries. Filter by `agent_id`, `project_id`, `date_from`, `date_to`. Supports `limit` and `offset`. |
+| GET | `/costs/alerts` | Agent/Admin | Recent budget alerts. Optional `?limit=`. |
+| GET | `/costs/widgets/spend-today` | Agent/Admin | Widget: today's spend with trend vs yesterday. |
+| GET | `/costs/widgets/budget-status` | Agent/Admin | Widget: daily budget usage percentage. |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_cost_report` | Get current period cost summary (today, week, budget status, top agents). |
+| `mycelium_cost_record` | Record token usage. Requires `input_tokens` and `output_tokens`. Optional `cache_read_tokens` and `task_id`. |
+| `mycelium_cost_by_agent` | Cost breakdown by agent for a date range. |
+| `mycelium_cost_by_project` | Cost breakdown by project for a date range. |
+| `mycelium_cost_trends` | Daily cost trend data for N days (default 14). |
+
+## Events
+
+**Listens to:**
+- `agent_heartbeat` -- auto-records token usage if `tokens` or `token_usage` is present in heartbeat data (fields: `input`, `output`, `cache_read`)
+
+**Emits:**
+- (none directly, but triggers operator inbox alerts when budgets are exceeded)
+
+## Database Tables
+
+### `dv_cost_entries`
+Individual token usage records.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| agent_id | TEXT | Agent that used the tokens |
+| project_id | TEXT | Associated project |
+| task_id | INTEGER | Associated task (nullable) |
+| input_tokens | INTEGER | Input token count |
+| output_tokens | INTEGER | Output token count |
+| cache_read_tokens | INTEGER | Cached input token count |
+| cost_usd | REAL | Calculated cost in USD |
+| session_id | TEXT | Agent session identifier |
+| recorded_at | TEXT | Timestamp |
+
+### `dv_cost_daily`
+Daily aggregated cost summaries (unique per date + agent + project).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| date | TEXT | Date (YYYY-MM-DD) |
+| agent_id | TEXT | Agent ID |
+| project_id | TEXT | Project ID |
+| total_input | INTEGER | Total input tokens for the day |
+| total_output | INTEGER | Total output tokens for the day |
+| total_cache | INTEGER | Total cached tokens for the day |
+| total_cost | REAL | Total cost in USD |
+| entry_count | INTEGER | Number of entries aggregated |
+
+### `dv_cost_alerts`
+Budget alert history.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| alert_type | TEXT | `daily_budget` or `weekly_budget` |
+| threshold_pct | REAL | Percentage that triggered the alert |
+| current_spend | REAL | Spend at time of alert |
+| budget_limit | REAL | Budget limit at time of alert |
+| triggered_at | TEXT | Timestamp |

--- a/server/plugins/daily-digest/README.md
+++ b/server/plugins/daily-digest/README.md
@@ -1,0 +1,76 @@
+# Daily Digest
+
+Auto-generates daily and weekly summaries of swarm activity and delivers them to operator inbox and optional Slack.
+
+Gathers completed tasks, fixed bugs, advanced plan steps, message counts, and per-agent breakdowns for a time period. Stores reports and records time-series metrics for trend tracking. Supports manual generation and scheduled delivery.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `schedule` | select | daily | How often to generate digests (`daily` or `weekly`). |
+| `timezone` | string | UTC | IANA timezone for digest generation (e.g. `America/Chicago`). |
+| `digest_hour` | number | 8 | Hour of day (0-23) to generate the digest. |
+| `slack_webhook` | secret | (none) | Optional Slack incoming webhook URL for digest delivery. |
+| `include_agent_stats` | boolean | true | Include per-agent task/bug/step breakdown in digest. |
+
+## API Endpoints
+
+All routes are prefixed with `/digest`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/digest/reports` | Agent/Admin | List past digest reports. Filter by `?type=` (daily/weekly). Supports `limit` and `offset`. |
+| GET | `/digest/reports/:id` | Agent/Admin | Get a single digest report with full content. |
+| POST | `/digest/generate` | Admin | Manually generate a digest. Body: `{ "type": "daily" }` or `"weekly"`. Creates report, records metrics, delivers to inbox and Slack. |
+| GET | `/digest/preview` | Admin | Preview what the next digest would contain without saving. Query: `?type=daily` or `weekly`. |
+| POST | `/digest/deliver/:id` | Admin | Re-deliver an existing report to inbox and Slack. |
+| GET | `/digest/trends` | Agent/Admin | Trend data for a metric. Query: `?metric=` (tasks_completed, bugs_fixed, plan_steps_completed, messages_sent) and `?periods=` (default 14). |
+| GET | `/digest/widgets/velocity` | Agent/Admin | Widget: today's task and bug completion counts. |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_digest_preview` | Preview current period's digest without saving. Optional `type` (daily/weekly). |
+| `mycelium_digest_generate` | Generate and deliver a digest now. Requires `type` (daily/weekly). |
+| `mycelium_digest_trends` | Get trend data for a metric over recent periods. Requires `metric`, optional `periods`. |
+| `mycelium_digest_reports` | List past digest reports. Optional `type` filter and `limit`. |
+
+## Events
+
+**Listens to:**
+- `task_completed` -- increments `tasks_completed` metric for the agent and total
+- `bug_fixed` -- increments `bugs_fixed` metric for the agent and total
+- `plan_step_completed` -- increments `plan_steps_completed` metric for the agent and total
+
+**Emits:**
+- `digest_generated` -- when a digest report is created
+
+## Database Tables
+
+### `dv_digest_reports`
+Stored digest reports.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| period_start | TEXT | ISO date start of the reporting period |
+| period_end | TEXT | ISO date end of the reporting period |
+| digest_type | TEXT | `daily` or `weekly` |
+| content | TEXT (JSON) | Full digest data (tasks, bugs, steps, agent stats) |
+| summary | TEXT | Human-readable summary text |
+| delivered_to | TEXT (JSON) | Array of delivery targets (e.g. `["inbox", "slack"]`) |
+| created_at | TEXT | Creation timestamp |
+
+### `dv_digest_metrics`
+Time-series metric snapshots for trend tracking.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| metric_type | TEXT | Metric name (e.g. `tasks_completed`, `bugs_fixed`) |
+| metric_key | TEXT | Agent ID or `total` |
+| value | REAL | Metric value |
+| period | TEXT | Date string for the period |
+| recorded_at | TEXT | Timestamp |

--- a/server/plugins/error-monitor/README.md
+++ b/server/plugins/error-monitor/README.md
@@ -1,0 +1,72 @@
+# Error Monitor
+
+Receives error alerts from Sentry, Bugsnag, and Datadog via webhooks. Auto-files Mycelium bugs with stack traces and deduplication.
+
+Provides webhook endpoints for each supported error tracking service. Errors are deduplicated by a provider-specific key and occurrence counts are tracked. When an error meets the auto-file threshold, a Mycelium bug is created automatically with the stack trace, linked to the error, and routed to operator inbox. Errors are auto-resolved when their linked bugs are fixed.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `provider` | select | (required) | Error tracking service: `sentry`, `bugsnag`, or `datadog`. |
+| `webhook_secret` | secret | (none) | Secret for verifying webhook signatures. |
+| `auto_assign` | boolean | false | Auto-assign bugs to the most recently active agent. |
+| `auto_file_threshold` | number | 1 | Minimum error occurrences before auto-filing a bug. 0 = file immediately. |
+| `default_project` | string | (none) | Mycelium project ID for new bugs. |
+| `default_severity` | select | normal | Default bug severity: `low`, `normal`, `high`, `critical`. |
+
+## API Endpoints
+
+All routes are prefixed with `/errors`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/errors/webhook/sentry` | None | Sentry webhook receiver. Extracts issue ID, title, and metadata. |
+| POST | `/errors/webhook/bugsnag` | None | Bugsnag webhook receiver. Extracts exception class, message, and stack trace. |
+| POST | `/errors/webhook/datadog` | None | Datadog webhook receiver. Extracts alert ID, title, and text. |
+| GET | `/errors/events` | Agent/Admin | List error events. Filter by `?provider=` and `?status=` (open/muted/resolved). Supports `limit` and `offset`. |
+| GET | `/errors/events/:id` | Agent/Admin | Get a single error event with full payload. |
+| PUT | `/errors/events/:id` | Agent/Admin | Update error: set `status` (open/muted/resolved) or link `bug_id`. |
+| POST | `/errors/events/:id/file-bug` | Admin | Manually file a Mycelium bug from an error event. |
+| GET | `/errors/stats` | Agent/Admin | Error counts by provider, by status, last 24h count, and top errors by occurrences. |
+| GET | `/errors/widgets/error-count` | Agent/Admin | Widget: error count in last 24 hours. |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_errors_recent` | List recent errors. Filter by `provider`, `status` (default: open), and `limit`. |
+| `mycelium_errors_stats` | Error statistics: counts by provider, by status, last 24h, top errors. |
+| `mycelium_errors_mute` | Mute a noisy error by `error_id`. Muted errors still track occurrences but won't auto-file bugs. |
+| `mycelium_errors_file_bug` | Manually file a Mycelium bug from an error by `error_id`. |
+
+## Events
+
+**Listens to:**
+- `bug_fixed` -- auto-resolves any open error events linked to the fixed bug
+
+**Emits:**
+- `error_received` -- when a webhook is processed (includes `is_new` and `occurrences`)
+- `error_bug_filed` -- when a bug is auto-filed from an error
+
+## Database Tables
+
+### `dv_error_events`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| provider | TEXT | Error service: `sentry`, `bugsnag`, or `datadog` |
+| error_key | TEXT | Deduplication key (e.g. `sentry:12345`) |
+| title | TEXT | Error title / exception class |
+| message | TEXT | Error message |
+| stack_trace | TEXT | Stack trace (if available) |
+| url | TEXT | Link to error in the provider's UI |
+| occurrences | INTEGER | Number of times this error has been seen |
+| first_seen | TEXT | First occurrence timestamp |
+| last_seen | TEXT | Most recent occurrence timestamp |
+| payload | TEXT (JSON) | Full webhook payload |
+| bug_id | INTEGER | Linked Mycelium bug ID (nullable) |
+| status | TEXT | `open`, `muted`, or `resolved` |
+| created_at | TEXT | Creation timestamp |
+| updated_at | TEXT | Last update timestamp |

--- a/server/plugins/github-sync/README.md
+++ b/server/plugins/github-sync/README.md
@@ -1,0 +1,86 @@
+# GitHub Sync
+
+Bidirectional sync between GitHub and Mycelium. Receives webhooks for PRs, issues, CI status, and pushes. Links GitHub entities to Mycelium tasks and bugs.
+
+Processes GitHub webhook events with HMAC signature verification. Auto-creates Mycelium bugs from GitHub issues, sends CI failure notifications to operator inbox, and tracks entity links between GitHub PRs/issues and Mycelium tasks/bugs. When a linked task or bug is completed in Mycelium, emits outbound sync events.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `webhook_secret` | secret | (required) | GitHub webhook secret for HMAC-SHA256 signature verification. |
+| `default_project` | string | (none) | Mycelium project ID for new items created from GitHub events. |
+| `auto_create_bugs` | boolean | true | Auto-create Mycelium bugs from new GitHub issues. |
+| `ci_notifications` | boolean | true | Send CI/workflow failure notifications to operator inbox. |
+
+## API Endpoints
+
+All routes are prefixed with `/github`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/github/webhook` | Signature | GitHub webhook receiver. Verifies `X-Hub-Signature-256` header. Handles: `pull_request`, `issues`, `check_suite`, `workflow_run`, `push`, `issue_comment`. |
+| GET | `/github/events` | Agent/Admin | List webhook events. Filter by `?event_type=`, `?repo=`, `?processed=`. Supports `limit` and `offset`. |
+| GET | `/github/events/:id` | Agent/Admin | Get a single event with full payload. |
+| GET | `/github/links` | Agent/Admin | List entity links. Filter by `?repo=`, `?github_type=` (pr/issue/check), `?mycelium_type=` (task/bug). |
+| POST | `/github/links` | Agent/Admin | Create a link. Body: `github_repo`, `github_number`, `github_type` (pr/issue/check), `mycelium_type` (task/bug), `mycelium_id`. |
+| DELETE | `/github/links/:id` | Agent/Admin | Delete a link. |
+| GET | `/github/stats` | Agent/Admin | Sync stats: event counts by type, link counts by type, unprocessed event count. |
+| GET | `/github/widgets/pr-status` | Agent/Admin | Widget: open PRs and recent merges derived from webhook events. |
+| GET | `/github/widgets/ci-status` | Agent/Admin | Widget: recent CI/workflow runs with latest pass and latest failure. |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_github_events` | List recent GitHub webhook events. Filter by `event_type`, `repo`, `limit`. |
+| `mycelium_github_links` | List entity links between GitHub and Mycelium. Filter by `repo` and `github_type`. |
+| `mycelium_github_link` | Create a link between a GitHub PR/issue and a Mycelium task/bug. Requires `github_repo`, `github_number`, `github_type`, `mycelium_type`, `mycelium_id`. |
+| `mycelium_github_stats` | Sync statistics: event counts, link counts, unprocessed events. |
+
+## Events
+
+**Listens to:**
+- `task_completed` -- emits `github_sync_outbound` if the task is linked to a GitHub entity
+- `bug_fixed` -- emits `github_sync_outbound` if the bug is linked to a GitHub entity
+
+**Emits:**
+- `github_pr_opened` -- new PR opened
+- `github_pr_merged` -- PR merged
+- `github_pr_closed` -- PR closed without merging
+- `github_issue_synced` -- GitHub issue auto-created as Mycelium bug
+- `github_issue_labeled` -- issue labels changed
+- `github_ci_failed` -- check suite failed
+- `github_workflow_failed` -- workflow run failed
+- `github_push` -- push event received
+- `github_comment` -- new issue/PR comment
+- `github_link_created` -- manual entity link created
+- `github_sync_outbound` -- Mycelium task/bug completed that is linked to GitHub
+
+## Database Tables
+
+### `dv_github_events`
+Log of all received GitHub webhook events.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| event_type | TEXT | GitHub event type (e.g. `push`, `pull_request`, `issues`) |
+| action | TEXT | Event action (e.g. `opened`, `closed`, `completed`) |
+| repo | TEXT | Repository full name (`owner/repo`) |
+| payload | TEXT (JSON) | Full webhook payload |
+| processed | INTEGER | 0 = pending, 1 = processed |
+| created_at | TEXT | Timestamp |
+
+### `dv_github_links`
+Entity links between GitHub and Mycelium.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| github_type | TEXT | `pr`, `issue`, or `check` |
+| github_repo | TEXT | Repository full name (`owner/repo`) |
+| github_number | INTEGER | PR or issue number |
+| mycelium_type | TEXT | `task` or `bug` |
+| mycelium_id | INTEGER | Mycelium task or bug ID |
+| synced_at | TEXT | Link creation timestamp |

--- a/server/plugins/guardrails/README.md
+++ b/server/plugins/guardrails/README.md
@@ -1,0 +1,63 @@
+# Guardrails
+
+Automated quality checks and rule enforcement for agent actions.
+
+Define rules that trigger on platform events and either **warn** or **block** when conditions are violated. Every violation is logged, and operators are notified via inbox. Admins can override blocked violations.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enforcement_mode` | select | `warn` | Default enforcement for new rules (`warn` or `block`) |
+| `notify_on_violation` | boolean | `true` | Send inbox notification to all operators on every violation |
+
+## API Endpoints
+
+All routes are under `/api/mycelium/guardrails`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/rules` | agent/admin | List rules. Filter: `?enabled=`, `?trigger_event=`, `?project_id=` |
+| POST | `/rules` | admin | Create a rule. Body: `name`, `trigger_event`, `conditions`, `enforcement`, `project_id` |
+| GET | `/rules/:id` | agent/admin | Get a single rule |
+| PUT | `/rules/:id` | admin | Update a rule |
+| DELETE | `/rules/:id` | admin | Delete a rule |
+| GET | `/violations` | agent/admin | List violations. Filter: `?rule_id=`, `?agent_id=`, `?project_id=`, `?limit=`, `?offset=` |
+| GET | `/violations/:id` | agent/admin | Get a single violation |
+| POST | `/violations/:id/override` | admin | Override a violation (gated: `guardrails_override`) |
+| GET | `/stats` | agent/admin | Violation statistics (by enforcement, by rule, last 24h, top violators) |
+| POST | `/check` | agent/admin | Dry-run: check an event against all active rules without logging. Body: `event_type`, `data`, `agent`, `project_id` |
+| GET | `/widgets/violations` | agent/admin | Dashboard widget: violation count last 24h |
+
+## Rule Condition Types
+
+Rules use a `conditions` JSON object with a `type` field:
+
+- **`require_field`** -- Check that `data[field]` exists. Fields: `field`, `message`.
+- **`max_value`** -- Check that `data[field]` does not exceed `max`. Fields: `field`, `max`, `message`.
+- **`require_approval`** -- Check that `data.approval_id` exists. Fields: `action_type`, `message`.
+- **`block_agent`** -- Block a specific agent. Fields: `agent_id`, `message`.
+- **`custom`** -- Evaluate a JS expression. Fields: `expression`, `message`.
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_guardrails_rules` | List active guardrail rules. Filter by `trigger_event` or `project_id` |
+| `mycelium_guardrails_check` | Pre-flight check: test an event against rules without logging violations |
+| `mycelium_guardrails_violations` | List recent violations. Filter by `agent_id`, `limit` |
+| `mycelium_guardrails_stats` | Violation statistics: counts by enforcement, by rule, last 24h, top violators |
+
+## Events
+
+**Listens to:** `*` (all events, except those starting with `guardrail_`)
+
+**Emits:**
+- `guardrail_violation` -- On any rule violation (warn or block)
+- `guardrail_blocked` -- On block-enforcement violations only
+
+## Database Tables
+
+**`dv_guardrail_rules`** -- Rule definitions (name, trigger_event, conditions JSON, enforcement, project_id, enabled).
+
+**`dv_guardrail_violations`** -- Violation log (rule_id, trigger_event, agent_id, project_id, enforcement, event_data JSON, violation_detail, overridden flag).

--- a/server/plugins/outreach/README.md
+++ b/server/plugins/outreach/README.md
@@ -1,0 +1,106 @@
+# Outreach Pipeline
+
+Press and creator outreach with YouTube discovery, Claude personalization, and Gmail delivery.
+
+Manages a full outreach pipeline: discover YouTube creators and press contacts (via Hunter.io), research their latest content, generate Claude-personalized pitches, approve drafts, and send emails via Gmail API. Contacts flow through statuses: discovered -> researched -> draft_ready -> approved -> sent -> followed_up -> replied -> covered -> closed. Real email sending is a gated action (`outreach_send`) and defaults to dry-run mode.
+
+## Configuration
+
+Campaign-level config is stored as JSON in the `config` field when creating a campaign. Expected keys:
+
+| Key | Used By | Description |
+|-----|---------|-------------|
+| `youtube_api_key` | Discovery, Research | YouTube Data API v3 key |
+| `queries` | Discovery | Array of search queries (string or `{ query, max_results }`) |
+| `min_subs` / `max_subs` | Discovery | Subscriber count range filter (default: 20k-500k) |
+| `hunter_api_key` | Discovery | Hunter.io API key for press email lookup |
+| `press_targets` | Discovery | Array of `{ outlet, url/domain, pitch_type }` |
+| `anthropic_api_key` | Personalize | Anthropic API key (falls back to `ANTHROPIC_API_KEY` env) |
+| `gmail_credentials` | Send | Gmail OAuth2 JSON (`{ client_id, client_secret, refresh_token, access_token }`) |
+| `sender_email` | Send | Sender email address |
+| `sender_name` | Follow-up | Sender display name for templates |
+| `dry_run` | Send | Default dry-run mode (default: true) |
+
+Campaign `templates` field (JSON) supports template keys like `creator_t1`, `creator_t2`, `creator_t3`, `games_press`, `default`, and `followup`. Templates use `{first_name}`, `{personalized_hook}`, `{archetype_paragraph}`, `{outlet_or_channel}`, etc. as placeholders.
+
+## API Endpoints
+
+All routes are prefixed with `/api/mycelium/outreach`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/campaigns` | Agent/Admin | List campaigns (filter by project_id, status) |
+| POST | `/campaigns` | Agent/Admin | Create a campaign |
+| PUT | `/campaigns/:id` | Agent/Admin | Update campaign fields |
+| GET | `/contacts` | Agent/Admin | List contacts (filter by project_id, status, type, campaign_id) |
+| POST | `/contacts` | Agent/Admin | Add a contact (deduplicates by email) |
+| PUT | `/contacts/:id` | Agent/Admin | Update contact fields |
+| DELETE | `/contacts/:id` | Agent/Admin | Delete contact |
+| POST | `/discover` | Agent/Admin | Run YouTube + Hunter.io discovery for a campaign |
+| POST | `/research/:id` | Agent/Admin | Research a contact (fetch latest content/timezone) |
+| POST | `/personalize/:id` | Agent/Admin | Generate Claude-personalized pitch for a contact |
+| PUT | `/approve/:id` | Agent/Admin | Approve a draft pitch (optionally edit subject/body) |
+| POST | `/send/:id` | Agent/Admin | Send approved pitch via Gmail (gated: `outreach_send`) |
+| POST | `/followup/:id` | Agent/Admin | Send follow-up email to a sent contact |
+| GET | `/status` | Agent/Admin | Pipeline status summary (contact counts, active campaigns) |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_outreach_status` | Get pipeline status for a project (contact counts, active campaigns) |
+| `mycelium_outreach_contacts` | List contacts with filters |
+| `mycelium_outreach_campaign` | Create or update an outreach campaign |
+| `mycelium_outreach_discover` | Run YouTube + Hunter.io contact discovery |
+| `mycelium_outreach_research` | Research a contact (fetch latest video/article) |
+| `mycelium_outreach_personalize` | Generate Claude-personalized pitch |
+| `mycelium_outreach_approve` | Approve a draft pitch |
+| `mycelium_outreach_send` | Send approved pitch via Gmail (dry_run default) |
+| `mycelium_outreach_followup` | Send follow-up email |
+
+## Events
+
+| Event | When |
+|-------|------|
+| `outreach_campaign_created` | Campaign created |
+| `outreach_contact_created` | Contact added |
+| `outreach_contact_updated` | Contact updated |
+| `outreach_discover` | Discovery run completed |
+| `outreach_pitch_sent` | Real email sent (not dry-run) |
+
+## Database Tables
+
+**`dv_outreach_campaigns`** -- Campaign configuration for outreach runs.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment |
+| project_id | TEXT | Project identifier |
+| name | TEXT | Campaign name |
+| persona_prompt | TEXT | System prompt for Claude pitch generation |
+| project_facts | TEXT | Project facts for Claude to reference |
+| templates | TEXT (JSON) | Email templates keyed by type/tier |
+| config | TEXT (JSON) | API keys, search queries, limits |
+| status | TEXT | active, paused, completed |
+| created_by | TEXT | Who created the campaign |
+
+**`dv_outreach_contacts`** -- Press, creator, and influencer contacts.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment |
+| project_id | TEXT | Project identifier |
+| campaign_id | INTEGER FK | Links to campaign |
+| type | TEXT | creator or press |
+| name | TEXT | Contact name |
+| email | TEXT | Email address |
+| outlet | TEXT | Channel/outlet name |
+| tier | TEXT | T1 (500k+), T2 (50k+), T3 (<50k) |
+| archetype | TEXT | roguelike_specialist, hidden_gem, etc. |
+| subscriber_count | INTEGER | YouTube subscriber count |
+| status | TEXT | Pipeline status (discovered through closed) |
+| pitch_subject | TEXT | Generated email subject |
+| pitch_body | TEXT | Generated email body |
+| last_content | TEXT | Latest video/article title |
+| pitch_sent_at | TEXT | When pitch was sent |
+| followup_due_at | TEXT | When follow-up is due (7 days after send) |

--- a/server/plugins/project-tracker-sync/README.md
+++ b/server/plugins/project-tracker-sync/README.md
@@ -1,0 +1,68 @@
+# Project Tracker Sync
+
+Bidirectional task sync with Linear and Jira.
+
+Syncs Mycelium tasks with external project trackers. Inbound webhooks create/update Mycelium tasks from external issues. Outbound hooks push new and updated tasks to the external tracker. Includes configurable status mapping and a sync log for audit.
+
+## Configuration
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `provider` | select | Yes | External tracker: `linear` or `jira` |
+| `api_key` | secret | Yes | Linear API key or Jira API token |
+| `jira_domain` | string | No | Jira domain (e.g. `myteam.atlassian.net`). Jira only. |
+| `jira_email` | string | No | Email for Jira API auth. Jira only. |
+| `sync_direction` | select | No | `bidirectional` (default), `outbound`, or `inbound` |
+| `default_project` | string | No | Mycelium project ID for inbound items |
+| `external_project` | string | No | Linear team ID or Jira project key for outbound creates |
+
+## API Endpoints
+
+All routes are under `/api/mycelium/tracker`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/webhook` | none | Inbound webhook from Linear or Jira. Handles issue create/update/remove. |
+| GET | `/links` | agent/admin | List sync links. Filter: `?provider=`, `?sync_status=`, `?limit=`, `?offset=` |
+| POST | `/links` | admin | Manually link a Mycelium task to an external issue. Body: `external_id`, `external_key`, `mycelium_id`, `mycelium_type` |
+| DELETE | `/links/:id` | admin | Remove a sync link |
+| POST | `/sync/:id` | admin | Force re-sync a linked item (fetches current state from external tracker) |
+| GET | `/status-map` | agent/admin | Get status mappings. Filter: `?provider=` |
+| POST | `/status-map` | admin | Create status mapping. Body: `provider`, `mycelium_status`, `external_status` |
+| DELETE | `/status-map/:id` | admin | Remove a status mapping |
+| GET | `/log` | agent/admin | Sync log. Filter: `?provider=`, `?direction=`, `?status=`, `?limit=` |
+| GET | `/stats` | agent/admin | Sync statistics (link counts, last sync time, conflict count) |
+| GET | `/widgets/sync-status` | agent/admin | Dashboard widget: linked items, last sync, conflicts |
+
+## Default Status Mappings
+
+**Linear:** open=Todo, in_progress=In Progress, review=In Review, done=Done, cancelled=Canceled
+
+**Jira:** open=To Do, in_progress=In Progress, review=In Review, done=Done
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_tracker_links` | List sync links between Mycelium tasks and external issues |
+| `mycelium_tracker_link` | Manually link a Mycelium task to an external issue |
+| `mycelium_tracker_sync` | Force re-sync a linked item from the external tracker |
+| `mycelium_tracker_status` | Get sync status and stats |
+
+## Events
+
+**Listens to:**
+- `task_created` -- Creates corresponding issue in external tracker (outbound)
+- `task_updated` -- Syncs status changes to external tracker (outbound)
+
+**Emits:**
+- `task_created` -- When inbound webhook creates a Mycelium task
+- `tracker_link_created` -- When a manual link is created
+
+## Database Tables
+
+**`dv_tracker_links`** -- Sync links (provider, external_id, external_key, mycelium_type, mycelium_id, sync_status, last_synced, conflict_data).
+
+**`dv_tracker_sync_log`** -- Audit log (provider, direction, action, mycelium_id, external_id, status, detail).
+
+**`dv_tracker_status_map`** -- Status mappings between Mycelium and external tracker statuses.

--- a/server/plugins/slack-bridge/README.md
+++ b/server/plugins/slack-bridge/README.md
@@ -1,0 +1,64 @@
+# Slack Bridge
+
+Bidirectional Slack integration for Mycelium.
+
+Forwards platform events to Slack channels, receives Slack messages and slash commands, and syncs Mycelium channels with Slack channels. Optionally forwards to Discord via webhook.
+
+## Configuration
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `bot_token` | secret | Yes | Slack bot token (`xoxb-...`) |
+| `signing_secret` | secret | Yes | Slack signing secret for request verification |
+| `default_channel` | string | No | Slack channel ID for general agent updates (e.g. `C0123456789`) |
+| `event_filters` | text | No | Comma-separated event types to forward (e.g. `task_completed,bug_filed`). Empty = all events. |
+| `discord_webhook` | secret | No | Discord webhook URL to also forward events to Discord |
+
+## API Endpoints
+
+All routes are under `/api/mycelium/slack`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/events` | Slack signature | Slack Events API endpoint. Handles URL verification and message events. |
+| POST | `/commands` | Slack signature | Slack slash command handler. Subcommands: `status`, `tasks`, `assign <agent> <description>` |
+| GET | `/channels` | agent/admin | List channel mappings |
+| POST | `/channels` | admin | Create channel mapping. Body: `mycelium_channel_id`, `slack_channel_id`, `direction` (`both`/`to_slack`/`to_mycelium`) |
+| PUT | `/channels/:id` | admin | Update a channel mapping |
+| DELETE | `/channels/:id` | admin | Remove a channel mapping |
+| GET | `/messages` | agent/admin | Message log. Filter: `?direction=`, `?slack_channel=`, `?limit=` |
+| POST | `/test` | admin | Send test message to default Slack channel |
+| GET | `/widgets/status` | agent/admin | Dashboard widget: active channel maps, messages forwarded today |
+
+## Slash Commands
+
+Register `/mycelium` as a slash command in your Slack app, pointing to `https://yourhost/api/mycelium/slack/commands`.
+
+- `/mycelium status` -- Show active agent statuses
+- `/mycelium tasks` -- Show open tasks (up to 15)
+- `/mycelium assign <agent-id> <description>` -- Create a task and assign it to an agent
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_slack_send` | Send a message to a Slack channel. Requires `channel` (ID) and `message`. |
+| `mycelium_slack_channels` | List all Slack-to-Mycelium channel mappings |
+| `mycelium_slack_test` | Send a test message to the default Slack channel |
+
+## Events
+
+**Listens to:**
+- `*` (all events) -- Forwards matching events to the default Slack channel (filtered by `event_filters` config) and optionally to Discord
+- `channel_message` -- Bridges Mycelium channel messages to mapped Slack channels (skips messages originating from Slack to prevent loops)
+
+**Emits:**
+- `slack_message_received` -- When a Slack message is forwarded to a Mycelium channel
+- `slack_channel_mapped` -- When a channel mapping is created
+- `slack_channel_unmapped` -- When a channel mapping is removed
+
+## Database Tables
+
+**`dv_slack_channel_map`** -- Channel mappings (mycelium_channel_id, slack_channel_id, direction, enabled).
+
+**`dv_slack_messages`** -- Message log for audit (direction, mycelium_msg_id, slack_ts, slack_channel, content, agent_id).

--- a/server/plugins/social-posting/README.md
+++ b/server/plugins/social-posting/README.md
@@ -1,0 +1,87 @@
+# Social Posting
+
+Dio-voiced social media posting with caption generation, scheduling, and publishing.
+
+Manages social media posts across TikTok, Twitter, Instagram, and YouTube Shorts. Generates in-character caption prompts (Dio narrator voice), queues posts with per-platform scheduling windows, and publishes via drone jobs using Buffer API or Instagram Graph API. Publishing is a gated action requiring approval.
+
+## Configuration
+
+No plugin-level config fields. Account credentials are stored per-account via the `/accounts` endpoints:
+
+- **credentials** (JSON): Platform API credentials. For Instagram: `{ access_token, ig_user_id }`. For TikTok/Twitter: `{ token, profile_ids }` (Buffer API).
+- **config** (JSON): Optional per-account config.
+
+## API Endpoints
+
+All routes are prefixed with `/api/mycelium/social`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/accounts` | Admin | Register a social media account |
+| GET | `/accounts` | Admin | List accounts (credentials redacted) |
+| PUT | `/accounts/:id` | Admin | Update account |
+| DELETE | `/accounts/:id` | Admin | Delete account |
+| POST | `/captions/generate` | Agent/Admin | Build a Dio-voiced caption prompt for a highlight clip |
+| POST | `/posts` | Agent/Admin | Create a post (draft or scheduled) |
+| GET | `/posts` | Agent/Admin | List posts (filter by project, platform, status, video_session_id) |
+| GET | `/posts/:id` | Agent/Admin | Get post details (includes drone job status if linked) |
+| PUT | `/posts/:id` | Agent/Admin | Update post fields |
+| DELETE | `/posts/:id` | Agent/Admin | Delete post |
+| GET | `/schedule` | Agent/Admin | Get scheduled posts queue |
+| POST | `/posts/:id/schedule` | Agent/Admin | Schedule a draft post (auto-selects time window if omitted) |
+| POST | `/posts/:id/publish` | Agent/Admin | Submit publishing drone job (gated: `social_publish`) |
+| GET | `/stats` | Agent/Admin | Post counts by platform and status |
+| GET | `/history` | Agent/Admin | Recent post history (default: last 7 days) |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_social_generate_caption` | Generate a Dio-voiced caption prompt for a gameplay highlight clip |
+| `mycelium_social_create_post` | Create a social media post (draft or scheduled) |
+| `mycelium_social_list_posts` | List posts with optional filters |
+| `mycelium_social_schedule_post` | Schedule a draft post (auto-selects time window if no `scheduled_at`) |
+| `mycelium_social_publish_post` | Publish a post via drone job (gated: `social_publish`) |
+| `mycelium_social_stats` | Get posting stats by platform/status |
+| `mycelium_social_history` | Get recent post history |
+
+## Events
+
+| Event | When |
+|-------|------|
+| `social_post_created` | Post created |
+| `social_post_scheduled` | Post scheduled |
+| `social_post_publishing` | Publishing drone job submitted |
+
+## Database Tables
+
+**`dv_social_accounts`** -- Registered social media accounts with platform credentials.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment |
+| project_id | TEXT | Project identifier |
+| platform | TEXT | tiktok, instagram, twitter, youtube_shorts |
+| account_name | TEXT | Display name |
+| credentials | TEXT (JSON) | API credentials (encrypted at rest) |
+| config | TEXT (JSON) | Account-specific config |
+| enabled | INTEGER | 1 = active |
+
+**`dv_social_posts`** -- Post queue with scheduling and publishing state.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment |
+| project_id | TEXT | Project identifier |
+| account_id | INTEGER FK | Links to dv_social_accounts |
+| platform | TEXT | Target platform |
+| clip_id | TEXT | Video pipeline clip ID (tracking) |
+| video_session_id | INTEGER | Video pipeline session ID |
+| event_type | TEXT | Highlight event type |
+| tier | TEXT | S/A/B/C quality tier |
+| caption | TEXT | Post caption text |
+| media_url | TEXT | URL of video/image |
+| status | TEXT | draft, scheduled, publishing, published, failed |
+| scheduled_at | TEXT | ISO timestamp for scheduled publish |
+| drone_job_id | INTEGER | Linked publishing drone job |
+| created_by | TEXT | Agent/user who created the post |

--- a/server/plugins/steam-assets/README.md
+++ b/server/plugins/steam-assets/README.md
@@ -1,0 +1,57 @@
+# Steam Assets
+
+Steam store page generation -- BBCode copy, curated screenshots, and segmented trailers.
+
+Generates Steam store page assets for a game project. Store copy generation runs in-process (returns a structured prompt for Claude API to produce BBCode). Screenshot extraction and trailer building submit drone jobs that require GPU workers. Assets are tracked through pending -> processing -> complete/failed statuses.
+
+## Configuration
+
+No plugin-level config. Game facts for store copy can be passed per-request or use built-in defaults (Willing Sacrifice). Drone jobs use the `wsac-agent` repo for worker scripts.
+
+## API Endpoints
+
+All routes are prefixed with `/api/mycelium/steam`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/assets` | Agent/Admin | List assets (filter by project_id, asset_type, status) |
+| GET | `/assets/:id` | Agent/Admin | Get asset details (includes drone job status) |
+| DELETE | `/assets/:id` | Admin | Delete asset |
+| POST | `/store-copy` | Agent/Admin | Generate Steam BBCode store copy prompt |
+| POST | `/screenshots` | Agent/Admin | Submit screenshot extraction drone job |
+| POST | `/trailer` | Agent/Admin | Submit trailer build drone job |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_steam_list_assets` | List Steam asset jobs (store copy, screenshots, trailers) |
+| `mycelium_steam_get_asset` | Get asset details including drone job status |
+| `mycelium_steam_store_copy` | Generate a BBCode store copy prompt for Claude API |
+| `mycelium_steam_screenshots` | Submit drone job to extract curated screenshots from footage |
+| `mycelium_steam_trailer` | Submit drone job to build a segmented trailer with Dio narration |
+
+## Events
+
+| Event | When |
+|-------|------|
+| `steam_store_copy_requested` | Store copy generation requested |
+| `steam_screenshots_started` | Screenshot extraction drone job submitted |
+| `steam_trailer_started` | Trailer build drone job submitted |
+
+## Database Tables
+
+**`dv_steam_assets`** -- Steam asset generation tracking.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment |
+| project_id | TEXT | Project identifier |
+| asset_type | TEXT | store_copy, screenshots, trailer |
+| title | TEXT | Asset description |
+| status | TEXT | pending, processing, complete, failed |
+| drone_job_id | INTEGER | Linked drone job (screenshots/trailer) |
+| config | TEXT (JSON) | Input parameters (game_facts, footage_url, etc.) |
+| result_data | TEXT (JSON) | Output data from generation |
+| result_url | TEXT | URL to generated asset file |
+| created_by | TEXT | Who requested the asset |

--- a/server/plugins/video-pipeline/README.md
+++ b/server/plugins/video-pipeline/README.md
@@ -1,0 +1,89 @@
+# Video Pipeline
+
+Gameplay capture to highlight detection to assembly to platform export.
+
+Processes raw gameplay footage through a multi-stage pipeline: detect highlights from event logs (optionally with Claude Vision), assemble clips with narration and overlays, then export platform-specific formats (TikTok 9:16, Twitter 16:9, YouTube Shorts, Instagram). Each stage submits a drone job for compute-heavy FFmpeg work. Sessions track drone job IDs for each stage and auto-count clips.
+
+## Configuration
+
+No plugin-level config. Session-level config is passed via the `config` field on session creation. Drone jobs use the `wsac-agent` repo for worker scripts. Detection optionally uses Claude Vision (requires GPU drone).
+
+## API Endpoints
+
+All routes are prefixed with `/api/mycelium/video`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/sessions` | Agent/Admin | Create a video processing session |
+| GET | `/sessions` | Agent/Admin | List sessions (filter by project_id, status) |
+| GET | `/sessions/:id` | Agent/Admin | Get session details with clips and stats |
+| PUT | `/sessions/:id` | Agent/Admin | Update session fields |
+| DELETE | `/sessions/:id` | Admin | Delete session and its clips |
+| GET | `/sessions/:id/clips` | Agent/Admin | List clips for a session (filter by tier, status) |
+| POST | `/sessions/:id/clips` | Agent/Admin | Bulk add clips (from detection results) |
+| PUT | `/clips/:id` | Agent/Admin | Update a clip |
+| POST | `/sessions/:id/detect` | Agent/Admin | Submit highlight detection drone job |
+| POST | `/sessions/:id/assemble` | Agent/Admin | Submit clip assembly drone job |
+| POST | `/sessions/:id/export` | Agent/Admin | Submit platform export drone job |
+| POST | `/sessions/:id/captions` | Agent/Admin | Get clip list for caption generation |
+| GET | `/sessions/:id/status` | Agent/Admin | Get session status with drone job progress |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_video_create_session` | Create a new video processing session |
+| `mycelium_video_list_sessions` | List sessions with optional filters |
+| `mycelium_video_get_session` | Get full session details with clips and stats |
+| `mycelium_video_detect` | Submit highlight detection drone job (optional Claude Vision) |
+| `mycelium_video_assemble` | Submit assembly drone job (cuts clips, mixes narration, adds overlays) |
+| `mycelium_video_export` | Submit export drone job (re-encodes for target platforms) |
+| `mycelium_video_session_status` | Get session status including all drone job progress |
+| `mycelium_video_add_clips` | Bulk add detected clips to a session |
+
+## Events
+
+| Event | When |
+|-------|------|
+| `video_session_created` | Session created |
+| `video_detect_started` | Detection drone job submitted |
+| `video_assemble_started` | Assembly drone job submitted |
+| `video_export_started` | Export drone job submitted |
+
+## Database Tables
+
+**`dv_video_sessions`** -- Video processing sessions tracking footage through the pipeline.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment |
+| project_id | TEXT | Project identifier |
+| title | TEXT | Session title |
+| footage_url | TEXT | URL/path to raw footage |
+| event_log_url | TEXT | URL/path to Godot JSONL event log |
+| status | TEXT | pending, detecting, assembling, exporting, completed, failed |
+| detect_job_id | INTEGER | Detection drone job ID |
+| assemble_job_id | INTEGER | Assembly drone job ID |
+| export_job_id | INTEGER | Export drone job ID |
+| clip_count | INTEGER | Number of detected clips |
+| config | TEXT (JSON) | Session-level config |
+| result_data | TEXT (JSON) | Pipeline output data |
+| created_by | TEXT | Who created the session |
+
+**`dv_video_clips`** -- Individual highlight clips within a session.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment |
+| session_id | INTEGER FK | Parent session |
+| clip_id | TEXT | Unique clip identifier |
+| tier | TEXT | S/A/B/C quality tier |
+| event_type | TEXT | Highlight event type |
+| start_sec | REAL | Start timestamp in footage |
+| end_sec | REAL | End timestamp in footage |
+| duration_sec | REAL | Clip duration (computed) |
+| status | TEXT | detected, assembled, exported |
+| platforms | TEXT (JSON) | Target platform list |
+| caption_data | TEXT (JSON) | Generated caption data |
+| metadata | TEXT (JSON) | Event metadata |
+| result_url | TEXT | URL to assembled clip file |

--- a/server/plugins/workflow-automations/README.md
+++ b/server/plugins/workflow-automations/README.md
@@ -1,0 +1,89 @@
+# Workflow Automations
+
+Event-driven automation rules -- when X happens, do Y.
+
+Create rules that trigger on platform events and execute actions like creating tasks, sending messages, filing bugs, assigning agents, firing webhooks, or sending inbox notifications. Supports conditions, rate limiting, dry-run mode, and built-in templates.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `max_actions_per_minute` | number | `30` | Rate limit for automation actions per minute. 0 = no limit. |
+| `dry_run` | boolean | `false` | Log triggers without executing actions |
+
+## API Endpoints
+
+All routes are under `/api/mycelium/automations`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/rules` | agent/admin | List rules. Filter: `?enabled=`, `?trigger_event=`, `?project_id=` |
+| POST | `/rules` | admin | Create rule. Body: `name`, `trigger_event`, `conditions`, `actions`, `project_id` |
+| GET | `/rules/:id` | agent/admin | Get a single rule |
+| PUT | `/rules/:id` | admin | Update a rule |
+| DELETE | `/rules/:id` | admin | Delete a rule |
+| POST | `/rules/:id/test` | admin | Test rule against sample event data without executing. Body: `event_data` |
+| POST | `/rules/:id/trigger` | admin | Manually trigger a rule. Body: `event_data` |
+| GET | `/log` | agent/admin | Execution log. Filter: `?rule_id=`, `?status=`, `?limit=` |
+| GET | `/stats` | agent/admin | Execution statistics (by status, by rule, last 24h) |
+| GET | `/templates` | agent/admin | List built-in templates. Filter: `?category=` |
+| POST | `/rules/from-template/:templateId` | admin | Create rule from template. Override with body: `name`, `conditions`, `actions`, `project_id` |
+| GET | `/widgets/activity` | agent/admin | Dashboard widget: triggers last 24h, top rules, recent log |
+
+## Condition Fields
+
+Rules match events using a `conditions` JSON object:
+
+- **`project_id`** -- Match events from a specific project
+- **`agent_id`** -- Match events from a specific agent
+- **`field_equals`** -- Object of `{ field: value }` pairs that must match in `event.data`
+- **`field_contains`** -- Object of `{ field: substring }` pairs for substring matching
+- **`field_exists`** -- Array of field names that must exist in `event.data`
+
+## Action Types
+
+Rules define an `actions` array. Each action has a `type`:
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `create_task` | `title`, `description`, `project_id`, `assignee` | Create a new task |
+| `send_message` | `to`, `content`, `project_id` | Send a message to an agent |
+| `file_bug` | `title`, `description`, `project_id`, `severity` | File a bug report |
+| `assign_agent` | `agent_id` | Assign an agent to the triggering task |
+| `send_webhook` | `url` | POST event data to a webhook URL |
+| `inbox_notify` | `title`, `summary`, `priority` | Send inbox notification to all operators |
+
+Action string fields support template variables: `{{agent}}`, `{{event_type}}`, `{{project}}`, `{{summary}}`, and any key from `event.data`.
+
+## Built-in Templates
+
+- **Auto-assign critical bugs** (category: bugs) -- Assign critical bugs to an agent + notify
+- **Notify on plan completion** (category: plans) -- Inbox notification when a plan step completes
+- **Webhook on deploy** (category: integrations) -- Fire webhook when a deploy approval is executed
+- **Create review task on PR** (category: github) -- Auto-create review task for new PRs
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_automation_list` | List automation rules. Filter by `trigger_event` or `enabled` status. |
+| `mycelium_automation_trigger` | Manually trigger a rule with provided `event_data` |
+| `mycelium_automation_log` | View recent execution log. Filter by `rule_id`, `limit`. |
+| `mycelium_automation_stats` | Execution statistics: counts by status, top rules, last 24h |
+
+## Events
+
+**Listens to:** `*` (all events, except those starting with `automation_`)
+
+**Emits:**
+- `automation_triggered` -- When a rule fires (includes `rule_id`, `rule_name`, action count, dry_run flag)
+- `automation_rule_created` -- When a rule is created
+- `automation_rule_deleted` -- When a rule is deleted
+
+## Database Tables
+
+**`dv_automation_rules`** -- Rule definitions (name, trigger_event, conditions JSON, actions JSON, project_id, enabled, run_count, last_run).
+
+**`dv_automation_log`** -- Execution log (rule_id, trigger_event, matched, actions_taken JSON, event_data JSON, status, error, dry_run).
+
+**`dv_automation_templates`** -- Built-in templates (name, trigger_event, conditions, actions, category). Seeded with 4 default templates.

--- a/server/plugins/x-posting/README.md
+++ b/server/plugins/x-posting/README.md
@@ -1,0 +1,61 @@
+# X/Twitter Posting
+
+Post directly to X/Twitter via API v2.
+
+Create tweet drafts, organize them into threads, and publish to X using OAuth 1.0a. Supports auto-creation of tweets from approved build-in-public (BIP) drafts. Publishing is a gated action (`x_publish`) requiring approval.
+
+## Configuration
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `api_key` | secret | Yes | Twitter/X API key (consumer key) |
+| `api_secret` | secret | Yes | Twitter/X API secret (consumer secret) |
+| `access_token` | secret | Yes | OAuth 1.0a access token |
+| `access_token_secret` | secret | Yes | OAuth 1.0a access token secret |
+| `auto_post_bip` | boolean | No | Auto-create tweet drafts from approved BIP drafts (default: false) |
+| `default_project` | string | No | Project ID for tracking posts (default: `mycelium`) |
+
+## API Endpoints
+
+All routes are under `/api/mycelium/x`.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/posts` | agent/admin | Create a tweet draft. Body: `text` (max 280 chars), `project_id`, `source`, `source_id`, `thread_id`, `thread_position` |
+| GET | `/posts` | agent/admin | List posts. Filter: `?status=`, `?project_id=`, `?thread_id=`, `?source=`, `?limit=` |
+| GET | `/posts/:id` | agent/admin | Get a single post |
+| PUT | `/posts/:id` | agent/admin | Edit a draft. Body: `text` (only drafts can be edited) |
+| DELETE | `/posts/:id` | admin | Delete a post |
+| POST | `/posts/:id/publish` | agent/admin | Publish a draft to X. **Gated action: `x_publish`**. Threads auto-chain replies. |
+| POST | `/thread` | agent/admin | Create a thread. Body: `tweets` (array of strings), `project_id`, `source`, `source_id` |
+| POST | `/thread/:threadId/publish` | agent/admin | Publish an entire thread sequentially. **Gated action: `x_publish`**. |
+| GET | `/stats` | agent/admin | Post counts grouped by status. Filter: `?project_id=` |
+
+## Post Statuses
+
+`draft` -> `publishing` -> `published` or `failed`
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `mycelium_x_post` | Create a tweet draft (max 280 chars) |
+| `mycelium_x_publish` | Publish a tweet draft to X. Gated: `x_publish` |
+| `mycelium_x_thread` | Create a tweet thread (array of tweets) |
+| `mycelium_x_publish_thread` | Publish an entire thread to X. Gated: `x_publish` |
+| `mycelium_x_list` | List posts with optional filters (status, project_id, source) |
+| `mycelium_x_stats` | Get posting stats by status |
+
+## Events
+
+**Listens to:**
+- `bip_draft_approved` -- When a BIP draft is approved and `auto_post_bip` is enabled, auto-creates a tweet draft and notifies operators via inbox
+
+**Emits:**
+- `x_tweet_published` -- When a single tweet is published (includes `post_id`, `tweet_id`, `tweet_url`)
+- `x_thread_published` -- When a thread is fully published (includes `thread_id`, tweet details)
+- `x_post_created` -- When a tweet draft is auto-created from a BIP draft
+
+## Database Tables
+
+**`dv_x_posts`** -- Tweet drafts and published posts (project_id, tweet_text, tweet_id, tweet_url, thread_id, thread_position, source, source_id, status, error, posted_by, posted_at).


### PR DESCRIPTION
## Summary
- README.md added to every plugin directory (14 plugins)
- Each doc covers: purpose, configuration, API endpoints, MCP tools, events, database tables
- Written from actual source code — not templates or guesses

## Plugins documented
build-in-public, cost-tracker, daily-digest, error-monitor, github-sync, guardrails, outreach, project-tracker-sync, slack-bridge, social-posting, steam-assets, video-pipeline, workflow-automations, x-posting

## Test plan
- [ ] Spot check 3-4 READMEs against actual route/handler code for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)