### PR TITLE
feat: Teams system + table rename (dv_ prefix removal)

### DIFF
--- a/docs/plans/2026-03-07-teams-and-table-rename-design.md
+++ b/docs/plans/2026-03-07-teams-and-table-rename-design.md
@@ -1,0 +1,128 @@
+# Teams System + Table Rename — Design Doc
+
+**Date**: 2026-03-07
+**Author**: dev-claude + Greatness
+**Status**: Approved
+
+## Goal
+
+Add a first-class Teams layer to Mycelium (teams inside orgs, with membership, work scoping, and visibility boundaries) AND remove the legacy `dv_` prefix from all 43 database tables to make the project clean and professional.
+
+## Key Decisions
+
+1. **Approach**: Join table model — `teams` + `team_members` tables. Projects get `team_id`. Operators/agents get `primary_team_id`.
+2. **Membership**: One primary team per entity, can guest on others. Roles: `lead`, `member`, `guest`.
+3. **Hierarchy**: Org → Teams → Projects → Tasks/Bugs/Plans/etc. Orgs remain the billing/instance boundary. Teams subdivide work ownership.
+4. **Visibility**: Teams organize ownership AND create soft visibility boundaries. Default view is team-scoped, admins see everything.
+5. **Plugins**: Stay global for v1. Per-team plugin config is on the enterprise roadmap ($120k install lever layer).
+6. **Table rename**: All `dv_*` tables renamed to clean names. Mechanical find/replace + live DB migration.
+
+## Data Model
+
+### New Tables
+
+**`teams`**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | TEXT PK | Slug, e.g. `platform` |
+| org_id | TEXT | FK to organizations |
+| name | TEXT | "Platform Team" |
+| description | TEXT | |
+| created_by | TEXT | Operator ID |
+| created_at | TIMESTAMP | |
+| updated_at | TIMESTAMP | |
+
+**`team_members`**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | Auto-increment |
+| team_id | TEXT | FK to teams |
+| user_id | TEXT | Operator or Agent ID |
+| user_type | TEXT | `operator` or `agent` |
+| role | TEXT | `lead`, `member`, `guest` |
+| is_primary | INTEGER | 1 = home team |
+| joined_at | TIMESTAMP | |
+| UNIQUE(team_id, user_id) | | |
+
+### Existing Table Changes
+
+- `projects` gets `team_id TEXT`
+- `operators` gets `primary_team_id TEXT`
+- `agents` gets `primary_team_id TEXT`
+
+### Table Rename (43 tables)
+
+All `dv_*` prefixes removed. Examples:
+- `dv_agents` → `agents`
+- `dv_organizations` → `organizations`
+- `dv_projects` → `projects`
+- `dv_team_settings` → `team_settings`
+- Plugin tables: `dv_billing_subscriptions` → `billing_subscriptions`
+
+All indexes renamed: `idx_dv_x` → `idx_x`.
+
+## API Endpoints
+
+### Team CRUD (admin only)
+- `GET /teams` — list teams (`?org_id=` filter)
+- `GET /teams/:id` — team detail with members
+- `POST /teams` — create team
+- `PUT /teams/:id` — update team
+- `DELETE /teams/:id` — delete team (must be empty)
+
+### Team Membership
+- `POST /teams/:id/members` — add member
+- `PUT /teams/:id/members/:userId` — update role/primary
+- `DELETE /teams/:id/members/:userId` — remove member
+
+### Team-Scoped Queries
+Existing endpoints get `?team_id=` filter:
+- `GET /tasks?team_id=`, `GET /bugs?team_id=`, `GET /agents?team_id=`, `GET /projects?team_id=`
+
+## System Integration
+
+### Auto-Dispatch
+When an agent goes idle, work assignment queries only tasks/plan steps from projects where `team_id` matches the agent's primary or guest teams. No cross-team surprise assignments.
+
+### Boot Payload
+Agent boot (`GET /boot/:agentId`) adds:
+- `team`: primary team object
+- `guest_teams`: array of guest team objects
+- `team_members`: operators and agents on same primary team
+- All data (tasks, bugs, plans, messages) filtered to agent's team projects. Admins still get everything.
+
+### Auto-Channel Creation
+Creating a team auto-creates a channel: `type='team'`, `linked_type='team'`, `linked_id=team.id`, name `#team-{slug}`. All members auto-join. Deleting a team archives the channel.
+
+### MCP Tools
+- `mycelium_list_teams`, `mycelium_get_team`, `mycelium_create_team`
+- `mycelium_add_team_member`, `mycelium_remove_team_member`
+
+### Dashboard
+- Team switcher in sidebar/header
+- Teams management page under Manage section
+- Existing pages filter by selected team
+- Team badge on operator/agent cards
+
+### Plans
+Plan steps assigned to cross-team agents still work. Guest access is the formal mechanism for cross-team collaboration.
+
+### Overview Endpoint
+`GET /admin/overview` stays unfiltered. Dashboard store applies `selectedTeamId` client-side.
+
+### Team Settings
+Current `team_settings` table stays global (instance DNA). Per-team overrides on the enterprise roadmap.
+
+## Migration Strategy
+
+Live DB migration via startup script: `ALTER TABLE dv_x RENAME TO x` for all 43 tables. SQLite supports this natively. Idempotent (checks if table exists before renaming).
+
+## Enterprise Roadmap (future)
+
+- Per-team plugin config
+- Per-team webhooks
+- Per-team approval chains
+- Per-team drone quotas
+- Per-team settings overrides

--- a/docs/plans/2026-03-07-teams-and-table-rename-plan.md
+++ b/docs/plans/2026-03-07-teams-and-table-rename-plan.md
@@ -1,0 +1,883 @@
+# Teams System + Table Rename — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove all `dv_` table prefixes from the Mycelium codebase (43 tables, ~835 references) and add a first-class Teams system with membership, work scoping, and auto-channel creation.
+
+**Architecture:** Phase 0 is a mechanical find/replace of `dv_` → `` across schema.sql, db.js, routes/mycelium.js, index.js, and all 14 plugin directories, plus a startup migration script that renames tables in the live SQLite DB. Phases 1-4 build the Teams feature on top of the clean schema.
+
+**Tech Stack:** Node.js/Express, SQLite (better-sqlite3), React/TypeScript dashboard (Vite + Tailwind), Mycelium MCP server.
+
+**Risk Mitigation:**
+- Each task ends with a commit. If anything breaks, we can revert to the last good commit.
+- After Phase 0 (table rename), verify the server starts and boots an agent before continuing.
+- Save state to Mycelium context keys after each phase completes.
+- Use subagents for each task to keep context fresh.
+
+---
+
+### Task 1: Table Rename — schema.sql
+
+**Files:**
+- Modify: `server/schema.sql` (all 672 lines)
+
+**Step 1: Rename all 43 CREATE TABLE statements**
+
+Find/replace `dv_` → `` in all CREATE TABLE lines. Examples:
+- `CREATE TABLE IF NOT EXISTS dv_agents` → `CREATE TABLE IF NOT EXISTS agents`
+- `CREATE TABLE IF NOT EXISTS dv_organizations` → `CREATE TABLE IF NOT EXISTS organizations`
+- etc. for all 43 tables
+
+**Step 2: Rename all indexes**
+
+Find/replace index names. Pattern: `idx_dv_foo` → `idx_foo`. Also fix the few inconsistent indexes that don't have `dv_` prefix:
+- `idx_task_comments_task` → `idx_task_comments_task` (already clean)
+- `idx_savepoints_agent` → `idx_savepoints_agent` (already clean)
+- `idx_drone_profile_assignments_drone` → `idx_drone_profile_assignments_drone` (already clean)
+- `idx_instances_org` → `idx_instances_org` (already clean)
+- `idx_msg_reads_agent` → `idx_msg_reads_agent` (already clean)
+- `idx_team_settings_section` → `idx_team_settings_section` (already clean)
+
+For the rest: `idx_dv_tasks_status` → `idx_tasks_status`, `idx_dv_agents_project` → `idx_agents_project`, etc.
+
+**Step 3: Update FOREIGN KEY references**
+
+Update all REFERENCES clauses:
+- Line 157: `REFERENCES dv_plans(id)` → `REFERENCES plans(id)`
+- Line 174: `REFERENCES dv_plan_steps(id)` → `REFERENCES plan_steps(id)`
+- Line 175: `REFERENCES dv_plans(id)` → `REFERENCES plans(id)`
+- Line 250: `REFERENCES dv_concepts(id)` → `REFERENCES concepts(id)`
+- Line 259: `REFERENCES dv_tasks(id)` → `REFERENCES tasks(id)`
+- Line 386: `REFERENCES dv_studio_users(id)` → `REFERENCES studio_users(id)`
+- Line 408: `REFERENCES dv_approvals(id)` → `REFERENCES approvals(id)`
+- Line 458: `REFERENCES dv_channels(id)` → `REFERENCES channels(id)`
+- Line 487: `REFERENCES dv_channels(id)` → `REFERENCES channels(id)`
+- Line 547: `REFERENCES dv_drone_profiles(id)` → `REFERENCES drone_profiles(id)`
+
+**Step 4: Verify — count remaining `dv_` references**
+
+Run: `grep -c "dv_" server/schema.sql`
+Expected: 0
+
+**Step 5: Commit**
+
+```bash
+git add server/schema.sql
+git commit -m "refactor: remove dv_ prefix from all table/index names in schema.sql"
+```
+
+---
+
+### Task 2: Table Rename — db.js
+
+**Files:**
+- Modify: `server/db.js` (~3400 lines, 414 `dv_` references)
+
+**Step 1: Global find/replace `dv_` → `` in all SQL strings**
+
+This is a mechanical replacement. Every occurrence of `dv_` in db.js is inside a SQL string (db.prepare() or stmt()). Replace all ~414 occurrences.
+
+Pattern: `dv_agents` → `agents`, `dv_tasks` → `tasks`, `dv_messages` → `messages`, etc.
+
+**Critical edge cases to verify after replace:**
+- `stmt('dvGetAgent', ...)` — The stmt cache KEY contains `dv` but that's a JS string key, NOT a table name. These should be left alone OR renamed for consistency. Decision: rename them too (e.g., `dvGetAgent` → `getAgent_stmt`). Actually, leave cache keys as-is for now — they're internal identifiers, not table names, and changing them risks cache misses.
+- Dynamic SET/WHERE construction (e.g., line patterns like `'UPDATE dv_agents SET ' + sets.join(', ')`) — the `dv_agents` part gets replaced, the dynamic part is column names only (safe).
+
+**Step 2: Verify — count remaining `dv_` references in SQL strings**
+
+Run: `grep -c "dv_" server/db.js`
+Expected: Only matches in stmt cache keys (like `dvGetAgent`), comments, or non-SQL contexts. Zero matches in actual SQL table references.
+
+**Step 3: Commit**
+
+```bash
+git add server/db.js
+git commit -m "refactor: remove dv_ prefix from all SQL queries in db.js"
+```
+
+---
+
+### Task 3: Table Rename — routes/mycelium.js + index.js
+
+**Files:**
+- Modify: `server/routes/mycelium.js` (54 `dv_` references)
+- Modify: `server/index.js` (9 `dv_` references)
+
+**Step 1: Replace all `dv_` in routes/mycelium.js**
+
+54 references across inline db.prepare() calls and db.pragma() calls. Same mechanical replacement.
+
+Key locations:
+- Lines 373, 463, 468, 481, 517: agent/org lookups
+- Lines 681, 691: `dv_waitlist` CREATE TABLE and INSERT (inline migration)
+- Lines 717-823: stats/health queries
+- Lines 873: waitlist query
+- Lines 928, 932: agent boot queries
+- Lines 2260-2316: password reset table operations
+- Lines 3207: org delete
+- Lines 3887-3953: drone job updates
+- Lines 4861-4971: operator/inbox lookups
+- Lines 5218-5263: bug/ticket migration ALTERs
+
+**Step 2: Replace all `dv_` in index.js**
+
+9 references:
+- Line 39: `dv_agents` in API key lookup
+- Lines 68-77: `dv_context_keys` migration (pragma + ALTER TABLE)
+- Line 208: `dv_agents` online count
+- Line 357: `dv_password_resets` cleanup
+
+**Step 3: Verify**
+
+Run: `grep -c "dv_" server/routes/mycelium.js server/index.js`
+Expected: 0 for both files (or only in comments/non-SQL contexts)
+
+**Step 4: Commit**
+
+```bash
+git add server/routes/mycelium.js server/index.js
+git commit -m "refactor: remove dv_ prefix from routes and index.js"
+```
+
+---
+
+### Task 4: Table Rename — All Plugins
+
+**Files:**
+- Modify: All `.js`, `.sql`, `.json`, `.md` files in `server/plugins/` (57 files, 324 references)
+
+**Step 1: Replace `dv_` in all plugin files**
+
+14 plugin directories, each with schema.sql, db.js, routes.js, handlers.js, README.md, etc.
+
+Plugin-owned tables to rename:
+- billing: `dv_subscriptions` → `subscriptions`
+- build-in-public: `dv_bip_drafts` → `bip_drafts`
+- cost-tracker: `dv_cost_entries`, `dv_cost_daily`, `dv_cost_alerts` → drop `dv_`
+- daily-digest: `dv_digest_reports`, `dv_digest_metrics` → drop `dv_`
+- error-monitor: `dv_error_events` → `error_events`
+- github-sync: `dv_github_events`, `dv_github_links` → drop `dv_`
+- guardrails: `dv_guardrail_rules`, `dv_guardrail_violations` → drop `dv_`
+- outreach: `dv_outreach_campaigns`, `dv_outreach_contacts` → drop `dv_`
+- social-posting: `dv_social_accounts`, `dv_social_posts` → drop `dv_`
+- steam-assets: `dv_steam_assets` → `steam_assets`
+- video-pipeline: `dv_video_sessions`, `dv_video_clips` → drop `dv_`
+- workflow-automations: `dv_automation_rules`, `dv_automation_log`, `dv_automation_templates` → drop `dv_`
+- x-posting: `dv_x_posts` → `x_posts`
+- _template: `dv_template_items` → `template_items`
+
+Also update core table references in plugins (e.g., `dv_plugin_config` → `plugin_config` in 11 plugins).
+
+Cross-plugin reference: x-posting/handlers.js references `dv_bip_drafts` → `bip_drafts`.
+
+**Step 2: Verify**
+
+Run: `grep -r "dv_" server/plugins/ --include="*.js" --include="*.sql" --include="*.json" | grep -v node_modules | grep -v README`
+Expected: 0 matches (README.md mentions are documentation-only, OK to leave or update)
+
+**Step 3: Commit**
+
+```bash
+git add server/plugins/
+git commit -m "refactor: remove dv_ prefix from all plugin table names"
+```
+
+---
+
+### Task 5: Live DB Migration Script
+
+**Files:**
+- Create: `server/migrate-table-names.js`
+- Modify: `server/index.js` (add migration call on startup)
+
+**Step 1: Create migration script**
+
+```javascript
+// server/migrate-table-names.js
+// One-time migration: rename dv_* tables to clean names
+// Idempotent — safe to run multiple times
+
+var TABLE_RENAMES = [
+  ['dv_agents', 'agents'],
+  ['dv_organizations', 'organizations'],
+  ['dv_projects', 'projects'],
+  ['dv_tasks', 'tasks'],
+  ['dv_context', 'context'],
+  ['dv_assets', 'assets'],
+  ['dv_events', 'events'],
+  ['dv_messages', 'messages'],
+  ['dv_context_keys', 'context_keys'],
+  ['dv_bugs', 'bugs'],
+  ['dv_plans', 'plans'],
+  ['dv_plan_steps', 'plan_steps'],
+  ['dv_plan_step_comments', 'plan_step_comments'],
+  ['dv_studio_users', 'studio_users'],
+  ['dv_password_resets', 'password_resets'],
+  ['dv_webhooks', 'webhooks'],
+  ['dv_drone_jobs', 'drone_jobs'],
+  ['dv_concepts', 'concepts'],
+  ['dv_project_concepts', 'project_concepts'],
+  ['dv_task_comments', 'task_comments'],
+  ['dv_support_tickets', 'support_tickets'],
+  ['dv_plugins', 'plugins'],
+  ['dv_plugin_migrations', 'plugin_migrations'],
+  ['dv_approvals', 'approvals'],
+  ['dv_operators', 'operators'],
+  ['dv_instance_config', 'instance_config'],
+  ['dv_approval_votes', 'approval_votes'],
+  ['dv_webhook_deliveries', 'webhook_deliveries'],
+  ['dv_channels', 'channels'],
+  ['dv_channel_members', 'channel_members'],
+  ['dv_agent_savepoints', 'agent_savepoints'],
+  ['dv_channel_reads', 'channel_reads'],
+  ['dv_operator_inbox', 'operator_inbox'],
+  ['dv_feedback', 'feedback'],
+  ['dv_drone_profiles', 'drone_profiles'],
+  ['dv_drone_profile_assignments', 'drone_profile_assignments'],
+  ['dv_job_templates', 'job_templates'],
+  ['dv_plugin_config', 'plugin_config'],
+  ['dv_runner_spawns', 'runner_spawns'],
+  ['dv_node_profiles', 'node_profiles'],
+  ['dv_customer_instances', 'customer_instances'],
+  ['dv_message_reads', 'message_reads'],
+  ['dv_team_settings', 'team_settings'],
+];
+
+// Plugin tables (created by plugin schema.sql files)
+var PLUGIN_TABLE_RENAMES = [
+  ['dv_subscriptions', 'subscriptions'],
+  ['dv_bip_drafts', 'bip_drafts'],
+  ['dv_cost_entries', 'cost_entries'],
+  ['dv_cost_daily', 'cost_daily'],
+  ['dv_cost_alerts', 'cost_alerts'],
+  ['dv_digest_reports', 'digest_reports'],
+  ['dv_digest_metrics', 'digest_metrics'],
+  ['dv_error_events', 'error_events'],
+  ['dv_github_events', 'github_events'],
+  ['dv_github_links', 'github_links'],
+  ['dv_guardrail_rules', 'guardrail_rules'],
+  ['dv_guardrail_violations', 'guardrail_violations'],
+  ['dv_outreach_campaigns', 'outreach_campaigns'],
+  ['dv_outreach_contacts', 'outreach_contacts'],
+  ['dv_social_accounts', 'social_accounts'],
+  ['dv_social_posts', 'social_posts'],
+  ['dv_steam_assets', 'steam_assets'],
+  ['dv_video_sessions', 'video_sessions'],
+  ['dv_video_clips', 'video_clips'],
+  ['dv_automation_rules', 'automation_rules'],
+  ['dv_automation_log', 'automation_log'],
+  ['dv_automation_templates', 'automation_templates'],
+  ['dv_x_posts', 'x_posts'],
+  ['dv_template_items', 'template_items'],
+];
+
+export default function migrateTableNames(db) {
+  var allRenames = TABLE_RENAMES.concat(PLUGIN_TABLE_RENAMES);
+  var existingTables = db.prepare(
+    "SELECT name FROM sqlite_master WHERE type='table'"
+  ).all().map(function(r) { return r.name; });
+
+  var renamed = 0;
+  for (var [oldName, newName] of allRenames) {
+    if (existingTables.includes(oldName) && !existingTables.includes(newName)) {
+      db.prepare('ALTER TABLE "' + oldName + '" RENAME TO "' + newName + '"').run();
+      renamed++;
+      console.log('[migration] Renamed', oldName, '→', newName);
+    }
+  }
+  if (renamed > 0) {
+    console.log('[migration] Table rename complete:', renamed, 'tables renamed');
+  }
+}
+```
+
+**Step 2: Wire migration into server startup**
+
+In `server/index.js`, after the database is opened but before schema.sql is run, call the migration:
+
+```javascript
+import migrateTableNames from './migrate-table-names.js';
+// ... after db is opened ...
+migrateTableNames(db);
+// ... then run schema.sql (CREATE TABLE IF NOT EXISTS will be no-ops for renamed tables)
+```
+
+**Step 3: Verify locally**
+
+Run: `node server/index.js`
+Expected: Server starts, migration logs show renamed tables (or "0 tables renamed" if already clean), all endpoints respond.
+
+**Step 4: Commit**
+
+```bash
+git add server/migrate-table-names.js server/index.js
+git commit -m "feat: add startup migration to rename dv_ tables to clean names"
+```
+
+---
+
+### Task 6: Verify Phase 0 — Server Health Check
+
+**Files:** None (verification only)
+
+**Step 1: Start the server locally**
+
+Run: `cd D:/mycelium && node server/index.js`
+Expected: Server starts on port 3002, no errors.
+
+**Step 2: Test boot endpoint**
+
+Run: `curl -s -H "X-Admin-Key: KPeO7ZspKsAQotZsrvnZ2vYk" "http://localhost:3002/api/mycelium/admin/overview" | python -m json.tool | head -20`
+Expected: JSON response with agents, tasks, etc.
+
+**Step 3: Test agent boot**
+
+Run: `curl -s -H "X-Admin-Key: KPeO7ZspKsAQotZsrvnZ2vYk" -H "X-Acting-As: dev-claude" "http://localhost:3002/api/mycelium/boot/dev-claude" | python -m json.tool | head -20`
+Expected: Boot payload with tasks, messages, etc.
+
+**Step 4: Save Phase 0 state to Mycelium**
+
+Use `mycelium_set_context` to save:
+- namespace: `dev-claude`
+- key: `table-rename-phase0`
+- data: `{"status": "complete", "tables_renamed": 43, "verified": true}`
+
+**Step 5: Push and deploy**
+
+```bash
+git push origin master
+cd D:/mycelium && railway up
+```
+
+Verify production: `curl -s https://mycelium.fyi/api/mycelium/admin/overview -H "X-Admin-Key: KPeO7ZspKsAQotZsrvnZ2vYk" | python -m json.tool | head -5`
+
+---
+
+### Task 7: Teams Schema + DB Functions
+
+**Files:**
+- Modify: `server/schema.sql` (add teams + team_members tables, add columns to existing tables)
+- Modify: `server/db.js` (add team CRUD + membership functions)
+
+**Step 1: Add teams tables to schema.sql**
+
+At end of schema.sql, add:
+
+```sql
+-- Teams
+CREATE TABLE IF NOT EXISTS teams (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  created_by TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_teams_org ON teams(org_id);
+
+CREATE TABLE IF NOT EXISTS team_members (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  team_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  user_type TEXT NOT NULL DEFAULT 'operator',
+  role TEXT NOT NULL DEFAULT 'member',
+  is_primary INTEGER NOT NULL DEFAULT 0,
+  joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(team_id, user_id),
+  FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_team_members_team ON team_members(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_members_user ON team_members(user_id);
+CREATE INDEX IF NOT EXISTS idx_team_members_primary ON team_members(is_primary) WHERE is_primary = 1;
+```
+
+**Step 2: Add columns to existing tables**
+
+Add inline migration in index.js (same pattern as existing migrations):
+
+```javascript
+// Team columns migration
+var projectCols = db.pragma('table_info(projects)').map(c => c.name);
+if (!projectCols.includes('team_id')) {
+  db.prepare('ALTER TABLE projects ADD COLUMN team_id TEXT').run();
+  console.log('[migration] Added team_id to projects');
+}
+var operatorCols = db.pragma('table_info(operators)').map(c => c.name);
+if (!operatorCols.includes('primary_team_id')) {
+  db.prepare('ALTER TABLE operators ADD COLUMN primary_team_id TEXT').run();
+  console.log('[migration] Added primary_team_id to operators');
+}
+var agentCols = db.pragma('table_info(agents)').map(c => c.name);
+if (!agentCols.includes('primary_team_id')) {
+  db.prepare('ALTER TABLE agents ADD COLUMN primary_team_id TEXT').run();
+  console.log('[migration] Added primary_team_id to agents');
+}
+```
+
+**Step 3: Add DB functions to db.js**
+
+After the team_settings functions, add:
+
+```javascript
+// ── Teams ──
+
+function createTeam(id, orgId, name, description, createdBy) {
+  db.prepare(
+    'INSERT INTO teams (id, org_id, name, description, created_by) VALUES (?, ?, ?, ?, ?)'
+  ).run(id, orgId, name, description || '', createdBy || '');
+  return getTeam(id);
+}
+
+function getTeam(id) {
+  var team = db.prepare('SELECT * FROM teams WHERE id = ?').get(id);
+  if (team) {
+    team.members = db.prepare(
+      'SELECT * FROM team_members WHERE team_id = ? ORDER BY role, joined_at'
+    ).all(id);
+  }
+  return team;
+}
+
+function listTeams(orgId) {
+  var sql = orgId
+    ? 'SELECT t.*, (SELECT COUNT(*) FROM team_members WHERE team_id = t.id) as member_count FROM teams t WHERE t.org_id = ? ORDER BY t.name'
+    : 'SELECT t.*, (SELECT COUNT(*) FROM team_members WHERE team_id = t.id) as member_count FROM teams t ORDER BY t.name';
+  return orgId ? db.prepare(sql).all(orgId) : db.prepare(sql).all();
+}
+
+function updateTeam(id, fields) {
+  var sets = [];
+  var values = [];
+  for (var [k, v] of Object.entries(fields)) {
+    if (['name', 'description', 'org_id'].includes(k)) {
+      sets.push(k + ' = ?');
+      values.push(v);
+    }
+  }
+  if (sets.length === 0) return getTeam(id);
+  sets.push("updated_at = datetime('now')");
+  values.push(id);
+  db.prepare('UPDATE teams SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  return getTeam(id);
+}
+
+function deleteTeam(id) {
+  var memberCount = db.prepare('SELECT COUNT(*) as c FROM team_members WHERE team_id = ?').get(id).c;
+  if (memberCount > 0) throw new Error('Team has members — remove them first');
+  db.prepare('DELETE FROM teams WHERE id = ?').run(id);
+}
+
+function addTeamMember(teamId, userId, userType, role, isPrimary) {
+  // If setting as primary, clear any existing primary for this user
+  if (isPrimary) {
+    db.prepare('UPDATE team_members SET is_primary = 0 WHERE user_id = ? AND is_primary = 1').run(userId);
+  }
+  db.prepare(
+    'INSERT INTO team_members (team_id, user_id, user_type, role, is_primary) VALUES (?, ?, ?, ?, ?)'
+  ).run(teamId, userId, userType || 'operator', role || 'member', isPrimary ? 1 : 0);
+
+  // Update denormalized primary_team_id
+  if (isPrimary) {
+    var table = userType === 'agent' ? 'agents' : 'operators';
+    db.prepare('UPDATE ' + table + ' SET primary_team_id = ? WHERE id = ?').run(teamId, userId);
+  }
+  return db.prepare('SELECT * FROM team_members WHERE team_id = ? AND user_id = ?').get(teamId, userId);
+}
+
+function updateTeamMember(teamId, userId, fields) {
+  var sets = [];
+  var values = [];
+  if (fields.role) { sets.push('role = ?'); values.push(fields.role); }
+  if (fields.is_primary !== undefined) {
+    if (fields.is_primary) {
+      // Clear existing primary
+      db.prepare('UPDATE team_members SET is_primary = 0 WHERE user_id = ? AND is_primary = 1').run(userId);
+    }
+    sets.push('is_primary = ?');
+    values.push(fields.is_primary ? 1 : 0);
+  }
+  if (sets.length === 0) return;
+  values.push(teamId, userId);
+  db.prepare('UPDATE team_members SET ' + sets.join(', ') + ' WHERE team_id = ? AND user_id = ?').run(...values);
+
+  // Update denormalized primary_team_id
+  if (fields.is_primary) {
+    var member = db.prepare('SELECT user_type FROM team_members WHERE team_id = ? AND user_id = ?').get(teamId, userId);
+    if (member) {
+      var table = member.user_type === 'agent' ? 'agents' : 'operators';
+      db.prepare('UPDATE ' + table + ' SET primary_team_id = ? WHERE id = ?').run(teamId, userId);
+    }
+  }
+}
+
+function removeTeamMember(teamId, userId) {
+  var member = db.prepare('SELECT * FROM team_members WHERE team_id = ? AND user_id = ?').get(teamId, userId);
+  if (!member) return;
+  db.prepare('DELETE FROM team_members WHERE team_id = ? AND user_id = ?').run(teamId, userId);
+
+  // Clear denormalized primary_team_id if this was the primary
+  if (member.is_primary) {
+    var table = member.user_type === 'agent' ? 'agents' : 'operators';
+    db.prepare('UPDATE ' + table + ' SET primary_team_id = NULL WHERE id = ?').run(userId);
+  }
+}
+
+function getTeamsForUser(userId) {
+  return db.prepare(
+    'SELECT t.*, tm.role, tm.is_primary FROM teams t JOIN team_members tm ON t.id = tm.team_id WHERE tm.user_id = ? ORDER BY tm.is_primary DESC, t.name'
+  ).all(userId);
+}
+
+function getTeamProjects(teamId) {
+  return db.prepare('SELECT * FROM projects WHERE team_id = ?').all(teamId);
+}
+```
+
+Export all new functions.
+
+**Step 4: Commit**
+
+```bash
+git add server/schema.sql server/db.js server/index.js
+git commit -m "feat: add teams schema, DB functions, and column migrations"
+```
+
+---
+
+### Task 8: Teams API Routes
+
+**Files:**
+- Modify: `server/routes/mycelium.js` (add team endpoints)
+
+**Step 1: Import new DB functions**
+
+Add to the destructured imports from db.js:
+`createTeam, getTeam, listTeams, updateTeam, deleteTeam, addTeamMember, updateTeamMember, removeTeamMember, getTeamsForUser, getTeamProjects`
+
+**Step 2: Add team CRUD routes**
+
+After the team-settings routes section, add:
+
+```javascript
+// ── Teams ──
+
+// GET /teams — list teams
+router.get('/teams', function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  res.json({ teams: listTeams(req.query.org_id || null) });
+});
+
+// GET /teams/:id — team detail with members
+router.get('/teams/:id', function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  var team = getTeam(req.params.id);
+  if (!team) return apiError(res, 404, 'Team not found');
+  team.projects = getTeamProjects(req.params.id);
+  res.json(team);
+});
+
+// POST /teams — create team (admin only)
+router.post('/teams', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var { id, org_id, name, description } = req.body;
+  if (!id || !org_id || !name) return apiError(res, 400, 'id, org_id, and name required');
+  try {
+    var team = createTeam(id, org_id, name, description, req.operatorId || '');
+    // Auto-create team channel
+    try {
+      var channelSlug = 'team-' + id;
+      createChannel({ name: '#' + channelSlug, slug: channelSlug, type: 'team', linked_type: 'team', linked_id: id, description: 'Team channel for ' + name, created_by: req.operatorId || '__system__' });
+    } catch (chErr) { console.log('[teams] Auto-channel creation failed:', chErr.message); }
+    res.json(team);
+  } catch (err) {
+    return apiError(res, 400, err.message);
+  }
+});
+
+// PUT /teams/:id — update team (admin only)
+router.put('/teams/:id', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var team = updateTeam(req.params.id, req.body);
+  if (!team) return apiError(res, 404, 'Team not found');
+  res.json(team);
+});
+
+// DELETE /teams/:id — delete team (admin only)
+router.delete('/teams/:id', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  try {
+    deleteTeam(req.params.id);
+    res.json({ ok: true });
+  } catch (err) {
+    return apiError(res, 400, err.message);
+  }
+});
+
+// POST /teams/:id/members — add member
+router.post('/teams/:id/members', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var { user_id, user_type, role, is_primary } = req.body;
+  if (!user_id) return apiError(res, 400, 'user_id required');
+  try {
+    var member = addTeamMember(req.params.id, user_id, user_type, role, is_primary);
+    // Auto-join team channel
+    try {
+      var channelSlug = 'team-' + req.params.id;
+      var ch = getChannelBySlug(channelSlug);
+      if (ch) addChannelMember(ch.id, user_id, user_type || 'operator', 'member');
+    } catch (_) {}
+    res.json(member);
+  } catch (err) {
+    return apiError(res, 400, err.message);
+  }
+});
+
+// PUT /teams/:id/members/:userId — update member role/primary
+router.put('/teams/:id/members/:userId', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  updateTeamMember(req.params.id, req.params.userId, req.body);
+  res.json({ ok: true });
+});
+
+// DELETE /teams/:id/members/:userId — remove member
+router.delete('/teams/:id/members/:userId', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  removeTeamMember(req.params.id, req.params.userId);
+  res.json({ ok: true });
+});
+
+// GET /teams/:id/projects — team's projects
+router.get('/teams/:id/projects', function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  res.json({ projects: getTeamProjects(req.params.id) });
+});
+```
+
+**Step 3: Add ?team_id filter to existing endpoints**
+
+For GET /tasks, GET /bugs, GET /projects, GET /agents — add optional `team_id` query param that filters results to projects owned by that team.
+
+**Step 4: Commit**
+
+```bash
+git add server/routes/mycelium.js
+git commit -m "feat: add teams API routes with CRUD, membership, and auto-channel"
+```
+
+---
+
+### Task 9: Boot Payload + Auto-Dispatch Scoping
+
+**Files:**
+- Modify: `server/db.js` (update getSlimBootPayload and work-pull functions)
+
+**Step 1: Add team context to boot payload**
+
+In `getSlimBootPayload(agentId)`, after fetching agent data, add:
+
+```javascript
+// Team context
+var agentTeams = getTeamsForUser(agentId);
+var primaryTeam = agentTeams.find(function(t) { return t.is_primary; }) || null;
+var guestTeams = agentTeams.filter(function(t) { return !t.is_primary; });
+var teamMembers = primaryTeam
+  ? db.prepare('SELECT tm.user_id, tm.user_type, tm.role FROM team_members tm WHERE tm.team_id = ?').all(primaryTeam.id)
+  : [];
+```
+
+Add to the return object: `team: primaryTeam, guest_teams: guestTeams, team_members: teamMembers`
+
+**Step 2: Scope auto-dispatch to team projects**
+
+In the work-pull / auto-dispatch logic, when querying for unassigned tasks and plan steps, add a WHERE clause:
+
+```javascript
+// Get agent's team project IDs
+var agentTeamIds = getTeamsForUser(agentId).map(function(t) { return t.id; });
+var teamProjectIds = agentTeamIds.length > 0
+  ? db.prepare('SELECT id FROM projects WHERE team_id IN (' + agentTeamIds.map(() => '?').join(',') + ')').all(...agentTeamIds).map(function(p) { return p.id; })
+  : [];
+
+// Filter tasks to team projects (or all if no team)
+if (teamProjectIds.length > 0) {
+  // Add: AND project_id IN (?, ?, ...)
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add server/db.js
+git commit -m "feat: add team context to boot payload and scope auto-dispatch"
+```
+
+---
+
+### Task 10: Dashboard — Types, API, Team Switcher
+
+**Files:**
+- Modify: `studio-react/src/api/types.ts` (add Team types)
+- Modify: `studio-react/src/api/endpoints.ts` (add team API functions)
+- Modify: `studio-react/src/stores/dashboardStore.ts` (add selectedTeamId)
+- Modify: `studio-react/src/layouts/SideNav.tsx` (add team switcher)
+- Create: `studio-react/src/pages/TeamsPage.tsx` (teams management)
+- Modify: `studio-react/src/App.tsx` (add teams route)
+
+**Step 1: Add types**
+
+In types.ts:
+```typescript
+export interface Team {
+  id: string;
+  org_id: string;
+  name: string;
+  description: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  members?: TeamMember[];
+  projects?: Project[];
+  member_count?: number;
+}
+
+export interface TeamMember {
+  id: number;
+  team_id: string;
+  user_id: string;
+  user_type: 'operator' | 'agent';
+  role: 'lead' | 'member' | 'guest';
+  is_primary: number;
+  joined_at: string;
+}
+```
+
+**Step 2: Add API functions**
+
+In endpoints.ts:
+```typescript
+export async function fetchTeams(orgId?: string): Promise<Team[]> {
+  var params = orgId ? '?org_id=' + orgId : '';
+  var res = await api('/teams' + params);
+  return res.teams;
+}
+export async function fetchTeam(id: string): Promise<Team> { return api('/teams/' + id); }
+export async function createTeam(data: Partial<Team>): Promise<Team> { return api('/teams', { method: 'POST', body: JSON.stringify(data) }); }
+export async function updateTeam(id: string, data: Partial<Team>): Promise<Team> { return api('/teams/' + id, { method: 'PUT', body: JSON.stringify(data) }); }
+export async function deleteTeam(id: string): Promise<void> { return api('/teams/' + id, { method: 'DELETE' }); }
+export async function addTeamMember(teamId: string, data: { user_id: string; user_type: string; role: string; is_primary?: boolean }): Promise<TeamMember> { return api('/teams/' + teamId + '/members', { method: 'POST', body: JSON.stringify(data) }); }
+export async function updateTeamMember(teamId: string, userId: string, data: { role?: string; is_primary?: boolean }): Promise<void> { return api('/teams/' + teamId + '/members/' + userId, { method: 'PUT', body: JSON.stringify(data) }); }
+export async function removeTeamMember(teamId: string, userId: string): Promise<void> { return api('/teams/' + teamId + '/members/' + userId, { method: 'DELETE' }); }
+```
+
+**Step 3: Add selectedTeamId to dashboard store**
+
+**Step 4: Build TeamsPage.tsx**
+
+Team management page: list teams as cards, click to expand members/projects. Add/remove members. Create new team form.
+
+**Step 5: Add team switcher to SideNav**
+
+Small dropdown at top of nav showing current team filter. Options: "All Teams" + each team the user belongs to.
+
+**Step 6: Wire into App.tsx**
+
+Add route and nav entry.
+
+**Step 7: Build and verify**
+
+Run: `cd D:/mycelium/studio-react && npm run build`
+Expected: Clean build, no TypeScript errors.
+
+**Step 8: Commit**
+
+```bash
+git add studio-react/
+git commit -m "feat: add teams dashboard page, team switcher, and API integration"
+```
+
+---
+
+### Task 11: MCP Tools + Seed Dioverse Teams
+
+**Files:**
+- Modify: `D:/mycelium-mcp/src/tools.js` (add team MCP tools)
+- No file changes for seeding (API calls only)
+
+**Step 1: Add MCP tools**
+
+Add to tools.js:
+- `mycelium_list_teams` — GET /teams
+- `mycelium_get_team` — GET /teams/:id
+- `mycelium_create_team` — POST /teams
+- `mycelium_add_team_member` — POST /teams/:id/members
+- `mycelium_remove_team_member` — DELETE /teams/:id/members/:userId
+
+**Step 2: Seed Dioverse teams via API**
+
+Using curl or MCP tools, create:
+
+```
+Team: platform (org: softbacon)
+  Members: Greatness (lead, primary), dev-claude (agent, primary), macbook-claude (agent, primary), admin-bot (agent, primary), greatness-claude (agent, primary)
+  Projects: mycelium
+
+Team: willing-sacrifice (org: softbacon)
+  Members: Greatness (lead, primary for WS work)
+  Projects: willing-sacrifice, willing-sacrifice-2
+
+Team: king-city (org: softbacon)
+  Members: Hijack (lead, primary), hijack-claude (agent, primary)
+  Projects: dioverse (KC lives here)
+
+Team: operations (org: softbacon)
+  Members: Unakron (lead, primary), Greatness (member, guest)
+  Projects: (none — drones/infra)
+```
+
+**Step 3: Commit MCP changes**
+
+```bash
+cd D:/mycelium-mcp && git add src/tools.js && git commit -m "feat: add team MCP tools"
+```
+
+**Step 4: Save final state**
+
+Use `mycelium_set_context`:
+- namespace: `dev-claude`
+- key: `teams-feature-complete`
+- data: `{"status": "complete", "tables_renamed": 43, "teams_created": 4, "verified": true}`
+
+---
+
+### Task 12: Deploy + Verify Production
+
+**Step 1: Push to GitHub**
+
+```bash
+cd D:/mycelium && git push origin master
+```
+
+**Step 2: Deploy to Railway**
+
+```bash
+cd D:/mycelium && railway up
+```
+
+**Step 3: Verify migration ran**
+
+Check Railway logs for `[migration] Renamed dv_agents → agents` etc.
+
+**Step 4: Verify API**
+
+```bash
+curl -s -H "X-Admin-Key: KPeO7ZspKsAQotZsrvnZ2vYk" "https://mycelium.fyi/api/mycelium/teams" | python -m json.tool
+curl -s -H "X-Admin-Key: KPeO7ZspKsAQotZsrvnZ2vYk" "https://mycelium.fyi/api/mycelium/admin/overview" | python -m json.tool | head -20
+```
+
+**Step 5: Notify the network**
+
+Broadcast to all agents: "Table rename complete. All dv_ prefixes removed. Teams system live. Check your boot payload for team context."

--- a/server/db.js
+++ b/server/db.js
@@ -26,61 +26,61 @@ export function initDB() {
   // Migrations: add columns that may not exist yet on the LIVE database.
   // MUST run BEFORE schema.sql because schema has CREATE INDEX on these columns.
   var migrations = [
-    ["dv_tasks", "blocked_by", "TEXT NOT NULL DEFAULT '[]'"],
-    ["dv_tasks", "blocks", "TEXT NOT NULL DEFAULT '[]'"],
-    ["dv_tasks", "needs_approval", "INTEGER NOT NULL DEFAULT 0"],
-    ["dv_tasks", "approved_by", "TEXT"],
-    ["dv_tasks", "approved_at", "TEXT"],
-    ["dv_tasks", "linked_asset_id", "INTEGER"],
-    ["dv_tasks", "request_id", "INTEGER"],
-    ["dv_tasks", "branch", "TEXT"],
-    ["dv_tasks", "pr_url", "TEXT"],
-    ["dv_tasks", "repo", "TEXT"],
-    ["dv_messages", "msg_type", "TEXT NOT NULL DEFAULT 'message'"],
-    ["dv_messages", "status", "TEXT NOT NULL DEFAULT 'sent'"],
-    ["dv_messages", "resolved_at", "TEXT"],
-    ["dv_messages", "resolved_by", "TEXT"],
-    ["dv_agents", "avatar_url", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_agents", "role", "TEXT NOT NULL DEFAULT 'agent'"],
-    ["dv_agents", "operator_id", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_agents", "project", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_approvals", "risk_tier", "TEXT NOT NULL DEFAULT 'medium'"],
-    ["dv_approvals", "required_approvals", "INTEGER NOT NULL DEFAULT 1"],
-    ["dv_approvals", "current_approvals", "INTEGER NOT NULL DEFAULT 0"],
-    ["dv_assets", "file_path", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_assets", "download_url", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_assets", "requested_by", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_assets", "assigned_to", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_messages", "channel_id", "INTEGER"],
-    ["dv_drone_jobs", "workspace_repo", "TEXT"],
-    ["dv_drone_jobs", "workspace_branch", "TEXT NOT NULL DEFAULT 'main'"],
-    ["dv_assets", "drone_job_id", "INTEGER"],
-    ["dv_assets", "prompt", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_agents", "llm_backend", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_agents", "llm_model", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_agents", "agent_type", "TEXT NOT NULL DEFAULT 'agent'"],
-    ["dv_projects", "org_id", "TEXT NOT NULL DEFAULT ''"],
-    ["dv_projects", "type", "TEXT NOT NULL DEFAULT 'software'"],
-    ["dv_projects", "status", "TEXT NOT NULL DEFAULT 'active'"],
-    ["dv_operators", "availability", "TEXT NOT NULL DEFAULT 'available'"],
-    ["dv_operators", "last_seen_at", "TEXT"],
-    ["dv_operators", "away_message", "TEXT NOT NULL DEFAULT ''"],
+    ["tasks", "blocked_by", "TEXT NOT NULL DEFAULT '[]'"],
+    ["tasks", "blocks", "TEXT NOT NULL DEFAULT '[]'"],
+    ["tasks", "needs_approval", "INTEGER NOT NULL DEFAULT 0"],
+    ["tasks", "approved_by", "TEXT"],
+    ["tasks", "approved_at", "TEXT"],
+    ["tasks", "linked_asset_id", "INTEGER"],
+    ["tasks", "request_id", "INTEGER"],
+    ["tasks", "branch", "TEXT"],
+    ["tasks", "pr_url", "TEXT"],
+    ["tasks", "repo", "TEXT"],
+    ["messages", "msg_type", "TEXT NOT NULL DEFAULT 'message'"],
+    ["messages", "status", "TEXT NOT NULL DEFAULT 'sent'"],
+    ["messages", "resolved_at", "TEXT"],
+    ["messages", "resolved_by", "TEXT"],
+    ["agents", "avatar_url", "TEXT NOT NULL DEFAULT ''"],
+    ["agents", "role", "TEXT NOT NULL DEFAULT 'agent'"],
+    ["agents", "operator_id", "TEXT NOT NULL DEFAULT ''"],
+    ["agents", "project", "TEXT NOT NULL DEFAULT ''"],
+    ["approvals", "risk_tier", "TEXT NOT NULL DEFAULT 'medium'"],
+    ["approvals", "required_approvals", "INTEGER NOT NULL DEFAULT 1"],
+    ["approvals", "current_approvals", "INTEGER NOT NULL DEFAULT 0"],
+    ["assets", "file_path", "TEXT NOT NULL DEFAULT ''"],
+    ["assets", "download_url", "TEXT NOT NULL DEFAULT ''"],
+    ["assets", "requested_by", "TEXT NOT NULL DEFAULT ''"],
+    ["assets", "assigned_to", "TEXT NOT NULL DEFAULT ''"],
+    ["messages", "channel_id", "INTEGER"],
+    ["drone_jobs", "workspace_repo", "TEXT"],
+    ["drone_jobs", "workspace_branch", "TEXT NOT NULL DEFAULT 'main'"],
+    ["assets", "drone_job_id", "INTEGER"],
+    ["assets", "prompt", "TEXT NOT NULL DEFAULT ''"],
+    ["agents", "llm_backend", "TEXT NOT NULL DEFAULT ''"],
+    ["agents", "llm_model", "TEXT NOT NULL DEFAULT ''"],
+    ["agents", "agent_type", "TEXT NOT NULL DEFAULT 'agent'"],
+    ["projects", "org_id", "TEXT NOT NULL DEFAULT ''"],
+    ["projects", "type", "TEXT NOT NULL DEFAULT 'software'"],
+    ["projects", "status", "TEXT NOT NULL DEFAULT 'active'"],
+    ["operators", "availability", "TEXT NOT NULL DEFAULT 'available'"],
+    ["operators", "last_seen_at", "TEXT"],
+    ["operators", "away_message", "TEXT NOT NULL DEFAULT ''"],
     // Step #197 — message priority tiers (urgent/normal/fyi)
-    ["dv_messages", "priority", "TEXT NOT NULL DEFAULT 'normal'"],
+    ["messages", "priority", "TEXT NOT NULL DEFAULT 'normal'"],
     // Plan #30 — dynamic bug categories per project
-    ["dv_projects", "bug_categories", "TEXT NOT NULL DEFAULT '[]'"],
+    ["projects", "bug_categories", "TEXT NOT NULL DEFAULT '[]'"],
     // Operator presence tracking — who's currently in the dashboard
-    ["dv_studio_users", "last_seen", "TEXT"],
+    ["studio_users", "last_seen", "TEXT"],
     // Drone profiles — link jobs to required profiles
-    ["dv_drone_jobs", "profile_id", "TEXT"],
+    ["drone_jobs", "profile_id", "TEXT"],
     // Drone system overhaul — smart job routing
-    ["dv_agents", "system_diagnostics", "TEXT NOT NULL DEFAULT '{}'"],
-    ["dv_drone_jobs", "job_type", "TEXT"],
+    ["agents", "system_diagnostics", "TEXT NOT NULL DEFAULT '{}'"],
+    ["drone_jobs", "job_type", "TEXT"],
     // Support ticket tiered routing
-    ["dv_support_tickets", "tier", "TEXT NOT NULL DEFAULT 'L2'"],
-    ["dv_support_tickets", "assigned_agent", "TEXT"],
-    ["dv_support_tickets", "requires_approval", "INTEGER NOT NULL DEFAULT 0"],
-    ["dv_support_tickets", "draft_response", "TEXT"],
+    ["support_tickets", "tier", "TEXT NOT NULL DEFAULT 'L2'"],
+    ["support_tickets", "assigned_agent", "TEXT"],
+    ["support_tickets", "requires_approval", "INTEGER NOT NULL DEFAULT 0"],
+    ["support_tickets", "draft_response", "TEXT"],
   ];
 
   for (var [table, col, def] of migrations) {
@@ -92,22 +92,22 @@ export function initDB() {
   db.exec(schema);
 
   // Indexes on migrated columns
-  try { db.exec('CREATE INDEX IF NOT EXISTS idx_dv_tasks_blocked ON dv_tasks(blocked_by)'); } catch (e) {}
-  try { db.exec('CREATE INDEX IF NOT EXISTS idx_dv_tasks_approval ON dv_tasks(needs_approval)'); } catch (e) {}
-  try { db.exec('CREATE INDEX IF NOT EXISTS idx_dv_messages_type ON dv_messages(msg_type)'); } catch (e) {}
-  try { db.exec('CREATE INDEX IF NOT EXISTS idx_dv_messages_status ON dv_messages(status)'); } catch (e) {}
-  try { db.exec('CREATE INDEX IF NOT EXISTS idx_dv_messages_channel ON dv_messages(channel_id)'); } catch (e) {}
-  try { db.exec('CREATE INDEX IF NOT EXISTS idx_dv_messages_priority ON dv_messages(priority)'); } catch (e) {}
+  try { db.exec('CREATE INDEX IF NOT EXISTS idx_tasks_blocked ON tasks(blocked_by)'); } catch (e) {}
+  try { db.exec('CREATE INDEX IF NOT EXISTS idx_tasks_approval ON tasks(needs_approval)'); } catch (e) {}
+  try { db.exec('CREATE INDEX IF NOT EXISTS idx_messages_type ON messages(msg_type)'); } catch (e) {}
+  try { db.exec('CREATE INDEX IF NOT EXISTS idx_messages_status ON messages(status)'); } catch (e) {}
+  try { db.exec('CREATE INDEX IF NOT EXISTS idx_messages_channel ON messages(channel_id)'); } catch (e) {}
+  try { db.exec('CREATE INDEX IF NOT EXISTS idx_messages_priority ON messages(priority)'); } catch (e) {}
 
-  // Bug #43: drop dead columns from dv_messages (is_stale, rerouted_from, rerouted_at)
+  // Bug #43: drop dead columns from messages (is_stale, rerouted_from, rerouted_at)
   // These were added in a prior branch but never used. SQLite 3.35+ supports DROP COLUMN.
   var deadCols = ['is_stale', 'rerouted_from', 'rerouted_at'];
   for (var dc of deadCols) {
-    try { db.exec('ALTER TABLE dv_messages DROP COLUMN ' + dc); } catch (e) { /* doesn't exist or older SQLite — skip */ }
+    try { db.exec('ALTER TABLE messages DROP COLUMN ' + dc); } catch (e) { /* doesn't exist or older SQLite — skip */ }
   }
 
   // Seed instance config defaults (if table is empty — fresh instance)
-  var cfgCount = db.prepare('SELECT COUNT(*) as c FROM dv_instance_config').get();
+  var cfgCount = db.prepare('SELECT COUNT(*) as c FROM instance_config').get();
   if (cfgCount.c === 0) {
     var riskTiers = JSON.stringify({
       plan_create: 'low', context_change: 'low',
@@ -115,11 +115,11 @@ export function initDB() {
       external_comm: 'high',
       money_action: 'critical', delete_agent: 'critical', instance_config: 'critical'
     });
-    db.prepare("INSERT INTO dv_instance_config (key, value, updated_by) VALUES (?, ?, ?)").run('instance_mode', 'developer', 'system');
-    db.prepare("INSERT INTO dv_instance_config (key, value, updated_by) VALUES (?, ?, ?)").run('admin_agent_id', '', 'system');
-    db.prepare("INSERT INTO dv_instance_config (key, value, updated_by) VALUES (?, ?, ?)").run('admin_status', 'coordinator', 'system');
-    db.prepare("INSERT INTO dv_instance_config (key, value, updated_by) VALUES (?, ?, ?)").run('risk_tiers', riskTiers, 'system');
-    console.log('Seeded dv_instance_config with defaults (set admin_agent_id via dashboard or API)');
+    db.prepare("INSERT INTO instance_config (key, value, updated_by) VALUES (?, ?, ?)").run('instance_mode', 'developer', 'system');
+    db.prepare("INSERT INTO instance_config (key, value, updated_by) VALUES (?, ?, ?)").run('admin_agent_id', '', 'system');
+    db.prepare("INSERT INTO instance_config (key, value, updated_by) VALUES (?, ?, ?)").run('admin_status', 'coordinator', 'system');
+    db.prepare("INSERT INTO instance_config (key, value, updated_by) VALUES (?, ?, ?)").run('risk_tiers', riskTiers, 'system');
+    console.log('Seeded instance_config with defaults (set admin_agent_id via dashboard or API)');
   }
 
   ensureDefaultChannels();
@@ -132,15 +132,15 @@ export function initDB() {
 // Migration: rename game -> project_id columns for enterprise-ready schema
 function migrateGameToProjectId() {
   var tables = [
-    ['dv_agents', 'game', 'project_id'],
-    ['dv_tasks', 'game', 'project_id'],
-    ['dv_context', 'game', 'project_id'],
-    ['dv_assets', 'game', 'project_id'],
-    ['dv_events', 'game', 'project_id'],
-    ['dv_messages', 'game', 'project_id'],
-    ['dv_bugs', 'game', 'project_id'],
-    ['dv_plans', 'game', 'project_id'],
-    ['dv_approvals', 'project', 'project_id'],
+    ['agents', 'game', 'project_id'],
+    ['tasks', 'game', 'project_id'],
+    ['context', 'game', 'project_id'],
+    ['assets', 'game', 'project_id'],
+    ['events', 'game', 'project_id'],
+    ['messages', 'game', 'project_id'],
+    ['bugs', 'game', 'project_id'],
+    ['plans', 'game', 'project_id'],
+    ['approvals', 'project', 'project_id'],
   ];
   for (var [table, oldCol, newCol] of tables) {
     try {
@@ -155,15 +155,15 @@ function migrateGameToProjectId() {
       console.error('[migration] Error renaming ' + table + '.' + oldCol + ':', e.message);
     }
   }
-  // Rename dv_games table to dv_projects
+  // Rename games table to projects
   try {
-    var gamesTables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='dv_games'").all();
+    var gamesTables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='games'").all();
     if (gamesTables.length > 0) {
-      db.prepare("ALTER TABLE dv_games RENAME TO dv_projects").run();
-      console.log('[migration] Renamed table dv_games -> dv_projects');
+      db.prepare("ALTER TABLE games RENAME TO projects").run();
+      console.log('[migration] Renamed table games -> projects');
     }
   } catch (e) {
-    console.error('[migration] Error renaming dv_games:', e.message);
+    console.error('[migration] Error renaming games:', e.message);
   }
 }
 
@@ -179,37 +179,37 @@ function stmt(key, sql) {
 // -- Agents --
 
 export function createAgent(id, name, projectId, apiKeyHash, capabilities) {
-  stmt('dvCreateAgent', `INSERT INTO dv_agents (id, name, project_id, api_key_hash, capabilities)
+  stmt('dvCreateAgent', `INSERT INTO agents (id, name, project_id, api_key_hash, capabilities)
     VALUES (?, ?, ?, ?, ?)`).run(id, name, projectId, apiKeyHash, capabilities || '[]');
 }
 
 export function getAgent(id) {
-  return stmt('dvGetAgent', 'SELECT * FROM dv_agents WHERE id = ?').get(id);
+  return stmt('dvGetAgent', 'SELECT * FROM agents WHERE id = ?').get(id);
 }
 
 export function getAgentByKeyHash(apiKeyHash) {
-  return stmt('dvGetAgentByKey', 'SELECT * FROM dv_agents WHERE api_key_hash = ?').get(apiKeyHash);
+  return stmt('dvGetAgentByKey', 'SELECT * FROM agents WHERE api_key_hash = ?').get(apiKeyHash);
 }
 
 export function listAgents() {
-  return stmt('dvListAgents3', "SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, avatar_url, role, operator_id, project, created_at FROM dv_agents WHERE project_id != 'drone' ORDER BY created_at").all();
+  return stmt('dvListAgents3', "SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, avatar_url, role, operator_id, project, created_at FROM agents WHERE project_id != 'drone' ORDER BY created_at").all();
 }
 
 export function listAllAgentsIncludingDrones() {
-  return stmt('dvListAllAgents', 'SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, avatar_url, role, operator_id, project, created_at FROM dv_agents ORDER BY created_at').all();
+  return stmt('dvListAllAgents', 'SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, avatar_url, role, operator_id, project, created_at FROM agents ORDER BY created_at').all();
 }
 
 export function updateAgentHeartbeat(id, status, workingOn) {
-  stmt('dvHeartbeat', `UPDATE dv_agents SET status = ?, working_on = ?, last_heartbeat = datetime('now')
+  stmt('dvHeartbeat', `UPDATE agents SET status = ?, working_on = ?, last_heartbeat = datetime('now')
     WHERE id = ?`).run(status || 'online', workingOn || '', id);
 }
 
 export function updateAgentKey(id, apiKeyHash) {
-  stmt('dvUpdateAgentKey', 'UPDATE dv_agents SET api_key_hash = ? WHERE id = ?').run(apiKeyHash, id);
+  stmt('dvUpdateAgentKey', 'UPDATE agents SET api_key_hash = ? WHERE id = ?').run(apiKeyHash, id);
 }
 
 export function deleteAgent(id) {
-  stmt('dvDeleteAgent', 'DELETE FROM dv_agents WHERE id = ?').run(id);
+  stmt('dvDeleteAgent', 'DELETE FROM agents WHERE id = ?').run(id);
 }
 
 export function updateAgent(id, fields) {
@@ -227,22 +227,22 @@ export function updateAgent(id, fields) {
   if (fields.system_diagnostics !== undefined) { sets.push('system_diagnostics = ?'); values.push(typeof fields.system_diagnostics === 'string' ? fields.system_diagnostics : JSON.stringify(fields.system_diagnostics)); }
   if (sets.length === 0) return;
   values.push(id);
-  db.prepare('UPDATE dv_agents SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  db.prepare('UPDATE agents SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 // -- Operators --
 
 export function createOperator(id, displayName, role, responsibilities, email, studioUserId) {
-  stmt('dvCreateOperator', `INSERT INTO dv_operators (id, display_name, role, responsibilities, email, studio_user_id)
+  stmt('dvCreateOperator', `INSERT INTO operators (id, display_name, role, responsibilities, email, studio_user_id)
     VALUES (?, ?, ?, ?, ?, ?)`).run(id, displayName, role || 'member', responsibilities || '', email || '', studioUserId || null);
 }
 
 export function getOperator(id) {
-  return stmt('dvGetOperator', 'SELECT * FROM dv_operators WHERE id = ?').get(id);
+  return stmt('dvGetOperator', 'SELECT * FROM operators WHERE id = ?').get(id);
 }
 
 export function listOperators() {
-  return stmt('dvListOperators', 'SELECT * FROM dv_operators ORDER BY created_at').all();
+  return stmt('dvListOperators', 'SELECT * FROM operators ORDER BY created_at').all();
 }
 
 export function updateOperator(id, fields) {
@@ -257,16 +257,16 @@ export function updateOperator(id, fields) {
   if (fields.availability !== undefined) { sets.push('availability = ?'); values.push(fields.availability); }
   if (fields.away_message !== undefined) { sets.push('away_message = ?'); values.push(fields.away_message); }
   values.push(id);
-  db.prepare('UPDATE dv_operators SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  db.prepare('UPDATE operators SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 export function setOperatorAvailability(id, availability, awayMessage) {
-  db.prepare(`UPDATE dv_operators SET availability = ?, away_message = ?, last_seen_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`)
+  db.prepare(`UPDATE operators SET availability = ?, away_message = ?, last_seen_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`)
     .run(availability, awayMessage || '', id);
 }
 
 export function getAvailableOperators() {
-  return db.prepare("SELECT * FROM dv_operators WHERE status = 'active' AND availability = 'available'").all();
+  return db.prepare("SELECT * FROM operators WHERE status = 'active' AND availability = 'available'").all();
 }
 
 export function isNetworkAutonomous() {
@@ -274,8 +274,8 @@ export function isNetworkAutonomous() {
   // dashboard user has been active recently. Agent heartbeats are automated and
   // do NOT indicate human presence.
   var count = db.prepare(
-    "SELECT COUNT(DISTINCT o.id) as c FROM dv_operators o " +
-    "LEFT JOIN dv_studio_users u ON u.id = o.studio_user_id " +
+    "SELECT COUNT(DISTINCT o.id) as c FROM operators o " +
+    "LEFT JOIN studio_users u ON u.id = o.studio_user_id " +
     "WHERE o.status = 'active' AND o.availability = 'available' AND " +
     "  u.last_seen > datetime('now', '-30 minutes')"
   ).get();
@@ -283,29 +283,29 @@ export function isNetworkAutonomous() {
 }
 
 export function deleteOperator(id) {
-  stmt('dvDeleteOperator', 'DELETE FROM dv_operators WHERE id = ?').run(id);
+  stmt('dvDeleteOperator', 'DELETE FROM operators WHERE id = ?').run(id);
 }
 
 // -- Instance Config --
 
 export function getInstanceConfig(key) {
-  var row = stmt('dvGetConfig', 'SELECT value FROM dv_instance_config WHERE key = ?').get(key);
+  var row = stmt('dvGetConfig', 'SELECT value FROM instance_config WHERE key = ?').get(key);
   return row ? row.value : null;
 }
 
 export function setInstanceConfig(key, value, updatedBy) {
-  stmt('dvSetConfig', `INSERT INTO dv_instance_config (key, value, updated_by, updated_at)
+  stmt('dvSetConfig', `INSERT INTO instance_config (key, value, updated_by, updated_at)
     VALUES (?, ?, ?, datetime('now'))
     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_by = excluded.updated_by, updated_at = excluded.updated_at`
   ).run(key, value, updatedBy || '');
 }
 
 export function listInstanceConfig() {
-  return stmt('dvListConfig', 'SELECT * FROM dv_instance_config ORDER BY key').all();
+  return stmt('dvListConfig', 'SELECT * FROM instance_config ORDER BY key').all();
 }
 
 export function deleteInstanceConfig(key) {
-  stmt('dvDeleteConfig', 'DELETE FROM dv_instance_config WHERE key = ?').run(key);
+  stmt('dvDeleteConfig', 'DELETE FROM instance_config WHERE key = ?').run(key);
 }
 
 // -- Sleep Mode --
@@ -332,16 +332,16 @@ export function appendSleepLog(field, item) {
 // -- Organizations --
 
 export function createOrg(id, name, description, ownerId) {
-  stmt('dvCreateOrg', `INSERT OR IGNORE INTO dv_organizations (id, name, description, owner_id)
+  stmt('dvCreateOrg', `INSERT OR IGNORE INTO organizations (id, name, description, owner_id)
     VALUES (?, ?, ?, ?)`).run(id, name, description || '', ownerId || '');
 }
 
 export function listOrgs() {
-  return stmt('dvListOrgs', 'SELECT * FROM dv_organizations ORDER BY created_at').all();
+  return stmt('dvListOrgs', 'SELECT * FROM organizations ORDER BY created_at').all();
 }
 
 export function getOrg(id) {
-  return stmt('dvGetOrg', 'SELECT * FROM dv_organizations WHERE id = ?').get(id);
+  return stmt('dvGetOrg', 'SELECT * FROM organizations WHERE id = ?').get(id);
 }
 
 export function updateOrg(id, fields) {
@@ -352,27 +352,27 @@ export function updateOrg(id, fields) {
   if (fields.status !== undefined) { sets.push('status = ?'); values.push(fields.status); }
   if (sets.length === 0) return;
   values.push(id);
-  db.prepare('UPDATE dv_organizations SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  db.prepare('UPDATE organizations SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 export function deleteOrg(id) {
-  db.prepare('DELETE FROM dv_organizations WHERE id = ?').run(id);
+  db.prepare('DELETE FROM organizations WHERE id = ?').run(id);
 }
 
 // -- Projects --
 
 export function createProject(id, name, description, repoUrl, orgId, type) {
-  stmt('dvCreateProject', `INSERT OR IGNORE INTO dv_projects (id, name, description, repo_url, org_id, type)
+  stmt('dvCreateProject', `INSERT OR IGNORE INTO projects (id, name, description, repo_url, org_id, type)
     VALUES (?, ?, ?, ?, ?, ?)`).run(id, name, description || '', repoUrl || '', orgId || '', type || 'software');
 }
 
 export function listProjects(orgId) {
-  if (orgId) return db.prepare('SELECT * FROM dv_projects WHERE org_id = ? ORDER BY created_at').all(orgId);
-  return stmt('dvListProjects', 'SELECT * FROM dv_projects ORDER BY created_at').all();
+  if (orgId) return db.prepare('SELECT * FROM projects WHERE org_id = ? ORDER BY created_at').all(orgId);
+  return stmt('dvListProjects', 'SELECT * FROM projects ORDER BY created_at').all();
 }
 
 export function getProject(id) {
-  return stmt('dvGetProject', 'SELECT * FROM dv_projects WHERE id = ?').get(id);
+  return stmt('dvGetProject', 'SELECT * FROM projects WHERE id = ?').get(id);
 }
 
 export function updateProject(id, fields) {
@@ -386,19 +386,19 @@ export function updateProject(id, fields) {
   if (fields.bug_categories !== undefined) { sets.push('bug_categories = ?'); values.push(typeof fields.bug_categories === 'string' ? fields.bug_categories : JSON.stringify(fields.bug_categories)); }
   if (sets.length === 0) return;
   values.push(id);
-  db.prepare('UPDATE dv_projects SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  db.prepare('UPDATE projects SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 // -- Tasks --
 
 export function createTask(title, description, projectId, requester, priority, tags) {
-  var result = stmt('dvCreateTask', `INSERT INTO dv_tasks (title, description, project_id, requester, priority, tags)
+  var result = stmt('dvCreateTask', `INSERT INTO tasks (title, description, project_id, requester, priority, tags)
     VALUES (?, ?, ?, ?, ?, ?) RETURNING id`).get(title, description || '', projectId || '', requester, priority || 'normal', tags || '[]');
   return result.id;
 }
 
 export function getTask(id) {
-  return stmt('dvGetTask', 'SELECT * FROM dv_tasks WHERE id = ?').get(id);
+  return stmt('dvGetTask', 'SELECT * FROM tasks WHERE id = ?').get(id);
 }
 
 export function listTasks(filters) {
@@ -412,7 +412,7 @@ export function listTasks(filters) {
   var limit = Math.min(filters.limit || 50, 500);
   var offset = filters.offset || 0;
   params.push(limit, offset);
-  return db.prepare('SELECT * FROM dv_tasks WHERE ' + where.join(' AND ') + ' ORDER BY updated_at DESC LIMIT ? OFFSET ?').all(...params);
+  return db.prepare('SELECT * FROM tasks WHERE ' + where.join(' AND ') + ' ORDER BY updated_at DESC LIMIT ? OFFSET ?').all(...params);
 }
 
 export function updateTask(id, fields) {
@@ -431,7 +431,7 @@ export function updateTask(id, fields) {
   if (fields.pr_url !== undefined) { sets.push('pr_url = ?'); values.push(fields.pr_url); }
   if (fields.repo !== undefined) { sets.push('repo = ?'); values.push(fields.repo); }
   values.push(id);
-  return db.prepare('UPDATE dv_tasks SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  return db.prepare('UPDATE tasks SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 // -- Task dependencies --
@@ -445,14 +445,14 @@ export function setTaskDependency(taskId, blockedById) {
   try { blockedBy = JSON.parse(task.blocked_by || '[]'); } catch (e) { console.warn('[mycelium] JSON parse failed for task.blocked_by (task: ' + taskId + '):', e.message); }
   if (blockedBy.indexOf(blockedById) === -1) {
     blockedBy.push(blockedById);
-    db.prepare("UPDATE dv_tasks SET blocked_by = ? WHERE id = ?").run(JSON.stringify(blockedBy), taskId);
+    db.prepare("UPDATE tasks SET blocked_by = ? WHERE id = ?").run(JSON.stringify(blockedBy), taskId);
   }
 
   var blocks = [];
   try { blocks = JSON.parse(blocker.blocks || '[]'); } catch (e) { console.warn('[mycelium] JSON parse failed for task.blocks (task: ' + blockedById + '):', e.message); }
   if (blocks.indexOf(taskId) === -1) {
     blocks.push(taskId);
-    db.prepare("UPDATE dv_tasks SET blocks = ? WHERE id = ?").run(JSON.stringify(blocks), blockedById);
+    db.prepare("UPDATE tasks SET blocks = ? WHERE id = ?").run(JSON.stringify(blocks), blockedById);
   }
   return true;
 }
@@ -470,7 +470,7 @@ export function resolveTaskDependencies(completedTaskId) {
     var deps = [];
     try { deps = JSON.parse(blocked.blocked_by || '[]'); } catch (e) { console.warn('[mycelium] JSON parse failed for task.blocked_by (task: ' + blockedId + '):', e.message); }
     deps = deps.filter(function (d) { return d !== completedTaskId; });
-    db.prepare("UPDATE dv_tasks SET blocked_by = ? WHERE id = ?").run(JSON.stringify(deps), blockedId);
+    db.prepare("UPDATE tasks SET blocked_by = ? WHERE id = ?").run(JSON.stringify(deps), blockedId);
     if (deps.length === 0) unblocked.push(blockedId);
   }
   return unblocked;
@@ -479,34 +479,34 @@ export function resolveTaskDependencies(completedTaskId) {
 // -- Task approval --
 
 export function approveTask(taskId, approvedBy) {
-  db.prepare("UPDATE dv_tasks SET approved_by = ?, approved_at = datetime('now'), updated_at = datetime('now') WHERE id = ?").run(approvedBy, taskId);
+  db.prepare("UPDATE tasks SET approved_by = ?, approved_at = datetime('now'), updated_at = datetime('now') WHERE id = ?").run(approvedBy, taskId);
 }
 
 export function listTasksNeedingApproval() {
-  return db.prepare("SELECT * FROM dv_tasks WHERE needs_approval = 1 AND approved_by IS NULL AND status != 'done' ORDER BY updated_at DESC").all();
+  return db.prepare("SELECT * FROM tasks WHERE needs_approval = 1 AND approved_by IS NULL AND status != 'done' ORDER BY updated_at DESC").all();
 }
 
 // -- Task Comments --
 
 export function addTaskComment(taskId, author, content) {
   var result = db.prepare(
-    "INSERT INTO dv_task_comments (task_id, author, content) VALUES (?, ?, ?) RETURNING *"
+    "INSERT INTO task_comments (task_id, author, content) VALUES (?, ?, ?) RETURNING *"
   ).get(taskId, author, content);
   return result;
 }
 
 export function getTaskComments(taskId) {
   return db.prepare(
-    "SELECT * FROM dv_task_comments WHERE task_id = ? ORDER BY created_at ASC"
+    "SELECT * FROM task_comments WHERE task_id = ? ORDER BY created_at ASC"
   ).all(taskId);
 }
 
 export function getTaskComment(commentId) {
-  return db.prepare("SELECT * FROM dv_task_comments WHERE id = ?").get(commentId);
+  return db.prepare("SELECT * FROM task_comments WHERE id = ?").get(commentId);
 }
 
 export function deleteTaskComment(commentId) {
-  var result = db.prepare("DELETE FROM dv_task_comments WHERE id = ?").run(commentId);
+  var result = db.prepare("DELETE FROM task_comments WHERE id = ?").run(commentId);
   return result.changes > 0;
 }
 
@@ -514,29 +514,29 @@ export function deleteTaskComment(commentId) {
 
 export function addPlanStepComment(stepId, planId, author, content) {
   var result = db.prepare(
-    "INSERT INTO dv_plan_step_comments (step_id, plan_id, author, content) VALUES (?, ?, ?, ?) RETURNING *"
+    "INSERT INTO plan_step_comments (step_id, plan_id, author, content) VALUES (?, ?, ?, ?) RETURNING *"
   ).get(stepId, planId, author, content);
   return result;
 }
 
 export function getPlanStepComments(stepId) {
   return db.prepare(
-    "SELECT * FROM dv_plan_step_comments WHERE step_id = ? ORDER BY created_at ASC"
+    "SELECT * FROM plan_step_comments WHERE step_id = ? ORDER BY created_at ASC"
   ).all(stepId);
 }
 
 // -- Context --
 
 export function getContext(projectId) {
-  return stmt('dvGetContext', 'SELECT * FROM dv_context WHERE project_id = ?').get(projectId);
+  return stmt('dvGetContext', 'SELECT * FROM context WHERE project_id = ?').get(projectId);
 }
 
 export function getAllContext() {
-  return stmt('dvGetAllContext', 'SELECT * FROM dv_context ORDER BY updated_at DESC').all();
+  return stmt('dvGetAllContext', 'SELECT * FROM context ORDER BY updated_at DESC').all();
 }
 
 export function upsertContext(projectId, data, agentId) {
-  stmt('dvUpsertContext', `INSERT INTO dv_context (project_id, data, updated_by, updated_at)
+  stmt('dvUpsertContext', `INSERT INTO context (project_id, data, updated_by, updated_at)
     VALUES (?, ?, ?, datetime('now'))
     ON CONFLICT(project_id) DO UPDATE SET data = excluded.data, updated_by = excluded.updated_by, updated_at = excluded.updated_at`).run(projectId, data, agentId);
 }
@@ -544,13 +544,13 @@ export function upsertContext(projectId, data, agentId) {
 // -- Assets --
 
 export function createAsset(name, type, projectId, status, assetPath, metadata, requester) {
-  var result = stmt('dvCreateAsset', `INSERT INTO dv_assets (name, type, project_id, status, path, metadata, requester)
+  var result = stmt('dvCreateAsset', `INSERT INTO assets (name, type, project_id, status, path, metadata, requester)
     VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id`).get(name, type || 'sprite', projectId || 'shared', status || 'requested', assetPath || '', metadata || '{}', requester || '');
   return result.id;
 }
 
 export function getAsset(id) {
-  return stmt('dvGetAsset', 'SELECT * FROM dv_assets WHERE id = ?').get(id);
+  return stmt('dvGetAsset', 'SELECT * FROM assets WHERE id = ?').get(id);
 }
 
 export function listAssets(filters) {
@@ -562,7 +562,7 @@ export function listAssets(filters) {
   var limit = Math.min(filters.limit || 50, 500);
   var offset = filters.offset || 0;
   params.push(limit, offset);
-  return db.prepare('SELECT * FROM dv_assets WHERE ' + where.join(' AND ') + ' ORDER BY updated_at DESC LIMIT ? OFFSET ?').all(...params);
+  return db.prepare('SELECT * FROM assets WHERE ' + where.join(' AND ') + ' ORDER BY updated_at DESC LIMIT ? OFFSET ?').all(...params);
 }
 
 export function updateAsset(id, fields) {
@@ -578,21 +578,21 @@ export function updateAsset(id, fields) {
   if (fields.drone_job_id !== undefined) { sets.push('drone_job_id = ?'); values.push(fields.drone_job_id); }
   if (fields.prompt !== undefined) { sets.push('prompt = ?'); values.push(fields.prompt); }
   values.push(id);
-  return db.prepare('UPDATE dv_assets SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  return db.prepare('UPDATE assets SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 export function deleteAsset(id) {
-  return db.prepare('DELETE FROM dv_assets WHERE id = ?').run(id);
+  return db.prepare('DELETE FROM assets WHERE id = ?').run(id);
 }
 
 export function listAssetsByDroneJob(droneJobId) {
-  return db.prepare('SELECT * FROM dv_assets WHERE drone_job_id = ?').all(droneJobId);
+  return db.prepare('SELECT * FROM assets WHERE drone_job_id = ?').all(droneJobId);
 }
 
 // -- Events --
 
 export function createEvent(type, agent, projectId, summary, data) {
-  var result = stmt('dvCreateEvent', `INSERT INTO dv_events (type, agent, project_id, summary, data)
+  var result = stmt('dvCreateEvent', `INSERT INTO events (type, agent, project_id, summary, data)
     VALUES (?, ?, ?, ?, ?) RETURNING id`).get(type, agent || '', projectId || null, summary || '', data || '{}');
   return result.id;
 }
@@ -608,7 +608,7 @@ export function listEvents(filters) {
   var limit = Math.min(filters.limit || 50, 500);
   var offset = filters.offset || 0;
   params.push(limit, offset);
-  return db.prepare('SELECT * FROM dv_events WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
+  return db.prepare('SELECT * FROM events WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
 }
 
 // -- Messages --
@@ -619,43 +619,43 @@ export function createMessage(fromAgent, toAgent, threadId, projectId, content, 
   var prio = VALID_MSG_PRIORITIES.includes(priority) ? priority : 'normal';
   if (msgType && msgType !== 'message') {
     var result = db.prepare(
-      "INSERT INTO dv_messages (from_agent, to_agent, thread_id, project_id, content, metadata, msg_type, channel_id, priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
+      "INSERT INTO messages (from_agent, to_agent, thread_id, project_id, content, metadata, msg_type, channel_id, priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
     ).get(fromAgent, toAgent || null, threadId || null, projectId || null, content, metadata || '{}', msgType, channelId || null, prio);
     return result.id;
   }
   var result = db.prepare(
-    "INSERT INTO dv_messages (from_agent, to_agent, thread_id, project_id, content, metadata, channel_id, priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
+    "INSERT INTO messages (from_agent, to_agent, thread_id, project_id, content, metadata, channel_id, priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
   ).get(fromAgent, toAgent || null, threadId || null, projectId || null, content, metadata || '{}', channelId || null, prio);
   return result.id;
 }
 
 export function createRequest(fromAgent, toAgent, threadId, projectId, content, metadata) {
   var result = db.prepare(
-    "INSERT INTO dv_messages (from_agent, to_agent, thread_id, project_id, content, metadata, msg_type, status, priority) VALUES (?, ?, ?, ?, ?, ?, 'request', 'pending', 'urgent') RETURNING id"
+    "INSERT INTO messages (from_agent, to_agent, thread_id, project_id, content, metadata, msg_type, status, priority) VALUES (?, ?, ?, ?, ?, ?, 'request', 'pending', 'urgent') RETURNING id"
   ).get(fromAgent, toAgent || null, threadId || null, projectId || null, content, metadata || '{}');
   return result.id;
 }
 
 export function acknowledgeMessage(id) {
-  db.prepare("UPDATE dv_messages SET status = 'acknowledged' WHERE id = ?").run(id);
+  db.prepare("UPDATE messages SET status = 'acknowledged' WHERE id = ?").run(id);
 }
 
 export function resolveMessage(id, resolvedBy) {
-  db.prepare("UPDATE dv_messages SET status = 'resolved', resolved_at = datetime('now'), resolved_by = ? WHERE id = ?").run(resolvedBy, id);
+  db.prepare("UPDATE messages SET status = 'resolved', resolved_at = datetime('now'), resolved_by = ? WHERE id = ?").run(resolvedBy, id);
 }
 
 export function listPendingRequests(agentId) {
   return db.prepare(
-    "SELECT * FROM dv_messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC"
+    "SELECT * FROM messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC"
   ).all(agentId);
 }
 
 export function countPendingForAgent(agentId) {
   var row = db.prepare(
     "SELECT " +
-    "(SELECT COUNT(*) FROM dv_messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('pending', 'sent')) as requests, " +
-    "(SELECT COUNT(*) FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('pending', 'sent')) as directives, " +
-    "(SELECT COUNT(*) FROM dv_messages WHERE (to_agent = ? OR to_agent IS NULL) AND msg_type IN ('message', 'info') AND status = 'sent') as unread"
+    "(SELECT COUNT(*) FROM messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('pending', 'sent')) as requests, " +
+    "(SELECT COUNT(*) FROM messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('pending', 'sent')) as directives, " +
+    "(SELECT COUNT(*) FROM messages WHERE (to_agent = ? OR to_agent IS NULL) AND msg_type IN ('message', 'info') AND status = 'sent') as unread"
   ).get(agentId, agentId, agentId);
   return row;
 }
@@ -664,26 +664,26 @@ export function getAgentInbox(agentId, limit) {
   limit = limit || 20;
   // Directives (blocking, must handle first)
   var directives = db.prepare(
-    "SELECT id, from_agent, content, msg_type, priority, project_id, created_at FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('pending', 'sent') ORDER BY created_at ASC"
+    "SELECT id, from_agent, content, msg_type, priority, project_id, created_at FROM messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('pending', 'sent') ORDER BY created_at ASC"
   ).all(agentId);
   // Requests (blocking, must respond)
   var requests = db.prepare(
-    "SELECT id, from_agent, content, msg_type, priority, project_id, created_at FROM dv_messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC"
+    "SELECT id, from_agent, content, msg_type, priority, project_id, created_at FROM messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC"
   ).all(agentId);
   // Unread messages (directed to me or broadcast, status=sent)
   var messages = db.prepare(
-    "SELECT id, from_agent, to_agent, content, msg_type, priority, project_id, created_at FROM dv_messages WHERE (to_agent = ? OR to_agent IS NULL) AND msg_type IN ('message', 'info') AND status = 'sent' ORDER BY created_at DESC LIMIT ?"
+    "SELECT id, from_agent, to_agent, content, msg_type, priority, project_id, created_at FROM messages WHERE (to_agent = ? OR to_agent IS NULL) AND msg_type IN ('message', 'info') AND status = 'sent' ORDER BY created_at DESC LIMIT ?"
   ).all(agentId, limit);
   return { directives: directives, requests: requests, messages: messages };
 }
 
 export function getMessage(id) {
-  return db.prepare("SELECT * FROM dv_messages WHERE id = ?").get(id);
+  return db.prepare("SELECT * FROM messages WHERE id = ?").get(id);
 }
 
 // Mark messages as read by an agent (idempotent via UNIQUE constraint)
 export function markMessagesRead(agentId, messageIds) {
-  var stmt = db.prepare("INSERT OR IGNORE INTO dv_message_reads (message_id, agent_id) VALUES (?, ?)");
+  var stmt = db.prepare("INSERT OR IGNORE INTO message_reads (message_id, agent_id) VALUES (?, ?)");
   var tx = db.transaction(function (ids) {
     for (var id of ids) stmt.run(id, agentId);
   });
@@ -695,16 +695,16 @@ export function getUnreadMessages(agentId, limit) {
   limit = limit || 20;
   // Directives + requests (blocking — always unread if status is pending/sent)
   var directives = db.prepare(
-    "SELECT id, from_agent, content, msg_type, priority, project_id, created_at FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('pending', 'sent') ORDER BY created_at ASC"
+    "SELECT id, from_agent, content, msg_type, priority, project_id, created_at FROM messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('pending', 'sent') ORDER BY created_at ASC"
   ).all(agentId);
   var requests = db.prepare(
-    "SELECT id, from_agent, content, msg_type, priority, project_id, created_at FROM dv_messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC"
+    "SELECT id, from_agent, content, msg_type, priority, project_id, created_at FROM messages WHERE to_agent = ? AND msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC"
   ).all(agentId);
   // Regular messages: directed to me OR broadcast, not yet read by me
   var messages = db.prepare(
     "SELECT m.id, m.from_agent, m.to_agent, m.content, m.msg_type, m.priority, m.project_id, m.created_at " +
-    "FROM dv_messages m " +
-    "LEFT JOIN dv_message_reads r ON r.message_id = m.id AND r.agent_id = ? " +
+    "FROM messages m " +
+    "LEFT JOIN message_reads r ON r.message_id = m.id AND r.agent_id = ? " +
     "WHERE (m.to_agent = ? OR m.to_agent IS NULL) AND m.msg_type IN ('message', 'info') AND m.status = 'sent' " +
     "AND r.id IS NULL " +
     "ORDER BY m.created_at DESC LIMIT ?"
@@ -735,23 +735,23 @@ export function listMessages(filters) {
   var orderBy = filters.priority_sort
     ? "CASE priority WHEN 'urgent' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END, created_at DESC"
     : 'created_at DESC';
-  return db.prepare('SELECT * FROM dv_messages WHERE ' + where.join(' AND ') + ' ORDER BY ' + orderBy + ' LIMIT ? OFFSET ?').all(...params);
+  return db.prepare('SELECT * FROM messages WHERE ' + where.join(' AND ') + ' ORDER BY ' + orderBy + ' LIMIT ? OFFSET ?').all(...params);
 }
 
 export function listThreads(limit) {
   return db.prepare(`SELECT thread_id, COUNT(*) as message_count,
     MAX(created_at) as last_message_at,
-    (SELECT from_agent FROM dv_messages m2 WHERE m2.thread_id = dv_messages.thread_id ORDER BY created_at DESC LIMIT 1) as last_sender
-    FROM dv_messages WHERE thread_id IS NOT NULL
+    (SELECT from_agent FROM messages m2 WHERE m2.thread_id = messages.thread_id ORDER BY created_at DESC LIMIT 1) as last_sender
+    FROM messages WHERE thread_id IS NOT NULL
     GROUP BY thread_id ORDER BY last_message_at DESC LIMIT ?`).all(Math.min(limit || 20, 500));
 }
 
 // Archive resolved messages older than N days (default 90)
-// Deletes from dv_messages, returns count of rows removed
+// Deletes from messages, returns count of rows removed
 export function archiveOldMessages(daysOld) {
   daysOld = parseInt(daysOld) || 90;
   var result = db.prepare(
-    "DELETE FROM dv_messages WHERE created_at < datetime('now', '-' || ? || ' days')" +
+    "DELETE FROM messages WHERE created_at < datetime('now', '-' || ? || ' days')" +
     " AND (status = 'resolved' OR msg_type = 'info')"
   ).run(String(daysOld));
   return result.changes;
@@ -761,7 +761,7 @@ export function archiveOldMessages(daysOld) {
 export function archiveOldEvents(daysOld) {
   daysOld = parseInt(daysOld) || 60;
   var result = db.prepare(
-    "DELETE FROM dv_events WHERE created_at < datetime('now', '-' || ? || ' days')"
+    "DELETE FROM events WHERE created_at < datetime('now', '-' || ? || ' days')"
   ).run(String(daysOld));
   return result.changes;
 }
@@ -773,7 +773,7 @@ export function bulkDeleteMessages(filters) {
   if (filters.to) { conditions.push('to_agent = ?'); params.push(filters.to); }
   if (filters.content_like) { conditions.push('content LIKE ?'); params.push('%' + filters.content_like + '%'); }
   if (conditions.length === 0) return 0;
-  var sql = 'DELETE FROM dv_messages WHERE ' + conditions.join(' AND ');
+  var sql = 'DELETE FROM messages WHERE ' + conditions.join(' AND ');
   return db.prepare(sql).run(...params).changes;
 }
 
@@ -794,7 +794,7 @@ export function upsertContextKey(namespace, key, data, agentId, opts) {
     expiresAt = opts.expires_at;
   }
 
-  var existing = db.prepare("SELECT data FROM dv_context_keys WHERE namespace = ? AND key = ?").get(namespace, key);
+  var existing = db.prepare("SELECT data FROM context_keys WHERE namespace = ? AND key = ?").get(namespace, key);
   var merged = data;
   if (existing) {
     try {
@@ -808,7 +808,7 @@ export function upsertContextKey(namespace, key, data, agentId, opts) {
     merged = typeof data === 'string' ? data : JSON.stringify(data);
   }
   db.prepare(
-    "INSERT INTO dv_context_keys (namespace, key, data, category, expires_at, updated_by, updated_at) VALUES (?, ?, ?, ?, ?, ?, datetime('now')) ON CONFLICT(namespace, key) DO UPDATE SET data = excluded.data, category = excluded.category, expires_at = excluded.expires_at, updated_by = excluded.updated_by, updated_at = excluded.updated_at"
+    "INSERT INTO context_keys (namespace, key, data, category, expires_at, updated_by, updated_at) VALUES (?, ?, ?, ?, ?, ?, datetime('now')) ON CONFLICT(namespace, key) DO UPDATE SET data = excluded.data, category = excluded.category, expires_at = excluded.expires_at, updated_by = excluded.updated_by, updated_at = excluded.updated_at"
   ).run(namespace, key, merged, category, expiresAt, agentId);
 
   // Enforce size cap per namespace
@@ -816,20 +816,20 @@ export function upsertContextKey(namespace, key, data, agentId, opts) {
 }
 
 function enforceNamespaceCap(namespace) {
-  var count = db.prepare("SELECT COUNT(*) as c FROM dv_context_keys WHERE namespace = ?").get(namespace);
+  var count = db.prepare("SELECT COUNT(*) as c FROM context_keys WHERE namespace = ?").get(namespace);
   if (count.c > CONTEXT_MAX_KEYS_PER_NAMESPACE) {
     // Delete oldest ephemeral keys first, then oldest durable
     var excess = count.c - CONTEXT_MAX_KEYS_PER_NAMESPACE;
     db.prepare(
-      "DELETE FROM dv_context_keys WHERE id IN (SELECT id FROM dv_context_keys WHERE namespace = ? ORDER BY CASE WHEN category = 'ephemeral' THEN 0 ELSE 1 END, updated_at ASC LIMIT ?)"
+      "DELETE FROM context_keys WHERE id IN (SELECT id FROM context_keys WHERE namespace = ? ORDER BY CASE WHEN category = 'ephemeral' THEN 0 ELSE 1 END, updated_at ASC LIMIT ?)"
     ).run(namespace, excess);
   }
 }
 
 export function getContextKey(namespace, key) {
-  var row = db.prepare("SELECT * FROM dv_context_keys WHERE namespace = ? AND key = ?").get(namespace, key);
+  var row = db.prepare("SELECT * FROM context_keys WHERE namespace = ? AND key = ?").get(namespace, key);
   if (row && row.expires_at && new Date(row.expires_at) < new Date()) {
-    db.prepare("DELETE FROM dv_context_keys WHERE namespace = ? AND key = ?").run(namespace, key);
+    db.prepare("DELETE FROM context_keys WHERE namespace = ? AND key = ?").run(namespace, key);
     return null;
   }
   return row;
@@ -839,43 +839,43 @@ export function listContextKeys(namespace) {
   // Filter out expired keys on read
   var now = new Date().toISOString();
   if (namespace) {
-    return db.prepare("SELECT * FROM dv_context_keys WHERE namespace = ? AND (expires_at IS NULL OR expires_at > ?) ORDER BY key").all(namespace, now);
+    return db.prepare("SELECT * FROM context_keys WHERE namespace = ? AND (expires_at IS NULL OR expires_at > ?) ORDER BY key").all(namespace, now);
   }
-  return db.prepare("SELECT * FROM dv_context_keys WHERE expires_at IS NULL OR expires_at > ? ORDER BY namespace, key").all(now);
+  return db.prepare("SELECT * FROM context_keys WHERE expires_at IS NULL OR expires_at > ? ORDER BY namespace, key").all(now);
 }
 
 export function deleteContextKey(namespace, key) {
-  db.prepare("DELETE FROM dv_context_keys WHERE namespace = ? AND key = ?").run(namespace, key);
+  db.prepare("DELETE FROM context_keys WHERE namespace = ? AND key = ?").run(namespace, key);
 }
 
 // Purge all expired context keys (called on server boot and periodically)
 export function purgeExpiredContextKeys() {
-  var result = db.prepare("DELETE FROM dv_context_keys WHERE expires_at IS NOT NULL AND expires_at <= datetime('now')").run();
+  var result = db.prepare("DELETE FROM context_keys WHERE expires_at IS NOT NULL AND expires_at <= datetime('now')").run();
   return result.changes;
 }
 
 // Clean up stale session keys for an agent (called on agent boot)
 export function cleanupAgentSessionKeys(agentId) {
-  var result = db.prepare("DELETE FROM dv_context_keys WHERE namespace = ? AND category = 'ephemeral' AND expires_at IS NOT NULL AND expires_at <= datetime('now')").run(agentId);
+  var result = db.prepare("DELETE FROM context_keys WHERE namespace = ? AND category = 'ephemeral' AND expires_at IS NOT NULL AND expires_at <= datetime('now')").run(agentId);
   return result.changes;
 }
 
 // Get context stats per namespace
 export function contextKeyStats() {
-  return db.prepare("SELECT namespace, category, COUNT(*) as count, SUM(LENGTH(data)) as total_bytes FROM dv_context_keys WHERE expires_at IS NULL OR expires_at > datetime('now') GROUP BY namespace, category ORDER BY namespace").all();
+  return db.prepare("SELECT namespace, category, COUNT(*) as count, SUM(LENGTH(data)) as total_bytes FROM context_keys WHERE expires_at IS NULL OR expires_at > datetime('now') GROUP BY namespace, category ORDER BY namespace").all();
 }
 
 // -- Bugs --
 
 export function createBug(projectId, title, description, category, severity, reporter, assignee, diagnosticData) {
   var result = db.prepare(
-    "INSERT INTO dv_bugs (project_id, title, description, category, severity, reporter, assignee, diagnostic_data) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
+    "INSERT INTO bugs (project_id, title, description, category, severity, reporter, assignee, diagnostic_data) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
   ).get(projectId || '', title, description, category || 'other', severity || 'normal', reporter || 'admin', assignee || null, diagnosticData || null);
   return result.id;
 }
 
 export function getBug(id) {
-  return db.prepare("SELECT * FROM dv_bugs WHERE id = ?").get(id);
+  return db.prepare("SELECT * FROM bugs WHERE id = ?").get(id);
 }
 
 export function listBugs(filters) {
@@ -890,7 +890,7 @@ export function listBugs(filters) {
   var limit = Math.min(filters.limit || 50, 500);
   var offset = filters.offset || 0;
   params.push(limit, offset);
-  return db.prepare('SELECT * FROM dv_bugs WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
+  return db.prepare('SELECT * FROM bugs WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
 }
 
 export function updateBug(id, updates) {
@@ -901,15 +901,15 @@ export function updateBug(id, updates) {
   if (updates.admin_notes !== undefined) { sets.push('admin_notes = ?'); params.push(updates.admin_notes); }
   if (updates.severity !== undefined) { sets.push('severity = ?'); params.push(updates.severity); }
   params.push(id);
-  db.prepare('UPDATE dv_bugs SET ' + sets.join(', ') + ' WHERE id = ?').run(...params);
+  db.prepare('UPDATE bugs SET ' + sets.join(', ') + ' WHERE id = ?').run(...params);
 }
 
 export function deleteBug(id) {
-  return db.prepare('DELETE FROM dv_bugs WHERE id = ?').run(id);
+  return db.prepare('DELETE FROM bugs WHERE id = ?').run(id);
 }
 
 export function countBugs() {
-  return db.prepare("SELECT SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) as open, SUM(CASE WHEN status = 'in_progress' THEN 1 ELSE 0 END) as in_progress, SUM(CASE WHEN status = 'fixed' THEN 1 ELSE 0 END) as fixed, COUNT(*) as total FROM dv_bugs").get();
+  return db.prepare("SELECT SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) as open, SUM(CASE WHEN status = 'in_progress' THEN 1 ELSE 0 END) as in_progress, SUM(CASE WHEN status = 'fixed' THEN 1 ELSE 0 END) as fixed, COUNT(*) as total FROM bugs").get();
 }
 
 // -- Boot payload --
@@ -920,18 +920,18 @@ export function getBootPayload(agentId) {
   var { api_key_hash, ...safeAgent } = agent;
 
   var myTasks = db.prepare(
-    "SELECT * FROM dv_tasks WHERE assignee = ? AND status IN ('open', 'in_progress') ORDER BY priority DESC, updated_at DESC"
+    "SELECT * FROM tasks WHERE assignee = ? AND status IN ('open', 'in_progress') ORDER BY priority DESC, updated_at DESC"
   ).all(agentId);
 
   var pendingRequests = listPendingRequests(agentId);
 
   var since = agent.last_heartbeat || '2000-01-01';
   var newMessages = db.prepare(
-    "SELECT * FROM dv_messages WHERE (to_agent = ? OR to_agent IS NULL) AND msg_type IN ('message', 'info') AND created_at > ? ORDER BY created_at DESC LIMIT 50"
+    "SELECT * FROM messages WHERE (to_agent = ? OR to_agent IS NULL) AND msg_type IN ('message', 'info') AND created_at > ? ORDER BY created_at DESC LIMIT 50"
   ).all(agentId, since);
 
   var pendingDirectives = db.prepare(
-    "SELECT * FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
+    "SELECT * FROM messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
   ).all(agentId);
 
   var capabilities = [];
@@ -939,13 +939,13 @@ export function getBootPayload(agentId) {
   var assetRequests = [];
   if (capabilities.indexOf('assets') !== -1) {
     assetRequests = db.prepare(
-      "SELECT * FROM dv_assets WHERE status = 'requested' ORDER BY created_at DESC LIMIT 50"
+      "SELECT * FROM assets WHERE status = 'requested' ORDER BY created_at DESC LIMIT 50"
     ).all();
   }
 
   // Only include agents active in last 7 days or in the same project
   var otherAgents = db.prepare(
-    "SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, avatar_url, role, operator_id, project FROM dv_agents WHERE id != ? AND (project_id = ? OR last_heartbeat > datetime('now', '-7 days')) ORDER BY created_at"
+    "SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, avatar_url, role, operator_id, project FROM agents WHERE id != ? AND (project_id = ? OR last_heartbeat > datetime('now', '-7 days')) ORDER BY created_at"
   ).all(agentId, agent.project_id);
 
   var projectContext = getContext(agent.project_id);
@@ -1001,16 +1001,16 @@ export function getBootPayload(agentId) {
   var sinceLastSession = null;
   if (since && since !== '2000-01-01') {
     var newMsgCount = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_messages WHERE (to_agent = ? OR to_agent IS NULL) AND created_at > ?"
+      "SELECT COUNT(*) as c FROM messages WHERE (to_agent = ? OR to_agent IS NULL) AND created_at > ?"
     ).get(agentId, since).c;
     var taskChangeCount = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_tasks WHERE (assignee = ? OR assignee IS NULL) AND updated_at > ?"
+      "SELECT COUNT(*) as c FROM tasks WHERE (assignee = ? OR assignee IS NULL) AND updated_at > ?"
     ).get(agentId, since).c;
     var planStepChangeCount = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_plan_steps WHERE updated_at > ?"
+      "SELECT COUNT(*) as c FROM plan_steps WHERE updated_at > ?"
     ).get(since).c;
     var newBugCount = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_bugs WHERE created_at > ?"
+      "SELECT COUNT(*) as c FROM bugs WHERE created_at > ?"
     ).get(since).c;
     sinceLastSession = {
       new_messages: newMsgCount,
@@ -1061,7 +1061,7 @@ export function getSlimBootPayload(agentId) {
 
   // Fetch directives and requests first — used for both counts and content
   var pendingDirectives = db.prepare(
-    "SELECT * FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
+    "SELECT * FROM messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
   ).all(agentId);
   var pendingRequests = listPendingRequests(agentId);
 
@@ -1081,20 +1081,20 @@ export function getSlimBootPayload(agentId) {
     requests: pendingRequests.length,
     messages_unread: unreadMsgCount,
     tasks_mine: db.prepare(
-      "SELECT COUNT(*) as c FROM dv_tasks WHERE assignee = ? AND status IN ('open', 'in_progress')"
+      "SELECT COUNT(*) as c FROM tasks WHERE assignee = ? AND status IN ('open', 'in_progress')"
     ).get(agentId).c,
     bugs_open: db.prepare(
-      "SELECT COUNT(*) as c FROM dv_bugs WHERE status = 'open'"
+      "SELECT COUNT(*) as c FROM bugs WHERE status = 'open'"
     ).get().c,
     plans_active: db.prepare(
-      "SELECT COUNT(*) as c FROM dv_plans WHERE (project_id = ? OR project_id = '') AND status = 'active'"
+      "SELECT COUNT(*) as c FROM plans WHERE (project_id = ? OR project_id = '') AND status = 'active'"
     ).get(agent.project_id).c
   };
 
   // Role contract — small, always needed
   var roleContract = buildRoleContract(agent, agentId);
   var myTasks = db.prepare(
-    "SELECT * FROM dv_tasks WHERE assignee = ? AND status IN ('open', 'in_progress') ORDER BY priority DESC, updated_at DESC"
+    "SELECT * FROM tasks WHERE assignee = ? AND status IN ('open', 'in_progress') ORDER BY priority DESC, updated_at DESC"
   ).all(agentId);
   var openBugs = listBugs({ status: 'open', limit: 5 });
   var myPlans = listPlans({ project_id: agent.project_id, limit: 5 });
@@ -1113,7 +1113,7 @@ export function getSlimBootPayload(agentId) {
 
   // Other agents — compact
   var otherAgents = db.prepare(
-    "SELECT id, status, working_on FROM dv_agents WHERE id != ? AND (project_id = ? OR last_heartbeat > datetime('now', '-7 days')) ORDER BY created_at"
+    "SELECT id, status, working_on FROM agents WHERE id != ? AND (project_id = ? OR last_heartbeat > datetime('now', '-7 days')) ORDER BY created_at"
   ).all(agentId, agent.project_id);
 
   // Sleep mode + autonomous mode — needed for MCP night directives
@@ -1266,7 +1266,7 @@ export function getIdleAgents() {
   // Agents that are online/idle, not drones, heartbeat within last 30 minutes
   return db.prepare(`
     SELECT id, name, project_id, status, working_on, capabilities, role
-    FROM dv_agents
+    FROM agents
     WHERE status IN ('online', 'idle')
       AND role != 'drone'
       AND last_heartbeat > datetime('now', '-30 minutes')
@@ -1281,7 +1281,7 @@ export function getNextUnassignedTask(excludeIds) {
     : '';
   var params = excludeIds && excludeIds.length > 0 ? [...excludeIds] : [];
   return db.prepare(
-    `SELECT * FROM dv_tasks
+    `SELECT * FROM tasks
      WHERE status = 'open' AND (assignee IS NULL OR assignee = '')
      ${exclude}
      ORDER BY priority DESC, created_at ASC
@@ -1293,8 +1293,8 @@ export function getNextUnassignedPlanStep() {
   // Find next unassigned pending plan step from an active plan
   return db.prepare(
     `SELECT s.*, p.title as plan_title
-     FROM dv_plan_steps s
-     JOIN dv_plans p ON p.id = s.plan_id
+     FROM plan_steps s
+     JOIN plans p ON p.id = s.plan_id
      WHERE p.status = 'active'
        AND s.status = 'pending'
        AND (s.assignee IS NULL OR s.assignee = '')
@@ -1309,7 +1309,7 @@ var _autoTaskFromAsset = null;
 
 export function initTransactions() {
   _autoTaskFromAsset = db.transaction(function (assetId, projectId, requester) {
-    var agents = db.prepare("SELECT id FROM dv_agents WHERE capabilities LIKE '%assets%'").all();
+    var agents = db.prepare("SELECT id FROM agents WHERE capabilities LIKE '%assets%'").all();
     var assignee = agents.length > 0 ? agents[0].id : null;
 
     var asset = getAsset(assetId);
@@ -1324,7 +1324,7 @@ export function initTransactions() {
       JSON.stringify(['auto', 'assets'])
     );
 
-    db.prepare("UPDATE dv_tasks SET assignee = ?, linked_asset_id = ? WHERE id = ?").run(assignee, assetId, taskId);
+    db.prepare("UPDATE tasks SET assignee = ?, linked_asset_id = ? WHERE id = ?").run(assignee, assetId, taskId);
 
     return { task_id: taskId, assignee: assignee };
   });
@@ -1339,17 +1339,17 @@ export function autoTaskFromAsset(assetId, projectId, requester) {
 
 export function createPlan(title, description, projectId, owner, priority, tags, createdBy) {
   var result = db.prepare(
-    "INSERT INTO dv_plans (title, description, project_id, owner, priority, tags, created_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
+    "INSERT INTO plans (title, description, project_id, owner, priority, tags, created_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
   ).get(title, description || '', projectId || '', owner || '', priority || 'normal', tags || '[]', createdBy || '');
   return result.id;
 }
 
 export function getPlan(id) {
-  var plan = db.prepare("SELECT * FROM dv_plans WHERE id = ?").get(id);
+  var plan = db.prepare("SELECT * FROM plans WHERE id = ?").get(id);
   if (!plan) return null;
-  var steps = db.prepare("SELECT * FROM dv_plan_steps WHERE plan_id = ? ORDER BY step_order, id").all(id);
+  var steps = db.prepare("SELECT * FROM plan_steps WHERE plan_id = ? ORDER BY step_order, id").all(id);
   // Batch-fetch all comments for this plan and group by step
-  var allComments = db.prepare("SELECT * FROM dv_plan_step_comments WHERE plan_id = ? ORDER BY created_at ASC").all(id);
+  var allComments = db.prepare("SELECT * FROM plan_step_comments WHERE plan_id = ? ORDER BY created_at ASC").all(id);
   var commentsByStep = {};
   for (var c of allComments) {
     if (!commentsByStep[c.step_id]) commentsByStep[c.step_id] = [];
@@ -1375,9 +1375,9 @@ export function listPlans(filters) {
   var limit = Math.min(filters.limit || 50, 500);
   var offset = filters.offset || 0;
   params.push(limit, offset);
-  var plans = db.prepare('SELECT * FROM dv_plans WHERE ' + where.join(' AND ') + ' ORDER BY updated_at DESC LIMIT ? OFFSET ?').all(...params);
+  var plans = db.prepare('SELECT * FROM plans WHERE ' + where.join(' AND ') + ' ORDER BY updated_at DESC LIMIT ? OFFSET ?').all(...params);
   for (var p of plans) {
-    var steps = db.prepare("SELECT id, status, title, assignee FROM dv_plan_steps WHERE plan_id = ? ORDER BY step_order ASC").all(p.id);
+    var steps = db.prepare("SELECT id, status, title, assignee FROM plan_steps WHERE plan_id = ? ORDER BY step_order ASC").all(p.id);
     var total = steps.length;
     var completed = steps.filter(function (s) { return s.status === 'completed'; }).length;
     p.step_count = total;
@@ -1401,21 +1401,21 @@ export function updatePlan(id, fields) {
   if (fields.tags !== undefined) { sets.push('tags = ?'); values.push(typeof fields.tags === 'string' ? fields.tags : JSON.stringify(fields.tags)); }
   if (fields.project_id !== undefined) { sets.push('project_id = ?'); values.push(fields.project_id); }
   values.push(id);
-  return db.prepare('UPDATE dv_plans SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  return db.prepare('UPDATE plans SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 export function deletePlan(id) {
-  db.prepare("DELETE FROM dv_plan_steps WHERE plan_id = ?").run(id);
-  db.prepare("DELETE FROM dv_plans WHERE id = ?").run(id);
+  db.prepare("DELETE FROM plan_steps WHERE plan_id = ?").run(id);
+  db.prepare("DELETE FROM plans WHERE id = ?").run(id);
 }
 
 export function createPlanStep(planId, title, description, assignee, phase) {
-  var maxOrder = db.prepare("SELECT MAX(step_order) as m FROM dv_plan_steps WHERE plan_id = ?").get(planId);
+  var maxOrder = db.prepare("SELECT MAX(step_order) as m FROM plan_steps WHERE plan_id = ?").get(planId);
   var order = (maxOrder && maxOrder.m !== null) ? maxOrder.m + 1 : 0;
   var result = db.prepare(
-    "INSERT INTO dv_plan_steps (plan_id, step_order, title, description, assignee, phase) VALUES (?, ?, ?, ?, ?, ?) RETURNING id"
+    "INSERT INTO plan_steps (plan_id, step_order, title, description, assignee, phase) VALUES (?, ?, ?, ?, ?, ?) RETURNING id"
   ).get(planId, order, title, description || '', assignee || null, phase || '');
-  db.prepare("UPDATE dv_plans SET updated_at = datetime('now') WHERE id = ?").run(planId);
+  db.prepare("UPDATE plans SET updated_at = datetime('now') WHERE id = ?").run(planId);
   return result.id;
 }
 
@@ -1433,44 +1433,44 @@ export function updatePlanStep(stepId, fields) {
   if (fields.step_order !== undefined) { sets.push('step_order = ?'); values.push(fields.step_order); }
   if (fields.status === 'completed') { sets.push("completed_at = datetime('now')"); }
   values.push(stepId);
-  db.prepare('UPDATE dv_plan_steps SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  db.prepare('UPDATE plan_steps SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
   // Update parent plan's updated_at
-  var step = db.prepare("SELECT plan_id FROM dv_plan_steps WHERE id = ?").get(stepId);
-  if (step) db.prepare("UPDATE dv_plans SET updated_at = datetime('now') WHERE id = ?").run(step.plan_id);
+  var step = db.prepare("SELECT plan_id FROM plan_steps WHERE id = ?").get(stepId);
+  if (step) db.prepare("UPDATE plans SET updated_at = datetime('now') WHERE id = ?").run(step.plan_id);
 }
 
 export function deletePlanStep(stepId) {
-  var step = db.prepare("SELECT plan_id FROM dv_plan_steps WHERE id = ?").get(stepId);
-  db.prepare("DELETE FROM dv_plan_steps WHERE id = ?").run(stepId);
-  if (step) db.prepare("UPDATE dv_plans SET updated_at = datetime('now') WHERE id = ?").run(step.plan_id);
+  var step = db.prepare("SELECT plan_id FROM plan_steps WHERE id = ?").get(stepId);
+  db.prepare("DELETE FROM plan_steps WHERE id = ?").run(stepId);
+  if (step) db.prepare("UPDATE plans SET updated_at = datetime('now') WHERE id = ?").run(step.plan_id);
 }
 
 export function reorderPlanSteps(planId, stepIds) {
   var reorder = db.transaction(function () {
     for (var i = 0; i < stepIds.length; i++) {
-      db.prepare("UPDATE dv_plan_steps SET step_order = ? WHERE id = ? AND plan_id = ?").run(i, stepIds[i], planId);
+      db.prepare("UPDATE plan_steps SET step_order = ? WHERE id = ? AND plan_id = ?").run(i, stepIds[i], planId);
     }
-    db.prepare("UPDATE dv_plans SET updated_at = datetime('now') WHERE id = ?").run(planId);
+    db.prepare("UPDATE plans SET updated_at = datetime('now') WHERE id = ?").run(planId);
   });
   reorder();
 }
 
 export function completeLinkedPlanSteps(taskId) {
-  var steps = db.prepare("SELECT id, plan_id FROM dv_plan_steps WHERE linked_task_id = ? AND status != 'completed'").all(taskId);
+  var steps = db.prepare("SELECT id, plan_id FROM plan_steps WHERE linked_task_id = ? AND status != 'completed'").all(taskId);
   var affectedPlanIds = [];
   for (var step of steps) {
-    db.prepare("UPDATE dv_plan_steps SET status = 'completed', completed_at = datetime('now'), updated_at = datetime('now') WHERE id = ?").run(step.id);
+    db.prepare("UPDATE plan_steps SET status = 'completed', completed_at = datetime('now'), updated_at = datetime('now') WHERE id = ?").run(step.id);
     if (affectedPlanIds.indexOf(step.plan_id) === -1) affectedPlanIds.push(step.plan_id);
   }
   // Check if any affected plans are now fully complete
   var completedPlans = [];
   for (var planId of affectedPlanIds) {
-    var remaining = db.prepare("SELECT COUNT(*) as c FROM dv_plan_steps WHERE plan_id = ? AND status NOT IN ('completed', 'skipped')").get(planId);
+    var remaining = db.prepare("SELECT COUNT(*) as c FROM plan_steps WHERE plan_id = ? AND status NOT IN ('completed', 'skipped')").get(planId);
     if (remaining.c === 0) {
-      db.prepare("UPDATE dv_plans SET status = 'completed', updated_at = datetime('now') WHERE id = ? AND status = 'active'").run(planId);
+      db.prepare("UPDATE plans SET status = 'completed', updated_at = datetime('now') WHERE id = ? AND status = 'active'").run(planId);
       completedPlans.push(planId);
     } else {
-      db.prepare("UPDATE dv_plans SET updated_at = datetime('now') WHERE id = ?").run(planId);
+      db.prepare("UPDATE plans SET updated_at = datetime('now') WHERE id = ?").run(planId);
     }
   }
   return { steps_completed: steps.length, plans_completed: completedPlans };
@@ -1480,36 +1480,36 @@ export function completeLinkedPlanSteps(taskId) {
 
 export function createStudioUser(username, displayName, passwordHash, role) {
   var result = db.prepare(
-    "INSERT INTO dv_studio_users (username, display_name, password_hash, role) VALUES (?, ?, ?, ?) RETURNING id"
+    "INSERT INTO studio_users (username, display_name, password_hash, role) VALUES (?, ?, ?, ?) RETURNING id"
   ).get(username, displayName, passwordHash, role || 'admin');
   return result.id;
 }
 
 export function getStudioUserByUsername(username) {
-  return db.prepare("SELECT * FROM dv_studio_users WHERE username = ?").get(username);
+  return db.prepare("SELECT * FROM studio_users WHERE username = ?").get(username);
 }
 
 export function getStudioUserById(id) {
-  return db.prepare("SELECT id, username, display_name, role, created_at FROM dv_studio_users WHERE id = ?").get(id);
+  return db.prepare("SELECT id, username, display_name, role, created_at FROM studio_users WHERE id = ?").get(id);
 }
 
 export function listStudioUsers() {
-  return db.prepare("SELECT id, username, display_name, role, created_at, last_seen FROM dv_studio_users ORDER BY created_at").all();
+  return db.prepare("SELECT id, username, display_name, role, created_at, last_seen FROM studio_users ORDER BY created_at").all();
 }
 
 export function touchStudioUserSeen(id) {
-  db.prepare("UPDATE dv_studio_users SET last_seen = datetime('now') WHERE id = ?").run(id);
+  db.prepare("UPDATE studio_users SET last_seen = datetime('now') WHERE id = ?").run(id);
 }
 
 export function getActiveStudioUsers(withinMinutes) {
   var mins = withinMinutes || 5;
   return db.prepare(
-    "SELECT id, username, display_name, role, last_seen FROM dv_studio_users WHERE last_seen >= datetime('now', '-' || ? || ' minutes') ORDER BY last_seen DESC"
+    "SELECT id, username, display_name, role, last_seen FROM studio_users WHERE last_seen >= datetime('now', '-' || ? || ' minutes') ORDER BY last_seen DESC"
   ).all(mins);
 }
 
 export function deleteStudioUser(id) {
-  db.prepare("DELETE FROM dv_studio_users WHERE id = ?").run(id);
+  db.prepare("DELETE FROM studio_users WHERE id = ?").run(id);
 }
 
 export function updateStudioUser(id, fields) {
@@ -1520,7 +1520,7 @@ export function updateStudioUser(id, fields) {
   if (fields.role !== undefined) { sets.push('role = ?'); values.push(fields.role); }
   if (sets.length === 0) return;
   values.push(id);
-  db.prepare('UPDATE dv_studio_users SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  db.prepare('UPDATE studio_users SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 // -- Webhooks --
@@ -1528,26 +1528,26 @@ export function updateStudioUser(id, fields) {
 export function createWebhook(agentId, url, events, secret) {
   var eventsJson = Array.isArray(events) ? JSON.stringify(events) : (events || '["task_created","request_created","message_sent"]');
   var result = db.prepare(
-    "INSERT INTO dv_webhooks (agent_id, url, events, secret) VALUES (?, ?, ?, ?) RETURNING id"
+    "INSERT INTO webhooks (agent_id, url, events, secret) VALUES (?, ?, ?, ?) RETURNING id"
   ).get(agentId, url, eventsJson, secret || '');
   return result.id;
 }
 
 export function listWebhooks(agentId) {
   if (agentId) {
-    return db.prepare("SELECT * FROM dv_webhooks WHERE agent_id = ? AND active = 1").all(agentId);
+    return db.prepare("SELECT * FROM webhooks WHERE agent_id = ? AND active = 1").all(agentId);
   }
-  return db.prepare("SELECT * FROM dv_webhooks WHERE active = 1").all();
+  return db.prepare("SELECT * FROM webhooks WHERE active = 1").all();
 }
 
 export function deleteWebhook(id) {
-  db.prepare("DELETE FROM dv_webhooks WHERE id = ?").run(id);
+  db.prepare("DELETE FROM webhooks WHERE id = ?").run(id);
 }
 
 export function dispatchWebhook(event, agentId, data) {
   // Query webhooks for the target agent AND __global__ (admin-claude receives all events)
   var webhooks = db.prepare(
-    "SELECT * FROM dv_webhooks WHERE active = 1 AND (agent_id = ? OR agent_id = '__global__')"
+    "SELECT * FROM webhooks WHERE active = 1 AND (agent_id = ? OR agent_id = '__global__')"
   ).all(agentId);
 
   for (var wh of webhooks) {
@@ -1596,7 +1596,7 @@ export function dispatchWebhook(event, agentId, data) {
 function logWebhookDelivery(webhookId, event, agentId, payload, statusCode, responseBody, error, durationMs) {
   try {
     db.prepare(
-      "INSERT INTO dv_webhook_deliveries (webhook_id, event, agent_id, payload, status_code, response_body, error, duration_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO webhook_deliveries (webhook_id, event, agent_id, payload, status_code, response_body, error, duration_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
     ).run(webhookId, event, agentId, payload, statusCode, responseBody, error, durationMs);
   } catch (e) {
     console.error('[webhook-log] Failed to log delivery:', e.message);
@@ -1612,12 +1612,12 @@ export function listWebhookDeliveries(filters) {
   var limit = Math.min(filters.limit || 50, 200);
   var offset = filters.offset || 0;
   params.push(limit, offset);
-  return db.prepare('SELECT * FROM dv_webhook_deliveries WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
+  return db.prepare('SELECT * FROM webhook_deliveries WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
 }
 
 export function pruneWebhookDeliveries(keepDays) {
   var days = keepDays || 7;
-  var result = db.prepare("DELETE FROM dv_webhook_deliveries WHERE created_at < datetime('now', '-' || ? || ' days')").run(days);
+  var result = db.prepare("DELETE FROM webhook_deliveries WHERE created_at < datetime('now', '-' || ? || ' days')").run(days);
   return result.changes;
 }
 
@@ -1625,14 +1625,14 @@ export function pruneWebhookDeliveries(keepDays) {
 
 export function createTeamChat(fromUser, content) {
   var result = db.prepare(
-    "INSERT INTO dv_messages (from_agent, content, msg_type) VALUES (?, ?, 'chat') RETURNING id"
+    "INSERT INTO messages (from_agent, content, msg_type) VALUES (?, ?, 'chat') RETURNING id"
   ).get(fromUser, content);
   return result.id;
 }
 
 export function listTeamChat(limit) {
   return db.prepare(
-    "SELECT * FROM dv_messages WHERE msg_type = 'chat' ORDER BY created_at DESC LIMIT ?"
+    "SELECT * FROM messages WHERE msg_type = 'chat' ORDER BY created_at DESC LIMIT ?"
   ).all(limit || 50);
 }
 
@@ -1640,21 +1640,21 @@ export function listTeamChat(limit) {
 
 export function createChannel(name, slug, type, linkedType, linkedId, description, createdBy) {
   var result = db.prepare(
-    "INSERT INTO dv_channels (name, slug, type, linked_type, linked_id, description, created_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
+    "INSERT INTO channels (name, slug, type, linked_type, linked_id, description, created_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
   ).get(name, slug, type || 'general', linkedType || null, linkedId || null, description || '', createdBy);
   return result.id;
 }
 
 export function getChannel(id) {
-  return db.prepare("SELECT * FROM dv_channels WHERE id = ?").get(id);
+  return db.prepare("SELECT * FROM channels WHERE id = ?").get(id);
 }
 
 export function getChannelBySlug(slug) {
-  return db.prepare("SELECT * FROM dv_channels WHERE slug = ?").get(slug);
+  return db.prepare("SELECT * FROM channels WHERE slug = ?").get(slug);
 }
 
 export function getChannelByLink(linkedType, linkedId) {
-  return db.prepare("SELECT * FROM dv_channels WHERE linked_type = ? AND linked_id = ?").get(linkedType, linkedId);
+  return db.prepare("SELECT * FROM channels WHERE linked_type = ? AND linked_id = ?").get(linkedType, linkedId);
 }
 
 export function listChannels(filters) {
@@ -1664,13 +1664,13 @@ export function listChannels(filters) {
   if (filters.status && filters.status !== 'all') { where.push('status = ?'); params.push(filters.status); }
   else if (!filters.status) { where.push("status = 'active'"); }
   if (filters.member) {
-    where.push('id IN (SELECT channel_id FROM dv_channel_members WHERE user_id = ?)');
+    where.push('id IN (SELECT channel_id FROM channel_members WHERE user_id = ?)');
     params.push(filters.member);
   }
   var limit = Math.min(filters.limit || 50, 500);
   var offset = filters.offset || 0;
   params.push(limit, offset);
-  return db.prepare('SELECT * FROM dv_channels WHERE ' + where.join(' AND ') + ' ORDER BY created_at ASC LIMIT ? OFFSET ?').all(...params);
+  return db.prepare('SELECT * FROM channels WHERE ' + where.join(' AND ') + ' ORDER BY created_at ASC LIMIT ? OFFSET ?').all(...params);
 }
 
 export function updateChannel(id, fields) {
@@ -1681,11 +1681,11 @@ export function updateChannel(id, fields) {
   if (fields.status !== undefined) { sets.push('status = ?'); values.push(fields.status); }
   if (sets.length === 0) return;
   values.push(id);
-  db.prepare('UPDATE dv_channels SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  db.prepare('UPDATE channels SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 export function deleteChannel(id) {
-  db.prepare("DELETE FROM dv_channels WHERE id = ?").run(id);
+  db.prepare("DELETE FROM channels WHERE id = ?").run(id);
 }
 
 // -- Channel Members --
@@ -1693,7 +1693,7 @@ export function deleteChannel(id) {
 export function addChannelMember(channelId, userId, userType, role) {
   try {
     db.prepare(
-      "INSERT INTO dv_channel_members (channel_id, user_id, user_type, role) VALUES (?, ?, ?, ?)"
+      "INSERT INTO channel_members (channel_id, user_id, user_type, role) VALUES (?, ?, ?, ?)"
     ).run(channelId, userId, userType || 'agent', role || 'member');
     return true;
   } catch (e) {
@@ -1702,22 +1702,22 @@ export function addChannelMember(channelId, userId, userType, role) {
 }
 
 export function removeChannelMember(channelId, userId) {
-  var result = db.prepare("DELETE FROM dv_channel_members WHERE channel_id = ? AND user_id = ?").run(channelId, userId);
+  var result = db.prepare("DELETE FROM channel_members WHERE channel_id = ? AND user_id = ?").run(channelId, userId);
   return result.changes > 0;
 }
 
 export function listChannelMembers(channelId) {
-  return db.prepare("SELECT * FROM dv_channel_members WHERE channel_id = ? ORDER BY joined_at ASC").all(channelId);
+  return db.prepare("SELECT * FROM channel_members WHERE channel_id = ? ORDER BY joined_at ASC").all(channelId);
 }
 
 export function isChannelMember(channelId, userId) {
-  var row = db.prepare("SELECT 1 FROM dv_channel_members WHERE channel_id = ? AND user_id = ?").get(channelId, userId);
+  var row = db.prepare("SELECT 1 FROM channel_members WHERE channel_id = ? AND user_id = ?").get(channelId, userId);
   return !!row;
 }
 
 export function getChannelsByUser(userId) {
   return db.prepare(
-    "SELECT c.*, cm.role as member_role FROM dv_channels c JOIN dv_channel_members cm ON c.id = cm.channel_id WHERE cm.user_id = ? AND c.status = 'active' ORDER BY c.created_at ASC"
+    "SELECT c.*, cm.role as member_role FROM channels c JOIN channel_members cm ON c.id = cm.channel_id WHERE cm.user_id = ? AND c.status = 'active' ORDER BY c.created_at ASC"
   ).all(userId);
 }
 
@@ -1725,18 +1725,18 @@ export function getChannelsByUser(userId) {
 
 export function markChannelRead(channelId, userId, messageId) {
   db.prepare(
-    "INSERT INTO dv_channel_reads (channel_id, user_id, last_read_at, last_read_message_id) VALUES (?, ?, datetime('now'), ?) ON CONFLICT(channel_id, user_id) DO UPDATE SET last_read_at = datetime('now'), last_read_message_id = excluded.last_read_message_id"
+    "INSERT INTO channel_reads (channel_id, user_id, last_read_at, last_read_message_id) VALUES (?, ?, datetime('now'), ?) ON CONFLICT(channel_id, user_id) DO UPDATE SET last_read_at = datetime('now'), last_read_message_id = excluded.last_read_message_id"
   ).run(channelId, userId, messageId || 0);
 }
 
 export function getUnreadCounts(userId) {
   return db.prepare(
-    "SELECT c.id as channel_id, c.name, c.slug, COUNT(m.id) as unread FROM dv_channels c JOIN dv_channel_members cm ON c.id = cm.channel_id LEFT JOIN dv_messages m ON m.channel_id = c.id AND m.id > COALESCE((SELECT last_read_message_id FROM dv_channel_reads WHERE channel_id = c.id AND user_id = ?), 0) WHERE cm.user_id = ? AND c.status = 'active' GROUP BY c.id"
+    "SELECT c.id as channel_id, c.name, c.slug, COUNT(m.id) as unread FROM channels c JOIN channel_members cm ON c.id = cm.channel_id LEFT JOIN messages m ON m.channel_id = c.id AND m.id > COALESCE((SELECT last_read_message_id FROM channel_reads WHERE channel_id = c.id AND user_id = ?), 0) WHERE cm.user_id = ? AND c.status = 'active' GROUP BY c.id"
   ).all(userId, userId);
 }
 
 export function getLatestChannelMessageId(channelId) {
-  var row = db.prepare("SELECT MAX(id) as max_id FROM dv_messages WHERE channel_id = ?").get(channelId);
+  var row = db.prepare("SELECT MAX(id) as max_id FROM messages WHERE channel_id = ?").get(channelId);
   return row ? (row.max_id || 0) : 0;
 }
 
@@ -1750,13 +1750,13 @@ export function listChannelMessages(channelId, filters) {
   var limit = Math.min(filters.limit || 50, 500);
   params.push(limit);
   return db.prepare(
-    'SELECT * FROM dv_messages WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?'
+    'SELECT * FROM messages WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?'
   ).all(...params);
 }
 
 export function createChannelMessage(channelId, fromAgent, content, metadata) {
   var result = db.prepare(
-    "INSERT INTO dv_messages (channel_id, from_agent, content, metadata, msg_type) VALUES (?, ?, ?, ?, 'message') RETURNING id"
+    "INSERT INTO messages (channel_id, from_agent, content, metadata, msg_type) VALUES (?, ?, ?, ?, 'message') RETURNING id"
   ).get(channelId, fromAgent, content, metadata || '{}');
   return result.id;
 }
@@ -1808,11 +1808,11 @@ export function getOrCreateDmChannel(userA, userB, userAType, userBType) {
   // Find any existing active DM channel that has exactly these two participants (case-insensitive).
   // This prevents duplicate channels when usernames differ by case or creation order.
   var existing = db.prepare(`
-    SELECT c.id FROM dv_channels c
+    SELECT c.id FROM channels c
     WHERE c.type = 'dm' AND c.status = 'active'
-      AND (SELECT COUNT(*) FROM dv_channel_members m
+      AND (SELECT COUNT(*) FROM channel_members m
            WHERE m.channel_id = c.id AND LOWER(m.user_id) IN (LOWER(?), LOWER(?))) = 2
-      AND (SELECT COUNT(*) FROM dv_channel_members m WHERE m.channel_id = c.id) = 2
+      AND (SELECT COUNT(*) FROM channel_members m WHERE m.channel_id = c.id) = 2
     ORDER BY c.id ASC
     LIMIT 1
   `).get(userA, userB);
@@ -1844,7 +1844,7 @@ export function getOrCreateDmChannel(userA, userB, userAType, userBType) {
 
 export function createDroneJob(title, command, inputData, requires, requester, priority, workspaceRepo, workspaceBranch, profileId) {
   var result = db.prepare(
-    "INSERT INTO dv_drone_jobs (title, command, input_data, requires, requester, priority, workspace_repo, workspace_branch, profile_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
+    "INSERT INTO drone_jobs (title, command, input_data, requires, requester, priority, workspace_repo, workspace_branch, profile_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
   ).get(
     title,
     command || '',
@@ -1860,7 +1860,7 @@ export function createDroneJob(title, command, inputData, requires, requester, p
 }
 
 export function getDroneJob(id) {
-  return db.prepare("SELECT * FROM dv_drone_jobs WHERE id = ?").get(id);
+  return db.prepare("SELECT * FROM drone_jobs WHERE id = ?").get(id);
 }
 
 export function claimDroneJob(droneId, capabilities) {
@@ -1868,7 +1868,7 @@ export function claimDroneJob(droneId, capabilities) {
   // If job has profile_id, drone must have completed setup for that profile
   var caps = Array.isArray(capabilities) ? capabilities : [];
   var pending = db.prepare(
-    "SELECT * FROM dv_drone_jobs WHERE status = 'pending' ORDER BY priority DESC, created_at ASC"
+    "SELECT * FROM drone_jobs WHERE status = 'pending' ORDER BY priority DESC, created_at ASC"
   ).all();
   for (var job of pending) {
     var reqs = [];
@@ -1878,12 +1878,12 @@ export function claimDroneJob(droneId, capabilities) {
     // Check profile requirement — drone must have setup_done=1 for this profile
     if (job.profile_id) {
       var assignment = db.prepare(
-        "SELECT setup_done FROM dv_drone_profile_assignments WHERE drone_id = ? AND profile_id = ?"
+        "SELECT setup_done FROM drone_profile_assignments WHERE drone_id = ? AND profile_id = ?"
       ).get(droneId, job.profile_id);
       if (!assignment || !assignment.setup_done) continue;
     }
     var result = db.prepare(
-      "UPDATE dv_drone_jobs SET status = 'claimed', drone_id = ?, started_at = datetime('now') WHERE id = ? AND status = 'pending'"
+      "UPDATE drone_jobs SET status = 'claimed', drone_id = ?, started_at = datetime('now') WHERE id = ? AND status = 'pending'"
     ).run(droneId, job.id);
     if (result.changes > 0) return getDroneJob(job.id);
   }
@@ -1902,7 +1902,7 @@ export function updateDroneJob(id, fields) {
   if (fields.completed_at !== undefined) { sets.push('completed_at = ?'); values.push(fields.completed_at); }
   if (sets.length === 0) return;
   values.push(id);
-  return db.prepare('UPDATE dv_drone_jobs SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  return db.prepare('UPDATE drone_jobs SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
 }
 
 export function listDroneJobs(filters) {
@@ -1914,18 +1914,18 @@ export function listDroneJobs(filters) {
   var limit = Math.min(filters.limit || 50, 200);
   var offset = filters.offset || 0;
   params.push(limit, offset);
-  return db.prepare('SELECT * FROM dv_drone_jobs WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
+  return db.prepare('SELECT * FROM drone_jobs WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
 }
 
 export function listDrones() {
-  return db.prepare("SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, created_at FROM dv_agents WHERE project_id = 'drone' ORDER BY created_at").all();
+  return db.prepare("SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, created_at FROM agents WHERE project_id = 'drone' ORDER BY created_at").all();
 }
 
 // -- Drone Profiles --
 
 export function createDroneProfile(id, name, description, requires, artifacts, setupScript, workspace, env) {
   db.prepare(
-    "INSERT INTO dv_drone_profiles (id, name, description, requires, artifacts, setup_script, workspace, env) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    "INSERT INTO drone_profiles (id, name, description, requires, artifacts, setup_script, workspace, env) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
   ).run(
     id, name, description || '',
     typeof requires === 'string' ? requires : JSON.stringify(requires || {}),
@@ -1938,11 +1938,11 @@ export function createDroneProfile(id, name, description, requires, artifacts, s
 }
 
 export function getDroneProfile(id) {
-  return db.prepare("SELECT * FROM dv_drone_profiles WHERE id = ?").get(id);
+  return db.prepare("SELECT * FROM drone_profiles WHERE id = ?").get(id);
 }
 
 export function listDroneProfiles() {
-  return db.prepare("SELECT * FROM dv_drone_profiles ORDER BY created_at").all();
+  return db.prepare("SELECT * FROM drone_profiles ORDER BY created_at").all();
 }
 
 export function updateDroneProfile(id, fields) {
@@ -1960,43 +1960,43 @@ export function updateDroneProfile(id, fields) {
   if (sets.length === 0) return getDroneProfile(id);
   sets.push("updated_at = datetime('now')");
   values.push(id);
-  db.prepare('UPDATE dv_drone_profiles SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  db.prepare('UPDATE drone_profiles SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
   // Invalidate setup_done for all drones assigned to this profile
-  db.prepare("UPDATE dv_drone_profile_assignments SET setup_done = 0, checksum = '' WHERE profile_id = ?").run(id);
+  db.prepare("UPDATE drone_profile_assignments SET setup_done = 0, checksum = '' WHERE profile_id = ?").run(id);
   return getDroneProfile(id);
 }
 
 export function deleteDroneProfile(id) {
-  return db.prepare("DELETE FROM dv_drone_profiles WHERE id = ?").run(id);
+  return db.prepare("DELETE FROM drone_profiles WHERE id = ?").run(id);
 }
 
 export function assignDroneProfile(droneId, profileId) {
   db.prepare(
-    "INSERT OR REPLACE INTO dv_drone_profile_assignments (drone_id, profile_id, setup_done, checksum) VALUES (?, ?, 0, '')"
+    "INSERT OR REPLACE INTO drone_profile_assignments (drone_id, profile_id, setup_done, checksum) VALUES (?, ?, 0, '')"
   ).run(droneId, profileId);
 }
 
 export function unassignDroneProfile(droneId, profileId) {
-  return db.prepare("DELETE FROM dv_drone_profile_assignments WHERE drone_id = ? AND profile_id = ?").run(droneId, profileId);
+  return db.prepare("DELETE FROM drone_profile_assignments WHERE drone_id = ? AND profile_id = ?").run(droneId, profileId);
 }
 
 export function getDroneProfileAssignments(droneId) {
   return db.prepare(
     "SELECT a.*, p.name, p.description, p.requires, p.artifacts, p.setup_script, p.workspace, p.env, p.updated_at as profile_updated_at " +
-    "FROM dv_drone_profile_assignments a JOIN dv_drone_profiles p ON a.profile_id = p.id WHERE a.drone_id = ? ORDER BY p.created_at"
+    "FROM drone_profile_assignments a JOIN drone_profiles p ON a.profile_id = p.id WHERE a.drone_id = ? ORDER BY p.created_at"
   ).all(droneId);
 }
 
 export function markProfileSetupDone(droneId, profileId, checksum) {
   db.prepare(
-    "UPDATE dv_drone_profile_assignments SET setup_done = 1, setup_at = datetime('now'), checksum = ? WHERE drone_id = ? AND profile_id = ?"
+    "UPDATE drone_profile_assignments SET setup_done = 1, setup_at = datetime('now'), checksum = ? WHERE drone_id = ? AND profile_id = ?"
   ).run(checksum || '', droneId, profileId);
 }
 
 export function getDronesWithProfile(profileId) {
   return db.prepare(
     "SELECT a.drone_id, a.setup_done, a.setup_at, a.checksum, ag.status, ag.last_heartbeat " +
-    "FROM dv_drone_profile_assignments a JOIN dv_agents ag ON a.drone_id = ag.id WHERE a.profile_id = ?"
+    "FROM drone_profile_assignments a JOIN agents ag ON a.drone_id = ag.id WHERE a.profile_id = ?"
   ).all(profileId);
 }
 
@@ -2008,14 +2008,14 @@ export function bulkCancelDroneJobs(statuses, olderThanDays) {
     where += " AND completed_at < datetime('now', '-' || ? || ' days')";
     params.push(String(parseInt(olderThanDays)));
   }
-  var jobs = db.prepare('SELECT id, title, status FROM dv_drone_jobs WHERE ' + where).all.apply(
-    db.prepare('SELECT id, title, status FROM dv_drone_jobs WHERE ' + where), params
+  var jobs = db.prepare('SELECT id, title, status FROM drone_jobs WHERE ' + where).all.apply(
+    db.prepare('SELECT id, title, status FROM drone_jobs WHERE ' + where), params
   );
   if (jobs.length > 0) {
     var idPlaceholders = jobs.map(function () { return '?'; }).join(',');
     var ids = jobs.map(function (j) { return j.id; });
-    db.prepare("UPDATE dv_drone_jobs SET status = 'cancelled' WHERE id IN (" + idPlaceholders + ')').run.apply(
-      db.prepare("UPDATE dv_drone_jobs SET status = 'cancelled' WHERE id IN (" + idPlaceholders + ')'), ids
+    db.prepare("UPDATE drone_jobs SET status = 'cancelled' WHERE id IN (" + idPlaceholders + ')').run.apply(
+      db.prepare("UPDATE drone_jobs SET status = 'cancelled' WHERE id IN (" + idPlaceholders + ')'), ids
     );
   }
   return jobs;
@@ -2025,10 +2025,10 @@ export function bulkCancelDroneJobs(statuses, olderThanDays) {
 
 // Seed the 3d_print template so new instances support printer drones out of the box.
 export function seedDefaultJobTemplates() {
-  var existing = db.prepare("SELECT id FROM dv_job_templates WHERE id = '3d_print'").get();
+  var existing = db.prepare("SELECT id FROM job_templates WHERE id = '3d_print'").get();
   if (!existing) {
     db.prepare(
-      "INSERT INTO dv_job_templates (id, name, project_id, requires, min_vram_gb, min_disk_gb) VALUES (?, ?, ?, ?, ?, ?)"
+      "INSERT INTO job_templates (id, name, project_id, requires, min_vram_gb, min_disk_gb) VALUES (?, ?, ?, ?, ?, ?)"
     ).run('3d_print', '3D Print Job', '', '["3d_printer"]', 0, 1);
     console.log('Seeded 3d_print job template');
   }
@@ -2036,7 +2036,7 @@ export function seedDefaultJobTemplates() {
 
 export function createJobTemplate(id, fields) {
   db.prepare(
-    "INSERT INTO dv_job_templates (id, name, project_id, requires, min_vram_gb, min_disk_gb, python_deps, python_deps_install, artifacts, setup_repo, command_template, workspace_name) " +
+    "INSERT INTO job_templates (id, name, project_id, requires, min_vram_gb, min_disk_gb, python_deps, python_deps_install, artifacts, setup_repo, command_template, workspace_name) " +
     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
   ).run(
     id,
@@ -2056,11 +2056,11 @@ export function createJobTemplate(id, fields) {
 }
 
 export function getJobTemplate(id) {
-  return db.prepare("SELECT * FROM dv_job_templates WHERE id = ?").get(id);
+  return db.prepare("SELECT * FROM job_templates WHERE id = ?").get(id);
 }
 
 export function listJobTemplates() {
-  return db.prepare("SELECT * FROM dv_job_templates ORDER BY created_at").all();
+  return db.prepare("SELECT * FROM job_templates ORDER BY created_at").all();
 }
 
 export function updateJobTemplate(id, fields) {
@@ -2080,23 +2080,23 @@ export function updateJobTemplate(id, fields) {
   }
   if (sets.length === 0) return getJobTemplate(id);
   values.push(id);
-  db.prepare('UPDATE dv_job_templates SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  db.prepare('UPDATE job_templates SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
   return getJobTemplate(id);
 }
 
 export function deleteJobTemplate(id) {
-  return db.prepare("DELETE FROM dv_job_templates WHERE id = ?").run(id);
+  return db.prepare("DELETE FROM job_templates WHERE id = ?").run(id);
 }
 
 // -- Drone Diagnostics --
 
 export function updateDroneDiagnostics(agentId, diagnostics) {
   var json = typeof diagnostics === 'string' ? diagnostics : JSON.stringify(diagnostics);
-  db.prepare("UPDATE dv_agents SET system_diagnostics = ? WHERE id = ?").run(json, agentId);
+  db.prepare("UPDATE agents SET system_diagnostics = ? WHERE id = ?").run(json, agentId);
 }
 
 export function getDroneDiagnostics(agentId) {
-  var row = db.prepare("SELECT system_diagnostics FROM dv_agents WHERE id = ?").get(agentId);
+  var row = db.prepare("SELECT system_diagnostics FROM agents WHERE id = ?").get(agentId);
   if (!row) return null;
   try { return JSON.parse(row.system_diagnostics || '{}'); } catch (e) { return {}; }
 }
@@ -2286,19 +2286,19 @@ export function checkDroneCompatibility(droneId) {
 // -- Shared Concepts --
 
 export function createConcept(name, type, description, data, createdBy) {
-  var r = stmt('dvCreateConcept', `INSERT INTO dv_concepts (name, type, description, data, created_by)
+  var r = stmt('dvCreateConcept', `INSERT INTO concepts (name, type, description, data, created_by)
     VALUES (?, ?, ?, ?, ?)`).run(name, type || 'custom', description || '', JSON.stringify(data || {}), createdBy || '');
   return r.lastInsertRowid;
 }
 
 export function getConcept(id) {
-  return stmt('dvGetConcept', 'SELECT * FROM dv_concepts WHERE id = ?').get(id);
+  return stmt('dvGetConcept', 'SELECT * FROM concepts WHERE id = ?').get(id);
 }
 
 export function listConcepts(filters) {
   var where = []; var params = [];
   if (filters && filters.type) { where.push('type = ?'); params.push(filters.type); }
-  var sql = 'SELECT * FROM dv_concepts' + (where.length ? ' WHERE ' + where.join(' AND ') : '') + ' ORDER BY updated_at DESC';
+  var sql = 'SELECT * FROM concepts' + (where.length ? ' WHERE ' + where.join(' AND ') : '') + ' ORDER BY updated_at DESC';
   if (filters && filters.limit) { sql += ' LIMIT ?'; params.push(filters.limit); }
   return stmt('dvListConcepts_' + where.join('_') + (filters && filters.limit || ''), sql).all(...params);
 }
@@ -2313,31 +2313,31 @@ export function updateConcept(id, fields) {
   sets.push("version = version + 1");
   sets.push("updated_at = datetime('now')");
   params.push(id);
-  db.prepare('UPDATE dv_concepts SET ' + sets.join(', ') + ' WHERE id = ?').run(...params);
+  db.prepare('UPDATE concepts SET ' + sets.join(', ') + ' WHERE id = ?').run(...params);
 }
 
 export function deleteConcept(id) {
-  db.prepare('DELETE FROM dv_concepts WHERE id = ?').run(id);
+  db.prepare('DELETE FROM concepts WHERE id = ?').run(id);
 }
 
 export function linkConceptToProject(projectId, conceptId, linkedBy) {
-  stmt('dvLinkConcept', `INSERT OR IGNORE INTO dv_project_concepts (project_id, concept_id, linked_by)
+  stmt('dvLinkConcept', `INSERT OR IGNORE INTO project_concepts (project_id, concept_id, linked_by)
     VALUES (?, ?, ?)`).run(projectId, conceptId, linkedBy || '');
 }
 
 export function unlinkConceptFromProject(projectId, conceptId) {
-  stmt('dvUnlinkConcept', 'DELETE FROM dv_project_concepts WHERE project_id = ? AND concept_id = ?').run(projectId, conceptId);
+  stmt('dvUnlinkConcept', 'DELETE FROM project_concepts WHERE project_id = ? AND concept_id = ?').run(projectId, conceptId);
 }
 
 export function getProjectConcepts(projectId) {
   return stmt('dvGetProjectConcepts', `SELECT c.*, pc.linked_at, pc.linked_by
-    FROM dv_concepts c JOIN dv_project_concepts pc ON c.id = pc.concept_id
+    FROM concepts c JOIN project_concepts pc ON c.id = pc.concept_id
     WHERE pc.project_id = ? ORDER BY c.name`).all(projectId);
 }
 
 export function getConceptProjects(conceptId) {
   return stmt('dvGetConceptProjects', `SELECT p.*, pc.linked_at, pc.linked_by
-    FROM dv_projects p JOIN dv_project_concepts pc ON p.id = pc.project_id
+    FROM projects p JOIN project_concepts pc ON p.id = pc.project_id
     WHERE pc.concept_id = ? ORDER BY p.name`).all(conceptId);
 }
 
@@ -2350,13 +2350,13 @@ export { GATED_ACTIONS };
 
 export function createApproval(actionType, requestedBy, title, payload, projectId, riskTier, requiredApprovals) {
   var result = stmt('dvCreateApproval2',
-    "INSERT INTO dv_approvals (action_type, requested_by, title, payload, project_id, risk_tier, required_approvals) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
+    "INSERT INTO approvals (action_type, requested_by, title, payload, project_id, risk_tier, required_approvals) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
   ).get(actionType, requestedBy, title || '', typeof payload === 'string' ? payload : JSON.stringify(payload || {}), projectId || 'mycelium', riskTier || 'medium', requiredApprovals || 1);
   return result.id;
 }
 
 export function getApproval(id) {
-  return stmt('dvGetApproval', "SELECT * FROM dv_approvals WHERE id = ?").get(id);
+  return stmt('dvGetApproval', "SELECT * FROM approvals WHERE id = ?").get(id);
 }
 
 export function listApprovals(filters) {
@@ -2367,65 +2367,65 @@ export function listApprovals(filters) {
   if (filters.project_id) { where.push('project_id = ?'); params.push(filters.project_id); }
   var limit = Math.min(filters.limit || 50, 500);
   params.push(limit);
-  return db.prepare('SELECT * FROM dv_approvals WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
+  return db.prepare('SELECT * FROM approvals WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
 }
 
 export function decideApproval(id, status, decidedBy, reason) {
   db.prepare(
-    "UPDATE dv_approvals SET status = ?, decided_by = ?, decided_at = datetime('now'), reason = ?, updated_at = datetime('now') WHERE id = ?"
+    "UPDATE approvals SET status = ?, decided_by = ?, decided_at = datetime('now'), reason = ?, updated_at = datetime('now') WHERE id = ?"
   ).run(status, decidedBy, reason || '', id);
 }
 
 export function markApprovalExecuted(id) {
-  db.prepare("UPDATE dv_approvals SET status = 'executed', executed_at = datetime('now'), updated_at = datetime('now') WHERE id = ?").run(id);
+  db.prepare("UPDATE approvals SET status = 'executed', executed_at = datetime('now'), updated_at = datetime('now') WHERE id = ?").run(id);
 }
 
 export function countPendingApprovals() {
-  return stmt('dvCountApprovals', "SELECT COUNT(*) as count FROM dv_approvals WHERE status = 'pending'").get();
+  return stmt('dvCountApprovals', "SELECT COUNT(*) as count FROM approvals WHERE status = 'pending'").get();
 }
 
 export function listPendingApprovalsByAgent(agentId) {
-  return db.prepare("SELECT * FROM dv_approvals WHERE requested_by = ? AND status IN ('pending', 'approved') ORDER BY created_at DESC").all(agentId);
+  return db.prepare("SELECT * FROM approvals WHERE requested_by = ? AND status IN ('pending', 'approved') ORDER BY created_at DESC").all(agentId);
 }
 
 // -- Approval Votes --
 
 export function castApprovalVote(approvalId, voter, vote, notes) {
-  stmt('dvCastVote', `INSERT INTO dv_approval_votes (approval_id, voter, vote, notes)
+  stmt('dvCastVote', `INSERT INTO approval_votes (approval_id, voter, vote, notes)
     VALUES (?, ?, ?, ?)
     ON CONFLICT(approval_id, voter) DO UPDATE SET vote = excluded.vote, notes = excluded.notes, created_at = datetime('now')`
   ).run(approvalId, voter, vote || 'approve', notes || '');
 }
 
 export function getApprovalVotes(approvalId) {
-  return stmt('dvGetVotes', 'SELECT * FROM dv_approval_votes WHERE approval_id = ? ORDER BY created_at').all(approvalId);
+  return stmt('dvGetVotes', 'SELECT * FROM approval_votes WHERE approval_id = ? ORDER BY created_at').all(approvalId);
 }
 
 export function countApprovalVotes(approvalId) {
   var row = db.prepare(
-    "SELECT SUM(CASE WHEN vote = 'approve' THEN 1 ELSE 0 END) as approves, SUM(CASE WHEN vote = 'deny' THEN 1 ELSE 0 END) as denies FROM dv_approval_votes WHERE approval_id = ?"
+    "SELECT SUM(CASE WHEN vote = 'approve' THEN 1 ELSE 0 END) as approves, SUM(CASE WHEN vote = 'deny' THEN 1 ELSE 0 END) as denies FROM approval_votes WHERE approval_id = ?"
   ).get(approvalId);
   return { approves: row.approves || 0, denies: row.denies || 0 };
 }
 
 export function getAdminOps() {
   var pendingRequests = db.prepare(
-    "SELECT * FROM dv_messages WHERE msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC LIMIT 50"
+    "SELECT * FROM messages WHERE msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC LIMIT 50"
   ).all();
   var unassignedTasks = db.prepare(
-    "SELECT * FROM dv_tasks WHERE assignee IS NULL AND status IN ('open', 'in_progress') ORDER BY updated_at DESC LIMIT 50"
+    "SELECT * FROM tasks WHERE assignee IS NULL AND status IN ('open', 'in_progress') ORDER BY updated_at DESC LIMIT 50"
   ).all();
   var unassignedBugs = db.prepare(
-    "SELECT * FROM dv_bugs WHERE assignee IS NULL AND status = 'open' ORDER BY created_at DESC LIMIT 50"
+    "SELECT * FROM bugs WHERE assignee IS NULL AND status = 'open' ORDER BY created_at DESC LIMIT 50"
   ).all();
   var failedDroneJobs = db.prepare(
-    "SELECT * FROM dv_drone_jobs WHERE status = 'failed' ORDER BY completed_at DESC LIMIT 50"
+    "SELECT * FROM drone_jobs WHERE status = 'failed' ORDER BY completed_at DESC LIMIT 50"
   ).all();
   var pendingApprovals = db.prepare(
-    "SELECT * FROM dv_approvals WHERE status = 'pending' ORDER BY created_at DESC LIMIT 50"
+    "SELECT * FROM approvals WHERE status = 'pending' ORDER BY created_at DESC LIMIT 50"
   ).all();
   var staleRequests = db.prepare(
-    "SELECT * FROM dv_messages WHERE msg_type = 'request' AND status IN ('pending', 'sent') AND created_at < datetime('now', '-1 day') ORDER BY created_at ASC LIMIT 50"
+    "SELECT * FROM messages WHERE msg_type = 'request' AND status IN ('pending', 'sent') AND created_at < datetime('now', '-1 day') ORDER BY created_at ASC LIMIT 50"
   ).all();
   return {
     pending_requests: pendingRequests,
@@ -2441,11 +2441,11 @@ export function getAdminOps() {
 export function resolveStaleRequests(hoursOld) {
   var hours = hoursOld || 72;
   var stale = db.prepare(
-    "SELECT id FROM dv_messages WHERE msg_type = 'request' AND status IN ('pending', 'sent') AND created_at < datetime('now', '-' || ? || ' hours')"
+    "SELECT id FROM messages WHERE msg_type = 'request' AND status IN ('pending', 'sent') AND created_at < datetime('now', '-' || ? || ' hours')"
   ).all(hours);
   for (var req of stale) {
     db.prepare(
-      "UPDATE dv_messages SET status = 'resolved', resolved_at = datetime('now'), resolved_by = 'system', content = content || '\n\n[Auto-resolved: request was pending for over ' || ? || ' hours]' WHERE id = ?"
+      "UPDATE messages SET status = 'resolved', resolved_at = datetime('now'), resolved_by = 'system', content = content || '\n\n[Auto-resolved: request was pending for over ' || ? || ' hours]' WHERE id = ?"
     ).run(hours, req.id);
   }
   return stale.length;
@@ -2464,7 +2464,7 @@ export function getOverview(userId) {
   var projects = listProjects();
   var approvalQueue = listTasksNeedingApproval();
   var pendingRequests = db.prepare(
-    "SELECT * FROM dv_messages WHERE msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC LIMIT 20"
+    "SELECT * FROM messages WHERE msg_type = 'request' AND status IN ('pending', 'sent') ORDER BY created_at DESC LIMIT 20"
   ).all();
   var assets = listAssets({ limit: 50 });
   var bugs = listBugs({ limit: 50 });
@@ -2532,7 +2532,7 @@ function timeSince(dateStr) {
 export function getSlimOverview() {
   // Agent statuses — compact
   var agents = db.prepare(
-    "SELECT id, status, working_on, last_heartbeat FROM dv_agents ORDER BY created_at"
+    "SELECT id, status, working_on, last_heartbeat FROM agents ORDER BY created_at"
   ).all().map(function (a) {
     var hb = a.last_heartbeat ? timeSince(a.last_heartbeat) : 'never';
     return { id: a.id, status: a.status, working_on: a.working_on || '', heartbeat: hb };
@@ -2540,14 +2540,14 @@ export function getSlimOverview() {
 
   // Counts
   var counts = {
-    tasks_open: db.prepare("SELECT COUNT(*) as c FROM dv_tasks WHERE status = 'open'").get().c,
-    tasks_in_progress: db.prepare("SELECT COUNT(*) as c FROM dv_tasks WHERE status = 'in_progress'").get().c,
-    bugs_open: db.prepare("SELECT COUNT(*) as c FROM dv_bugs WHERE status = 'open'").get().c,
-    plans_active: db.prepare("SELECT COUNT(*) as c FROM dv_plans WHERE status = 'active'").get().c,
-    requests_pending: db.prepare("SELECT COUNT(*) as c FROM dv_messages WHERE msg_type = 'request' AND status IN ('sent', 'pending')").get().c,
-    approvals_pending: db.prepare("SELECT COUNT(*) as c FROM dv_approvals WHERE status = 'pending'").get().c,
-    drones_online: db.prepare("SELECT COUNT(*) as c FROM dv_agents WHERE agent_type = 'drone' AND status = 'online'").get().c,
-    drone_jobs_pending: db.prepare("SELECT COUNT(*) as c FROM dv_drone_jobs WHERE status = 'pending'").get().c
+    tasks_open: db.prepare("SELECT COUNT(*) as c FROM tasks WHERE status = 'open'").get().c,
+    tasks_in_progress: db.prepare("SELECT COUNT(*) as c FROM tasks WHERE status = 'in_progress'").get().c,
+    bugs_open: db.prepare("SELECT COUNT(*) as c FROM bugs WHERE status = 'open'").get().c,
+    plans_active: db.prepare("SELECT COUNT(*) as c FROM plans WHERE status = 'active'").get().c,
+    requests_pending: db.prepare("SELECT COUNT(*) as c FROM messages WHERE msg_type = 'request' AND status IN ('sent', 'pending')").get().c,
+    approvals_pending: db.prepare("SELECT COUNT(*) as c FROM approvals WHERE status = 'pending'").get().c,
+    drones_online: db.prepare("SELECT COUNT(*) as c FROM agents WHERE agent_type = 'drone' AND status = 'online'").get().c,
+    drone_jobs_pending: db.prepare("SELECT COUNT(*) as c FROM drone_jobs WHERE status = 'pending'").get().c
   };
 
   // Attention array — server-side triage
@@ -2555,7 +2555,7 @@ export function getSlimOverview() {
 
   // Stale requests (>1h unresolved)
   var staleRequests = db.prepare(
-    "SELECT id, from_agent, content, created_at FROM dv_messages WHERE msg_type = 'request' AND status IN ('sent', 'pending') AND created_at < datetime('now', '-1 hour') ORDER BY created_at ASC LIMIT 5"
+    "SELECT id, from_agent, content, created_at FROM messages WHERE msg_type = 'request' AND status IN ('sent', 'pending') AND created_at < datetime('now', '-1 hour') ORDER BY created_at ASC LIMIT 5"
   ).all();
   for (var r of staleRequests) {
     attention.push({ type: 'stale_request', id: r.id, from: r.from_agent, title: r.content.slice(0, 80), action: 'respond', age: timeSince(r.created_at) });
@@ -2563,7 +2563,7 @@ export function getSlimOverview() {
 
   // Pending approvals
   var pendingApprovals = db.prepare(
-    "SELECT id, title, created_at FROM dv_approvals WHERE status = 'pending' ORDER BY created_at ASC LIMIT 5"
+    "SELECT id, title, created_at FROM approvals WHERE status = 'pending' ORDER BY created_at ASC LIMIT 5"
   ).all();
   for (var a of pendingApprovals) {
     attention.push({ type: 'pending_approval', id: a.id, title: a.title, action: 'approve_or_deny', age: timeSince(a.created_at) });
@@ -2571,7 +2571,7 @@ export function getSlimOverview() {
 
   // Stale tasks (in_progress >6h without update)
   var staleTasks = db.prepare(
-    "SELECT t.id, t.title, t.assignee, t.updated_at FROM dv_tasks t WHERE t.status = 'in_progress' AND t.updated_at < datetime('now', '-6 hours') ORDER BY t.updated_at ASC LIMIT 5"
+    "SELECT t.id, t.title, t.assignee, t.updated_at FROM tasks t WHERE t.status = 'in_progress' AND t.updated_at < datetime('now', '-6 hours') ORDER BY t.updated_at ASC LIMIT 5"
   ).all();
   for (var t of staleTasks) {
     attention.push({ type: 'stale_task', id: t.id, assignee: t.assignee, title: t.title, action: 'reassign_or_unblock', age: timeSince(t.updated_at) });
@@ -2579,7 +2579,7 @@ export function getSlimOverview() {
 
   // Unassigned bugs
   var unassignedBugs = db.prepare(
-    "SELECT id, title, severity, created_at FROM dv_bugs WHERE status = 'open' AND (assignee IS NULL OR assignee = '') ORDER BY CASE severity WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END, created_at ASC LIMIT 5"
+    "SELECT id, title, severity, created_at FROM bugs WHERE status = 'open' AND (assignee IS NULL OR assignee = '') ORDER BY CASE severity WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END, created_at ASC LIMIT 5"
   ).all();
   for (var b of unassignedBugs) {
     attention.push({ type: 'unassigned_bug', id: b.id, title: b.title, severity: b.severity, action: 'assign', age: timeSince(b.created_at) });
@@ -2587,7 +2587,7 @@ export function getSlimOverview() {
 
   // Recent activity — 5 one-liners
   var recentEvents = db.prepare(
-    "SELECT summary, created_at FROM dv_events ORDER BY created_at DESC LIMIT 5"
+    "SELECT summary, created_at FROM events ORDER BY created_at DESC LIMIT 5"
   ).all();
   var recent_activity = recentEvents.map(function (e) {
     return e.summary + ' (' + timeSince(e.created_at) + ')';
@@ -2601,66 +2601,66 @@ export function getSlimOverview() {
 export function getDB() { return db; }
 
 export function ensurePluginRecord(manifest) {
-  var existing = stmt('dvGetPlugin', 'SELECT * FROM dv_plugins WHERE name = ?').get(manifest.name);
+  var existing = stmt('dvGetPlugin', 'SELECT * FROM plugins WHERE name = ?').get(manifest.name);
   if (existing) {
-    stmt('dvUpdatePlugin', `UPDATE dv_plugins SET display_name = ?, description = ?, version = ?, author = ?, route_prefix = ?, mcp_tool_count = ?, updated_at = datetime('now')
+    stmt('dvUpdatePlugin', `UPDATE plugins SET display_name = ?, description = ?, version = ?, author = ?, route_prefix = ?, mcp_tool_count = ?, updated_at = datetime('now')
       WHERE name = ?`).run(manifest.displayName || '', manifest.description || '', manifest.version || '1.0.0', manifest.author || '', manifest.routePrefix || '', manifest.mcpToolCount || 0, manifest.name);
     return { ...existing, updated: true };
   }
-  stmt('dvInsertPlugin', `INSERT INTO dv_plugins (name, display_name, description, version, author, enabled, route_prefix, mcp_tool_count)
+  stmt('dvInsertPlugin', `INSERT INTO plugins (name, display_name, description, version, author, enabled, route_prefix, mcp_tool_count)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`).run(manifest.name, manifest.displayName || '', manifest.description || '', manifest.version || '1.0.0', manifest.author || '', 0, manifest.routePrefix || '', manifest.mcpToolCount || 0);
   return { name: manifest.name, created: true };
 }
 
 export function getPluginRecord(name) {
-  return stmt('dvGetPlugin', 'SELECT * FROM dv_plugins WHERE name = ?').get(name);
+  return stmt('dvGetPlugin', 'SELECT * FROM plugins WHERE name = ?').get(name);
 }
 
 export function listPluginRecords() {
-  return db.prepare('SELECT * FROM dv_plugins ORDER BY name').all();
+  return db.prepare('SELECT * FROM plugins ORDER BY name').all();
 }
 
 export function updatePluginEnabled(name, enabled) {
-  return db.prepare("UPDATE dv_plugins SET enabled = ?, updated_at = datetime('now') WHERE name = ?").run(enabled ? 1 : 0, name);
+  return db.prepare("UPDATE plugins SET enabled = ?, updated_at = datetime('now') WHERE name = ?").run(enabled ? 1 : 0, name);
 }
 
 export function getPluginMigrationVersion(pluginName) {
-  var row = db.prepare('SELECT MAX(version) as v FROM dv_plugin_migrations WHERE plugin_name = ?').get(pluginName);
+  var row = db.prepare('SELECT MAX(version) as v FROM plugin_migrations WHERE plugin_name = ?').get(pluginName);
   return row ? (row.v || 0) : 0;
 }
 
 export function recordPluginMigration(pluginName, version, description) {
-  db.prepare('INSERT INTO dv_plugin_migrations (plugin_name, version, description) VALUES (?, ?, ?)').run(pluginName, version, description || '');
+  db.prepare('INSERT INTO plugin_migrations (plugin_name, version, description) VALUES (?, ?, ?)').run(pluginName, version, description || '');
 }
 
 // ======== PLUGIN CONFIG ========
 
 export function getPluginConfig(pluginName) {
-  var rows = db.prepare('SELECT key, value, is_secret FROM dv_plugin_config WHERE plugin_name = ?').all(pluginName);
+  var rows = db.prepare('SELECT key, value, is_secret FROM plugin_config WHERE plugin_name = ?').all(pluginName);
   return rows;
 }
 
 export function getPluginConfigValue(pluginName, key) {
-  var row = db.prepare('SELECT value FROM dv_plugin_config WHERE plugin_name = ? AND key = ?').get(pluginName, key);
+  var row = db.prepare('SELECT value FROM plugin_config WHERE plugin_name = ? AND key = ?').get(pluginName, key);
   return row ? row.value : null;
 }
 
 export function setPluginConfig(pluginName, key, value, isSecret) {
   db.prepare(
-    `INSERT INTO dv_plugin_config (plugin_name, key, value, is_secret, updated_at) VALUES (?, ?, ?, ?, datetime('now'))
+    `INSERT INTO plugin_config (plugin_name, key, value, is_secret, updated_at) VALUES (?, ?, ?, ?, datetime('now'))
      ON CONFLICT(plugin_name, key) DO UPDATE SET value = excluded.value, is_secret = excluded.is_secret, updated_at = excluded.updated_at`
   ).run(pluginName, key, String(value), isSecret ? 1 : 0);
 }
 
 export function deletePluginConfig(pluginName, key) {
-  db.prepare('DELETE FROM dv_plugin_config WHERE plugin_name = ? AND key = ?').run(pluginName, key);
+  db.prepare('DELETE FROM plugin_config WHERE plugin_name = ? AND key = ?').run(pluginName, key);
 }
 
 // ======== AGENT SAVEPOINTS ========
 
 export function createSavepoint(agentId, data) {
   return db.prepare(
-    `INSERT INTO dv_agent_savepoints (agent_id, session_id, heartbeat_at, working_on, state_snapshot, messages_acked, context_versions, notes)
+    `INSERT INTO agent_savepoints (agent_id, session_id, heartbeat_at, working_on, state_snapshot, messages_acked, context_versions, notes)
      VALUES (?, ?, datetime('now'), ?, ?, ?, ?, ?)`
   ).run(
     agentId,
@@ -2675,20 +2675,20 @@ export function createSavepoint(agentId, data) {
 
 export function getLatestSavepoint(agentId) {
   return db.prepare(
-    'SELECT * FROM dv_agent_savepoints WHERE agent_id = ? ORDER BY heartbeat_at DESC LIMIT 1'
+    'SELECT * FROM agent_savepoints WHERE agent_id = ? ORDER BY heartbeat_at DESC LIMIT 1'
   ).get(agentId);
 }
 
 export function getSavepointHistory(agentId, limit) {
   return db.prepare(
-    'SELECT id, agent_id, session_id, heartbeat_at, working_on, notes, created_at FROM dv_agent_savepoints WHERE agent_id = ? ORDER BY heartbeat_at DESC LIMIT ?'
+    'SELECT id, agent_id, session_id, heartbeat_at, working_on, notes, created_at FROM agent_savepoints WHERE agent_id = ? ORDER BY heartbeat_at DESC LIMIT ?'
   ).all(agentId, limit || 10);
 }
 
 export function updateSavepointNotes(agentId, notes) {
   var latest = getLatestSavepoint(agentId);
   if (!latest) return null;
-  db.prepare('UPDATE dv_agent_savepoints SET notes = ? WHERE id = ?').run(notes, latest.id);
+  db.prepare('UPDATE agent_savepoints SET notes = ? WHERE id = ?').run(notes, latest.id);
   return latest.id;
 }
 
@@ -2707,37 +2707,37 @@ export function computeSavepointDiff(agentId) {
 
   // Messages the agent hasn't seen (not in acked list, sent after savepoint)
   var newMessages = db.prepare(
-    "SELECT * FROM dv_messages WHERE (to_agent = ? OR to_agent IS NULL) AND id NOT IN (SELECT value FROM json_each(?)) AND created_at > ? ORDER BY created_at ASC LIMIT 100"
+    "SELECT * FROM messages WHERE (to_agent = ? OR to_agent IS NULL) AND id NOT IN (SELECT value FROM json_each(?)) AND created_at > ? ORDER BY created_at ASC LIMIT 100"
   ).all(agentId, JSON.stringify(ackedIds), savepoint.heartbeat_at);
 
   // Tasks that changed since savepoint
   var tasksChanged = db.prepare(
-    "SELECT * FROM dv_tasks WHERE (assignee = ? OR assignee IS NULL) AND updated_at > ? ORDER BY updated_at DESC LIMIT 50"
+    "SELECT * FROM tasks WHERE (assignee = ? OR assignee IS NULL) AND updated_at > ? ORDER BY updated_at DESC LIMIT 50"
   ).all(agentId, savepoint.heartbeat_at);
 
   // Context keys that changed since savepoint
   var contextChanged = db.prepare(
-    "SELECT * FROM dv_context_keys WHERE updated_at > ? ORDER BY updated_at DESC LIMIT 50"
+    "SELECT * FROM context_keys WHERE updated_at > ? ORDER BY updated_at DESC LIMIT 50"
   ).all(savepoint.heartbeat_at);
 
   // Plans that changed since savepoint
   var plansChanged = db.prepare(
-    "SELECT p.* FROM dv_plans p WHERE p.updated_at > ? ORDER BY p.updated_at DESC LIMIT 20"
+    "SELECT p.* FROM plans p WHERE p.updated_at > ? ORDER BY p.updated_at DESC LIMIT 20"
   ).all(savepoint.heartbeat_at);
 
   // Bugs that changed since savepoint
   var bugsChanged = db.prepare(
-    "SELECT * FROM dv_bugs WHERE updated_at > ? ORDER BY updated_at DESC LIMIT 20"
+    "SELECT * FROM bugs WHERE updated_at > ? ORDER BY updated_at DESC LIMIT 20"
   ).all(savepoint.heartbeat_at);
 
   // Drone jobs that changed since savepoint
   var droneJobsChanged = db.prepare(
-    "SELECT * FROM dv_drone_jobs WHERE (started_at > ? OR completed_at > ? OR created_at > ?) ORDER BY created_at DESC LIMIT 20"
+    "SELECT * FROM drone_jobs WHERE (started_at > ? OR completed_at > ? OR created_at > ?) ORDER BY created_at DESC LIMIT 20"
   ).all(savepoint.heartbeat_at, savepoint.heartbeat_at, savepoint.heartbeat_at);
 
   // Events since savepoint
   var eventsSince = db.prepare(
-    "SELECT * FROM dv_events WHERE created_at > ? ORDER BY created_at DESC LIMIT 50"
+    "SELECT * FROM events WHERE created_at > ? ORDER BY created_at DESC LIMIT 50"
   ).all(savepoint.heartbeat_at);
 
   return {
@@ -2774,10 +2774,10 @@ export function pruneSavepoints(agentId, keepCount) {
   // Keep only the most recent N savepoints per agent
   var count = keepCount || 50;
   var cutoff = db.prepare(
-    'SELECT heartbeat_at FROM dv_agent_savepoints WHERE agent_id = ? ORDER BY heartbeat_at DESC LIMIT 1 OFFSET ?'
+    'SELECT heartbeat_at FROM agent_savepoints WHERE agent_id = ? ORDER BY heartbeat_at DESC LIMIT 1 OFFSET ?'
   ).get(agentId, count);
   if (cutoff) {
-    db.prepare('DELETE FROM dv_agent_savepoints WHERE agent_id = ? AND heartbeat_at < ?').run(agentId, cutoff.heartbeat_at);
+    db.prepare('DELETE FROM agent_savepoints WHERE agent_id = ? AND heartbeat_at < ?').run(agentId, cutoff.heartbeat_at);
   }
 }
 
@@ -2786,13 +2786,13 @@ export function pruneSavepoints(agentId, keepCount) {
 export function createFeedback(entityType, entityId, subject, rating, comment, submittedBy, agentId) {
   var r = Math.max(1, Math.min(5, parseInt(rating) || 3));
   var result = db.prepare(
-    'INSERT INTO dv_feedback (entity_type, entity_id, subject, rating, comment, submitted_by, agent_id) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
+    'INSERT INTO feedback (entity_type, entity_id, subject, rating, comment, submitted_by, agent_id) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
   ).get(entityType || 'general', entityId || '', subject || '', r, comment || '', submittedBy || 'operator', agentId || '');
   return result.id;
 }
 
 export function getFeedback(id) {
-  return db.prepare('SELECT * FROM dv_feedback WHERE id = ?').get(id);
+  return db.prepare('SELECT * FROM feedback WHERE id = ?').get(id);
 }
 
 export function listFeedback(filters) {
@@ -2805,29 +2805,29 @@ export function listFeedback(filters) {
   if (filters.min_rating) { where.push('rating >= ?'); params.push(parseInt(filters.min_rating)); }
   var limit = Math.min(filters.limit || 50, 500);
   var offset = filters.offset || 0;
-  var sql = 'SELECT * FROM dv_feedback WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?';
+  var sql = 'SELECT * FROM feedback WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?';
   params.push(limit, offset);
   return db.prepare(sql).all(...params);
 }
 
 export function deleteFeedback(id) {
-  db.prepare('DELETE FROM dv_feedback WHERE id = ?').run(id);
+  db.prepare('DELETE FROM feedback WHERE id = ?').run(id);
 }
 
 // -- Operator Inbox --
 
 export function createInboxItem(operatorId, type, entityType, entityId, title, summary, data, priority) {
   var result = db.prepare(
-    'INSERT INTO dv_operator_inbox (operator_id, type, entity_type, entity_id, title, summary, data, priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id'
+    'INSERT INTO operator_inbox (operator_id, type, entity_type, entity_id, title, summary, data, priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id'
   ).get(operatorId, type || 'message', entityType || '', entityId || '', title || '', summary || '', JSON.stringify(data || {}), priority || 'normal');
   return result.id;
 }
 
 export function createInboxItemForAllOperators(type, entityType, entityId, title, summary, data, priority) {
-  var ops = db.prepare("SELECT id FROM dv_operators WHERE status = 'active'").all();
+  var ops = db.prepare("SELECT id FROM operators WHERE status = 'active'").all();
   var ids = [];
   var insertStmt = db.prepare(
-    'INSERT INTO dv_operator_inbox (operator_id, type, entity_type, entity_id, title, summary, data, priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id'
+    'INSERT INTO operator_inbox (operator_id, type, entity_type, entity_id, title, summary, data, priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id'
   );
   for (var op of ops) {
     var row = insertStmt.get(op.id, type || 'message', entityType || '', entityId || '', title || '', summary || '', JSON.stringify(data || {}), priority || 'normal');
@@ -2837,7 +2837,7 @@ export function createInboxItemForAllOperators(type, entityType, entityId, title
 }
 
 export function getInboxItem(id) {
-  return db.prepare('SELECT * FROM dv_operator_inbox WHERE id = ?').get(id);
+  return db.prepare('SELECT * FROM operator_inbox WHERE id = ?').get(id);
 }
 
 export function listInboxItems(filters) {
@@ -2850,51 +2850,51 @@ export function listInboxItems(filters) {
   if (filters.entity_type) { where.push('entity_type = ?'); params.push(filters.entity_type); }
   var limit = Math.min(filters.limit || 50, 200);
   var offset = filters.offset || 0;
-  var sql = 'SELECT * FROM dv_operator_inbox WHERE ' + where.join(' AND ') + ' ORDER BY CASE priority WHEN \'urgent\' THEN 0 WHEN \'normal\' THEN 1 ELSE 2 END, created_at DESC LIMIT ? OFFSET ?';
+  var sql = 'SELECT * FROM operator_inbox WHERE ' + where.join(' AND ') + ' ORDER BY CASE priority WHEN \'urgent\' THEN 0 WHEN \'normal\' THEN 1 ELSE 2 END, created_at DESC LIMIT ? OFFSET ?';
   params.push(limit, offset);
   return db.prepare(sql).all(...params);
 }
 
 export function markInboxItemRead(id) {
-  db.prepare("UPDATE dv_operator_inbox SET status = 'read', read_at = datetime('now') WHERE id = ? AND status = 'unread'").run(id);
+  db.prepare("UPDATE operator_inbox SET status = 'read', read_at = datetime('now') WHERE id = ? AND status = 'unread'").run(id);
 }
 
 export function markInboxItemActioned(id) {
-  db.prepare("UPDATE dv_operator_inbox SET status = 'actioned', read_at = COALESCE(read_at, datetime('now')) WHERE id = ?").run(id);
+  db.prepare("UPDATE operator_inbox SET status = 'actioned', read_at = COALESCE(read_at, datetime('now')) WHERE id = ?").run(id);
 }
 
 export function dismissInboxItem(id) {
-  db.prepare("UPDATE dv_operator_inbox SET status = 'dismissed' WHERE id = ?").run(id);
+  db.prepare("UPDATE operator_inbox SET status = 'dismissed' WHERE id = ?").run(id);
 }
 
 export function countUnreadInbox(operatorId) {
-  var row = db.prepare("SELECT COUNT(*) as c FROM dv_operator_inbox WHERE operator_id = ? AND status = 'unread'").get(operatorId);
+  var row = db.prepare("SELECT COUNT(*) as c FROM operator_inbox WHERE operator_id = ? AND status = 'unread'").get(operatorId);
   return row ? row.c : 0;
 }
 
 export function countAllUnreadInbox() {
-  return db.prepare("SELECT operator_id, COUNT(*) as count FROM dv_operator_inbox WHERE status = 'unread' GROUP BY operator_id").all();
+  return db.prepare("SELECT operator_id, COUNT(*) as count FROM operator_inbox WHERE status = 'unread' GROUP BY operator_id").all();
 }
 
 // ======== RUNNER SPAWNS (dynamic agent swarm) ========
 
 export function createRunnerSpawn(tier, model, cwd, maxTurns, title, workContext, requestedBy) {
   var result = db.prepare(
-    'INSERT INTO dv_runner_spawns (tier, model, cwd, max_turns, title, work_context, requested_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
+    'INSERT INTO runner_spawns (tier, model, cwd, max_turns, title, work_context, requested_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
   ).get(tier || 'agent', model || '', cwd || '', maxTurns || 50, title || '', JSON.stringify(workContext || {}), requestedBy || '');
   return result.id;
 }
 
 export function getRunnerSpawn(id) {
-  var row = db.prepare('SELECT * FROM dv_runner_spawns WHERE id = ?').get(id);
+  var row = db.prepare('SELECT * FROM runner_spawns WHERE id = ?').get(id);
   if (row) { try { row.work_context = JSON.parse(row.work_context); } catch (e) { row.work_context = {}; } }
   return row;
 }
 
 export function listRunnerSpawns(status) {
   var rows = status
-    ? db.prepare("SELECT * FROM dv_runner_spawns WHERE status = ? ORDER BY created_at DESC LIMIT 100").all(status)
-    : db.prepare("SELECT * FROM dv_runner_spawns ORDER BY created_at DESC LIMIT 100").all();
+    ? db.prepare("SELECT * FROM runner_spawns WHERE status = ? ORDER BY created_at DESC LIMIT 100").all(status)
+    : db.prepare("SELECT * FROM runner_spawns ORDER BY created_at DESC LIMIT 100").all();
   return rows.map(function (r) {
     try { r.work_context = JSON.parse(r.work_context); } catch (e) { r.work_context = {}; }
     return r;
@@ -2902,39 +2902,39 @@ export function listRunnerSpawns(status) {
 }
 
 export function claimRunnerSpawn(id, runnerId) {
-  db.prepare("UPDATE dv_runner_spawns SET status = 'claimed', runner_id = ?, claimed_at = datetime('now') WHERE id = ? AND status = 'pending'").run(runnerId || 'runner', id);
+  db.prepare("UPDATE runner_spawns SET status = 'claimed', runner_id = ?, claimed_at = datetime('now') WHERE id = ? AND status = 'pending'").run(runnerId || 'runner', id);
 }
 
 export function doneRunnerSpawn(id, result, status) {
-  db.prepare("UPDATE dv_runner_spawns SET status = ?, result = ?, done_at = datetime('now') WHERE id = ?").run(status || 'done', result || '', id);
+  db.prepare("UPDATE runner_spawns SET status = ?, result = ?, done_at = datetime('now') WHERE id = ?").run(status || 'done', result || '', id);
 }
 
 export function getFeedbackSummary() {
-  var total = db.prepare('SELECT COUNT(*) as count FROM dv_feedback').get().count;
-  var avgRating = db.prepare('SELECT ROUND(AVG(rating), 2) as avg FROM dv_feedback').get().avg || 0;
+  var total = db.prepare('SELECT COUNT(*) as count FROM feedback').get().count;
+  var avgRating = db.prepare('SELECT ROUND(AVG(rating), 2) as avg FROM feedback').get().avg || 0;
   var byAgent = db.prepare(
-    "SELECT agent_id, COUNT(*) as count, ROUND(AVG(rating), 2) as avg_rating FROM dv_feedback WHERE agent_id != '' GROUP BY agent_id ORDER BY count DESC LIMIT 20"
+    "SELECT agent_id, COUNT(*) as count, ROUND(AVG(rating), 2) as avg_rating FROM feedback WHERE agent_id != '' GROUP BY agent_id ORDER BY count DESC LIMIT 20"
   ).all();
   var byType = db.prepare(
-    'SELECT entity_type, COUNT(*) as count, ROUND(AVG(rating), 2) as avg_rating FROM dv_feedback GROUP BY entity_type ORDER BY count DESC'
+    'SELECT entity_type, COUNT(*) as count, ROUND(AVG(rating), 2) as avg_rating FROM feedback GROUP BY entity_type ORDER BY count DESC'
   ).all();
   var ratingDist = db.prepare(
-    'SELECT rating, COUNT(*) as count FROM dv_feedback GROUP BY rating ORDER BY rating'
+    'SELECT rating, COUNT(*) as count FROM feedback GROUP BY rating ORDER BY rating'
   ).all();
-  var recent = db.prepare('SELECT * FROM dv_feedback ORDER BY created_at DESC LIMIT 5').all();
+  var recent = db.prepare('SELECT * FROM feedback ORDER BY created_at DESC LIMIT 5').all();
   return { total, avg_rating: avgRating, by_agent: byAgent, by_type: byType, rating_dist: ratingDist, recent };
 }
 
 // ---- Support Tickets ----
 export function createSupportTicket(data) {
   var result = db.prepare(
-    'INSERT INTO dv_support_tickets (instance_id, subject, description, category, priority, reporter_email, reporter_name) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING *'
+    'INSERT INTO support_tickets (instance_id, subject, description, category, priority, reporter_email, reporter_name) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING *'
   ).get(data.instance_id || '', data.subject, data.description || '', data.category || 'general', data.priority || 'normal', data.reporter_email || '', data.reporter_name || '');
   return result;
 }
 
 export function getSupportTicket(id) {
-  return db.prepare('SELECT * FROM dv_support_tickets WHERE id = ?').get(id);
+  return db.prepare('SELECT * FROM support_tickets WHERE id = ?').get(id);
 }
 
 export function listSupportTickets(filters) {
@@ -2945,7 +2945,7 @@ export function listSupportTickets(filters) {
   if (filters && filters.priority) { where.push('priority = ?'); params.push(filters.priority); }
   var limit = parseInt((filters && filters.limit) || 100) || 100;
   params.push(limit);
-  var sql = 'SELECT * FROM dv_support_tickets' + (where.length ? ' WHERE ' + where.join(' AND ') : '') + ' ORDER BY created_at DESC LIMIT ?';
+  var sql = 'SELECT * FROM support_tickets' + (where.length ? ' WHERE ' + where.join(' AND ') : '') + ' ORDER BY created_at DESC LIMIT ?';
   return db.prepare(sql).all.apply(db.prepare(sql), params);
 }
 
@@ -2959,12 +2959,12 @@ export function updateSupportTicket(id, updates) {
   if (sets.length === 0) return getSupportTicket(id);
   sets.push("updated_at = datetime('now')");
   params.push(id);
-  db.prepare('UPDATE dv_support_tickets SET ' + sets.join(', ') + ' WHERE id = ?').run.apply(db.prepare('UPDATE dv_support_tickets SET ' + sets.join(', ') + ' WHERE id = ?'), params);
+  db.prepare('UPDATE support_tickets SET ' + sets.join(', ') + ' WHERE id = ?').run.apply(db.prepare('UPDATE support_tickets SET ' + sets.join(', ') + ' WHERE id = ?'), params);
   return getSupportTicket(id);
 }
 
 export function deleteSupportTicket(id) {
-  return db.prepare('DELETE FROM dv_support_tickets WHERE id = ?').run(id);
+  return db.prepare('DELETE FROM support_tickets WHERE id = ?').run(id);
 }
 
 // =============== NODE PROFILES — Stand Up Calibration ===============
@@ -2990,7 +2990,7 @@ function parseProfileRow(row) {
 export function createNodeProfile(id, data) {
   var d = data || {};
   db.prepare(
-    'INSERT INTO dv_node_profiles (id, node_type, layer, parent_id, rules, required_concepts, mcp_config, tool_whitelist, repo_list, md_checkpoints, md_blocklist) ' +
+    'INSERT INTO node_profiles (id, node_type, layer, parent_id, rules, required_concepts, mcp_config, tool_whitelist, repo_list, md_checkpoints, md_blocklist) ' +
     'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
   ).run(
     id,
@@ -3009,7 +3009,7 @@ export function createNodeProfile(id, data) {
 }
 
 export function getNodeProfile(id) {
-  var row = db.prepare('SELECT * FROM dv_node_profiles WHERE id = ?').get(id);
+  var row = db.prepare('SELECT * FROM node_profiles WHERE id = ?').get(id);
   return parseProfileRow(row);
 }
 
@@ -3018,7 +3018,7 @@ export function listNodeProfiles(filter) {
   var params = [];
   if (filter && filter.node_type) { where.push('node_type = ?'); params.push(filter.node_type); }
   if (filter && filter.layer) { where.push('layer = ?'); params.push(filter.layer); }
-  var sql = 'SELECT * FROM dv_node_profiles' + (where.length ? ' WHERE ' + where.join(' AND ') : '') + ' ORDER BY layer, node_type, id';
+  var sql = 'SELECT * FROM node_profiles' + (where.length ? ' WHERE ' + where.join(' AND ') : '') + ' ORDER BY layer, node_type, id';
   var rows = db.prepare(sql).all.apply(db.prepare(sql), params);
   return rows.map(parseProfileRow);
 }
@@ -3038,8 +3038,8 @@ export function updateNodeProfile(id, data) {
   }
   if (values.length === 0) return existing;
   values.push(id);
-  db.prepare('UPDATE dv_node_profiles SET ' + sets.join(', ') + ' WHERE id = ?').run.apply(
-    db.prepare('UPDATE dv_node_profiles SET ' + sets.join(', ') + ' WHERE id = ?'), values
+  db.prepare('UPDATE node_profiles SET ' + sets.join(', ') + ' WHERE id = ?').run.apply(
+    db.prepare('UPDATE node_profiles SET ' + sets.join(', ') + ' WHERE id = ?'), values
   );
   return getNodeProfile(id);
 }
@@ -3048,7 +3048,7 @@ export function deleteNodeProfile(id) {
   var existing = getNodeProfile(id);
   if (!existing) return null;
   if (existing.layer === 'platform') return null;
-  db.prepare('DELETE FROM dv_node_profiles WHERE id = ?').run(id);
+  db.prepare('DELETE FROM node_profiles WHERE id = ?').run(id);
   return existing;
 }
 
@@ -3127,12 +3127,12 @@ export function resolveProfileChain(agentId) {
 
 export function seedPlatformProfiles() {
   // Only seed if default-agent doesn't exist yet
-  var existing = db.prepare('SELECT id FROM dv_node_profiles WHERE id = ?').get('default-agent');
+  var existing = db.prepare('SELECT id FROM node_profiles WHERE id = ?').get('default-agent');
   if (existing) return;
 
   // default-agent: base rules for all agents
   db.prepare(
-    'INSERT INTO dv_node_profiles (id, node_type, layer, parent_id, rules, required_concepts, mcp_config, tool_whitelist, repo_list, md_checkpoints, md_blocklist) ' +
+    'INSERT INTO node_profiles (id, node_type, layer, parent_id, rules, required_concepts, mcp_config, tool_whitelist, repo_list, md_checkpoints, md_blocklist) ' +
     'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
   ).run(
     'default-agent',
@@ -3159,7 +3159,7 @@ export function seedPlatformProfiles() {
 
   // default-drone: minimal rules for GPU/CPU workers
   db.prepare(
-    'INSERT INTO dv_node_profiles (id, node_type, layer, parent_id, rules, required_concepts, mcp_config, tool_whitelist, repo_list, md_checkpoints, md_blocklist) ' +
+    'INSERT INTO node_profiles (id, node_type, layer, parent_id, rules, required_concepts, mcp_config, tool_whitelist, repo_list, md_checkpoints, md_blocklist) ' +
     'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
   ).run(
     'default-drone',
@@ -3180,7 +3180,7 @@ export function seedPlatformProfiles() {
 
   // default-admin: inherits agent rules + coordination emphasis
   db.prepare(
-    'INSERT INTO dv_node_profiles (id, node_type, layer, parent_id, rules, required_concepts, mcp_config, tool_whitelist, repo_list, md_checkpoints, md_blocklist) ' +
+    'INSERT INTO node_profiles (id, node_type, layer, parent_id, rules, required_concepts, mcp_config, tool_whitelist, repo_list, md_checkpoints, md_blocklist) ' +
     'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
   ).run(
     'default-admin',
@@ -3286,20 +3286,20 @@ export function buildCalibrationBlock(agentId) {
 
 export function listTeamSettings(section) {
   if (section) {
-    return db.prepare('SELECT * FROM dv_team_settings WHERE section = ? ORDER BY key').all(section);
+    return db.prepare('SELECT * FROM team_settings WHERE section = ? ORDER BY key').all(section);
   }
-  return db.prepare('SELECT * FROM dv_team_settings ORDER BY section, key').all();
+  return db.prepare('SELECT * FROM team_settings ORDER BY section, key').all();
 }
 
 export function getTeamSetting(section, key) {
-  return db.prepare('SELECT * FROM dv_team_settings WHERE section = ? AND key = ?').get(section, key);
+  return db.prepare('SELECT * FROM team_settings WHERE section = ? AND key = ?').get(section, key);
 }
 
 export function upsertTeamSetting(section, key, value, updatedBy) {
   var now = new Date().toISOString();
   var valueStr = typeof value === 'object' ? JSON.stringify(value) : String(value);
   db.prepare(
-    "INSERT INTO dv_team_settings (section, key, value, updated_at, updated_by) VALUES (?, ?, ?, ?, ?) " +
+    "INSERT INTO team_settings (section, key, value, updated_at, updated_by) VALUES (?, ?, ?, ?, ?) " +
     "ON CONFLICT(section, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at, updated_by = excluded.updated_by"
   ).run(section, key, valueStr, now, updatedBy || '');
   syncTeamSettingsToProfile();
@@ -3307,7 +3307,7 @@ export function upsertTeamSetting(section, key, value, updatedBy) {
 }
 
 export function deleteTeamSetting(section, key) {
-  var result = db.prepare('DELETE FROM dv_team_settings WHERE section = ? AND key = ?').run(section, key);
+  var result = db.prepare('DELETE FROM team_settings WHERE section = ? AND key = ?').run(section, key);
   syncTeamSettingsToProfile();
   return result;
 }
@@ -3410,7 +3410,7 @@ export function syncTeamSettingsToProfile() {
 
 export function createInstance(data) {
   var result = db.prepare(
-    'INSERT INTO dv_customer_instances (org_id, railway_project_id, railway_service_id, railway_environment_id, domain, cloudflare_record_id, status, admin_username, customer_email) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *'
+    'INSERT INTO customer_instances (org_id, railway_project_id, railway_service_id, railway_environment_id, domain, cloudflare_record_id, status, admin_username, customer_email) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *'
   ).get(
     data.org_id,
     data.railway_project_id || null,
@@ -3426,15 +3426,15 @@ export function createInstance(data) {
 }
 
 export function getInstance(id) {
-  return db.prepare('SELECT * FROM dv_customer_instances WHERE id = ?').get(id);
+  return db.prepare('SELECT * FROM customer_instances WHERE id = ?').get(id);
 }
 
 export function getInstanceByOrg(orgId) {
-  return db.prepare('SELECT * FROM dv_customer_instances WHERE org_id = ? ORDER BY created_at DESC LIMIT 1').get(orgId);
+  return db.prepare('SELECT * FROM customer_instances WHERE org_id = ? ORDER BY created_at DESC LIMIT 1').get(orgId);
 }
 
 export function getInstanceByDomain(domain) {
-  return db.prepare('SELECT * FROM dv_customer_instances WHERE domain = ?').get(domain);
+  return db.prepare('SELECT * FROM customer_instances WHERE domain = ?').get(domain);
 }
 
 export function listInstances(filters) {
@@ -3442,7 +3442,7 @@ export function listInstances(filters) {
   var params = [];
   if (filters && filters.status) { where.push('status = ?'); params.push(filters.status); }
   if (filters && filters.org_id) { where.push('org_id = ?'); params.push(filters.org_id); }
-  var sql = 'SELECT * FROM dv_customer_instances' + (where.length ? ' WHERE ' + where.join(' AND ') : '') + ' ORDER BY created_at DESC LIMIT ' + ((filters && filters.limit) || 100);
+  var sql = 'SELECT * FROM customer_instances' + (where.length ? ' WHERE ' + where.join(' AND ') : '') + ' ORDER BY created_at DESC LIMIT ' + ((filters && filters.limit) || 100);
   return db.prepare(sql).all.apply(db.prepare(sql), params);
 }
 
@@ -3456,6 +3456,6 @@ export function updateInstance(id, updates) {
   if (sets.length === 0) return getInstance(id);
   sets.push("updated_at = datetime('now')");
   params.push(id);
-  db.prepare('UPDATE dv_customer_instances SET ' + sets.join(', ') + ' WHERE id = ?').run.apply(db.prepare('UPDATE dv_customer_instances SET ' + sets.join(', ') + ' WHERE id = ?'), params);
+  db.prepare('UPDATE customer_instances SET ' + sets.join(', ') + ' WHERE id = ?').run.apply(db.prepare('UPDATE customer_instances SET ' + sets.join(', ') + ' WHERE id = ?'), params);
   return getInstance(id);
 }

--- a/server/db.js
+++ b/server/db.js
@@ -91,6 +91,23 @@ export function initDB() {
     try { db.exec('ALTER TABLE ' + table + ' ADD COLUMN ' + col + ' ' + def); } catch (e) { /* already exists */ }
   }
 
+  // Team columns migration
+  var projectCols = db.pragma('table_info(projects)').map(function(c) { return c.name; });
+  if (!projectCols.includes('team_id')) {
+    db.prepare('ALTER TABLE projects ADD COLUMN team_id TEXT').run();
+    console.log('[migration] Added team_id to projects');
+  }
+  var operatorCols = db.pragma('table_info(operators)').map(function(c) { return c.name; });
+  if (!operatorCols.includes('primary_team_id')) {
+    db.prepare('ALTER TABLE operators ADD COLUMN primary_team_id TEXT').run();
+    console.log('[migration] Added primary_team_id to operators');
+  }
+  var agentCols = db.pragma('table_info(agents)').map(function(c) { return c.name; });
+  if (!agentCols.includes('primary_team_id')) {
+    db.prepare('ALTER TABLE agents ADD COLUMN primary_team_id TEXT').run();
+    console.log('[migration] Added primary_team_id to agents');
+  }
+
   // Run platform schema AFTER migrations (schema has CREATE INDEX on migrated columns)
   var schema = fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8');
   db.exec(schema);
@@ -3408,6 +3425,114 @@ export function syncTeamSettingsToProfile() {
   } else {
     createNodeProfile(profileId, Object.assign({ node_type: 'agent', layer: 'customer' }, updates));
   }
+}
+
+// =============== TEAMS ===============
+
+export function createTeam(id, orgId, name, description, createdBy) {
+  db.prepare(
+    'INSERT INTO teams (id, org_id, name, description, created_by) VALUES (?, ?, ?, ?, ?)'
+  ).run(id, orgId, name, description || '', createdBy || '');
+  return getTeam(id);
+}
+
+export function getTeam(id) {
+  var team = db.prepare('SELECT * FROM teams WHERE id = ?').get(id);
+  if (team) {
+    team.members = db.prepare(
+      'SELECT * FROM team_members WHERE team_id = ? ORDER BY role, joined_at'
+    ).all(id);
+  }
+  return team;
+}
+
+export function listTeams(orgId) {
+  var sql = orgId
+    ? 'SELECT t.*, (SELECT COUNT(*) FROM team_members WHERE team_id = t.id) as member_count FROM teams t WHERE t.org_id = ? ORDER BY t.name'
+    : 'SELECT t.*, (SELECT COUNT(*) FROM team_members WHERE team_id = t.id) as member_count FROM teams t ORDER BY t.name';
+  return orgId ? db.prepare(sql).all(orgId) : db.prepare(sql).all();
+}
+
+export function updateTeam(id, fields) {
+  var sets = [];
+  var values = [];
+  for (var key of Object.keys(fields)) {
+    if (['name', 'description', 'org_id'].includes(key)) {
+      sets.push(key + ' = ?');
+      values.push(fields[key]);
+    }
+  }
+  if (sets.length === 0) return getTeam(id);
+  sets.push("updated_at = datetime('now')");
+  values.push(id);
+  db.prepare('UPDATE teams SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+  return getTeam(id);
+}
+
+export function deleteTeam(id) {
+  var memberCount = db.prepare('SELECT COUNT(*) as c FROM team_members WHERE team_id = ?').get(id).c;
+  if (memberCount > 0) throw new Error('Team has members — remove them first');
+  db.prepare('DELETE FROM teams WHERE id = ?').run(id);
+}
+
+export function addTeamMember(teamId, userId, userType, role, isPrimary) {
+  if (isPrimary) {
+    db.prepare('UPDATE team_members SET is_primary = 0 WHERE user_id = ? AND is_primary = 1').run(userId);
+  }
+  db.prepare(
+    'INSERT INTO team_members (team_id, user_id, user_type, role, is_primary) VALUES (?, ?, ?, ?, ?)'
+  ).run(teamId, userId, userType || 'operator', role || 'member', isPrimary ? 1 : 0);
+
+  if (isPrimary) {
+    var table = userType === 'agent' ? 'agents' : 'operators';
+    db.prepare('UPDATE ' + table + ' SET primary_team_id = ? WHERE id = ?').run(teamId, userId);
+  }
+  return db.prepare('SELECT * FROM team_members WHERE team_id = ? AND user_id = ?').get(teamId, userId);
+}
+
+export function updateTeamMember(teamId, userId, fields) {
+  var sets = [];
+  var values = [];
+  if (fields.role) { sets.push('role = ?'); values.push(fields.role); }
+  if (fields.is_primary !== undefined) {
+    if (fields.is_primary) {
+      db.prepare('UPDATE team_members SET is_primary = 0 WHERE user_id = ? AND is_primary = 1').run(userId);
+    }
+    sets.push('is_primary = ?');
+    values.push(fields.is_primary ? 1 : 0);
+  }
+  if (sets.length === 0) return;
+  values.push(teamId, userId);
+  db.prepare('UPDATE team_members SET ' + sets.join(', ') + ' WHERE team_id = ? AND user_id = ?').run(...values);
+
+  if (fields.is_primary) {
+    var member = db.prepare('SELECT user_type FROM team_members WHERE team_id = ? AND user_id = ?').get(teamId, userId);
+    if (member) {
+      var table = member.user_type === 'agent' ? 'agents' : 'operators';
+      db.prepare('UPDATE ' + table + ' SET primary_team_id = ? WHERE id = ?').run(teamId, userId);
+    }
+  }
+}
+
+export function removeTeamMember(teamId, userId) {
+  var member = db.prepare('SELECT * FROM team_members WHERE team_id = ? AND user_id = ?').get(teamId, userId);
+  if (!member) return;
+  db.prepare('DELETE FROM team_members WHERE team_id = ? AND user_id = ?').run(teamId, userId);
+
+  if (member.is_primary) {
+    var table = member.user_type === 'agent' ? 'agents' : 'operators';
+    db.prepare('UPDATE ' + table + ' SET primary_team_id = NULL WHERE id = ?').run(userId);
+  }
+}
+
+export function getTeamsForUser(userId) {
+  return db.prepare(
+    'SELECT t.*, tm.role, tm.is_primary FROM teams t JOIN team_members tm ON t.id = tm.team_id WHERE tm.user_id = ? ORDER BY tm.is_primary DESC, t.name'
+  ).all(userId);
+}
+
+export function getTeamProjects(teamId) {
+  return db.prepare('SELECT * FROM projects WHERE team_id = ?').all(teamId);
 }
 
 // =============== CUSTOMER INSTANCES ===============

--- a/server/db.js
+++ b/server/db.js
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import migrateTableNames from './migrate-table-names.js';
 
 var __dirname = path.dirname(fileURLToPath(import.meta.url));
 var DATA_DIR = process.env.DATA_DIR || path.join(__dirname, 'data');
@@ -22,6 +23,9 @@ export function initDB() {
 
   // Migration: rename game -> project_id columns BEFORE schema (which references project_id)
   migrateGameToProjectId();
+
+  // Migration: rename dv_* tables to clean names BEFORE schema.sql runs
+  migrateTableNames(db);
 
   // Migrations: add columns that may not exist yet on the LIVE database.
   // MUST run BEFORE schema.sql because schema has CREATE INDEX on these columns.

--- a/server/db.js
+++ b/server/db.js
@@ -1080,6 +1080,17 @@ export function getSlimBootPayload(agentId) {
   // Auto-heartbeat on boot
   updateAgentHeartbeat(agentId, 'online', agent.working_on);
 
+  // Team context
+  var agentTeams = getTeamsForUser(agentId);
+  var primaryTeam = agentTeams.find(function(t) { return t.is_primary; }) || null;
+  var guestTeams = agentTeams.filter(function(t) { return !t.is_primary; });
+  var teamMembers = [];
+  if (primaryTeam) {
+    teamMembers = db.prepare(
+      'SELECT tm.user_id, tm.user_type, tm.role FROM team_members tm WHERE tm.team_id = ?'
+    ).all(primaryTeam.id);
+  }
+
   // Fetch directives and requests first — used for both counts and content
   var pendingDirectives = db.prepare(
     "SELECT * FROM messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
@@ -1156,6 +1167,9 @@ export function getSlimBootPayload(agentId) {
       return { id: a.id, status: a.status, working_on: a.working_on || '' };
     }),
     inbox: inbox.messages.length > 0 || inbox.directives.length > 0 || inbox.requests.length > 0 ? inbox : undefined,
+    team: primaryTeam || undefined,
+    guest_teams: guestTeams.length > 0 ? guestTeams : undefined,
+    team_members: teamMembers.length > 0 ? teamMembers : undefined,
     sleep_mode: sleepMode,
     autonomous_mode: autonomousMode,
     operators_available: operatorsAvailable,
@@ -1207,6 +1221,17 @@ function buildRoleContract(agent, agentId) {
   }
 
   return contract;
+}
+
+// Get project IDs scoped to an agent's teams (all teams: primary + guest)
+// Returns empty array if agent has no teams (legacy/unscoped)
+export function getTeamProjectIdsForAgent(agentId) {
+  var agentTeamIds = getTeamsForUser(agentId).map(function(t) { return t.id; });
+  if (agentTeamIds.length === 0) return [];
+  var placeholders = agentTeamIds.map(function() { return '?'; }).join(',');
+  return db.prepare(
+    'SELECT id FROM projects WHERE team_id IN (' + placeholders + ')'
+  ).all(...agentTeamIds).map(function(p) { return p.id; });
 }
 
 // Build a prioritized work queue: what should this agent do next?
@@ -1269,8 +1294,15 @@ export function buildWorkQueue(agentId, projectId, directives, requests, tasks, 
     }
   }
 
-  // Priority 9: Unassigned bugs for this agent's project
-  var unassignedBugs = bugs.filter(function (b) { return !b.assignee && (b.project_id === projectId || !b.project_id); });
+  // Priority 9: Unassigned bugs for this agent's project/team
+  var teamProjIds = getTeamProjectIdsForAgent(agentId);
+  var unassignedBugs = bugs.filter(function (b) {
+    if (b.assignee) return false;
+    if (!b.project_id) return true; // unscoped bugs visible to everyone
+    if (b.project_id === projectId) return true;
+    if (teamProjIds.length > 0) return teamProjIds.indexOf(b.project_id) !== -1;
+    return true; // no team = legacy, see everything
+  });
   for (var b of unassignedBugs) {
     queue.push({ priority: 8, type: 'bug_unassigned', id: b.id, title: b.title, severity: b.severity, status: b.status, project_id: b.project_id });
   }
@@ -1295,23 +1327,34 @@ export function getIdleAgents() {
   `).all();
 }
 
-export function getNextUnassignedTask(excludeIds) {
+export function getNextUnassignedTask(excludeIds, teamProjectIds) {
   // Find highest priority open task not assigned to anyone
+  // If teamProjectIds provided, scope to those projects only
   var exclude = excludeIds && excludeIds.length > 0
     ? ' AND id NOT IN (' + excludeIds.map(() => '?').join(',') + ')'
     : '';
-  var params = excludeIds && excludeIds.length > 0 ? [...excludeIds] : [];
+  var teamScope = teamProjectIds && teamProjectIds.length > 0
+    ? ' AND project_id IN (' + teamProjectIds.map(() => '?').join(',') + ')'
+    : '';
+  var params = [];
+  if (excludeIds && excludeIds.length > 0) params = params.concat(excludeIds);
+  if (teamProjectIds && teamProjectIds.length > 0) params = params.concat(teamProjectIds);
   return db.prepare(
     `SELECT * FROM tasks
      WHERE status = 'open' AND (assignee IS NULL OR assignee = '')
-     ${exclude}
+     ${exclude}${teamScope}
      ORDER BY priority DESC, created_at ASC
      LIMIT 1`
   ).get(...params) || null;
 }
 
-export function getNextUnassignedPlanStep() {
+export function getNextUnassignedPlanStep(teamProjectIds) {
   // Find next unassigned pending plan step from an active plan
+  // If teamProjectIds provided, scope to those plan projects only
+  var teamScope = teamProjectIds && teamProjectIds.length > 0
+    ? ' AND p.project_id IN (' + teamProjectIds.map(() => '?').join(',') + ')'
+    : '';
+  var params = teamProjectIds && teamProjectIds.length > 0 ? teamProjectIds : [];
   return db.prepare(
     `SELECT s.*, p.title as plan_title
      FROM plan_steps s
@@ -1319,9 +1362,10 @@ export function getNextUnassignedPlanStep() {
      WHERE p.status = 'active'
        AND s.status = 'pending'
        AND (s.assignee IS NULL OR s.assignee = '')
+       ${teamScope}
      ORDER BY s.step_order ASC
      LIMIT 1`
-  ).get() || null;
+  ).get(...params) || null;
 }
 
 // -- Auto-task from asset request --

--- a/server/index.js
+++ b/server/index.js
@@ -36,7 +36,7 @@ function checkVoiceAuth(req, res) {
   if (agentKey) {
     var keyHash = crypto.createHash('sha256').update(agentKey).digest('hex');
     var db = getDB();
-    var match = db.prepare("SELECT id FROM dv_agents WHERE api_key_hash = ?").get(keyHash);
+    var match = db.prepare("SELECT id FROM agents WHERE api_key_hash = ?").get(keyHash);
     if (match) return true;
   }
   res.status(401).json({ error: 'Authentication required' });
@@ -65,17 +65,17 @@ if (!process.env.TURN_SECRET) {
 process.stdout.write('[boot] initializing DB...\n');
 initDB();
 
-// Migrate: add category + expires_at columns to dv_context_keys if missing
+// Migrate: add category + expires_at columns to context_keys if missing
 try {
   var _db = getDB();
-  var cols = _db.pragma('table_info(dv_context_keys)').map(function(c) { return c.name; });
+  var cols = _db.pragma('table_info(context_keys)').map(function(c) { return c.name; });
   if (!cols.includes('category')) {
-    _db.prepare("ALTER TABLE dv_context_keys ADD COLUMN category TEXT NOT NULL DEFAULT 'durable'").run();
-    process.stdout.write('[boot] migrated dv_context_keys: added category column\n');
+    _db.prepare("ALTER TABLE context_keys ADD COLUMN category TEXT NOT NULL DEFAULT 'durable'").run();
+    process.stdout.write('[boot] migrated context_keys: added category column\n');
   }
   if (!cols.includes('expires_at')) {
-    _db.prepare("ALTER TABLE dv_context_keys ADD COLUMN expires_at TEXT").run();
-    process.stdout.write('[boot] migrated dv_context_keys: added expires_at column\n');
+    _db.prepare("ALTER TABLE context_keys ADD COLUMN expires_at TEXT").run();
+    process.stdout.write('[boot] migrated context_keys: added expires_at column\n');
   }
 } catch (e) {
   process.stdout.write('[boot] context_keys migration note: ' + e.message + '\n');
@@ -205,7 +205,7 @@ app.get('/health', function (req, res) {
   var dbOk = false;
   try { getDB().prepare('SELECT 1').get(); dbOk = true; } catch (e) { /* */ }
   var agentsOnline = 0;
-  try { agentsOnline = getDB().prepare("SELECT COUNT(*) as c FROM dv_agents WHERE status = 'online'").get().c; } catch (e) { /* */ }
+  try { agentsOnline = getDB().prepare("SELECT COUNT(*) as c FROM agents WHERE status = 'online'").get().c; } catch (e) { /* */ }
   var mem = process.memoryUsage();
   res.json({
     status: dbOk ? 'ok' : 'degraded',
@@ -354,7 +354,7 @@ setInterval(function () {
     if (ctxPurged > 0) console.log('[daily] Purged ' + ctxPurged + ' expired context keys');
     // Clean expired password reset tokens (older than 1 day)
     try {
-      var tokensPurged = getDB().prepare("DELETE FROM dv_password_resets WHERE expires_at < datetime('now', '-1 day')").run().changes;
+      var tokensPurged = getDB().prepare("DELETE FROM password_resets WHERE expires_at < datetime('now', '-1 day')").run().changes;
       if (tokensPurged > 0) console.log('[daily] Purged ' + tokensPurged + ' expired password reset tokens');
     } catch (e) { /* table may not exist yet — non-fatal */ }
   } catch (e) {

--- a/server/migrate-table-names.js
+++ b/server/migrate-table-names.js
@@ -1,0 +1,99 @@
+// =============== Table Rename Migration: dv_* → clean names ===============
+// Idempotent: only renames tables that still have the old dv_ prefix.
+// Safe to run on every startup — already-renamed tables are skipped.
+
+const TABLE_RENAMES = [
+  // Core tables (43)
+  ['dv_agents', 'agents'],
+  ['dv_organizations', 'organizations'],
+  ['dv_projects', 'projects'],
+  ['dv_tasks', 'tasks'],
+  ['dv_context', 'context'],
+  ['dv_assets', 'assets'],
+  ['dv_events', 'events'],
+  ['dv_messages', 'messages'],
+  ['dv_context_keys', 'context_keys'],
+  ['dv_bugs', 'bugs'],
+  ['dv_plans', 'plans'],
+  ['dv_plan_steps', 'plan_steps'],
+  ['dv_plan_step_comments', 'plan_step_comments'],
+  ['dv_studio_users', 'studio_users'],
+  ['dv_password_resets', 'password_resets'],
+  ['dv_webhooks', 'webhooks'],
+  ['dv_drone_jobs', 'drone_jobs'],
+  ['dv_concepts', 'concepts'],
+  ['dv_project_concepts', 'project_concepts'],
+  ['dv_task_comments', 'task_comments'],
+  ['dv_support_tickets', 'support_tickets'],
+  ['dv_plugins', 'plugins'],
+  ['dv_plugin_migrations', 'plugin_migrations'],
+  ['dv_approvals', 'approvals'],
+  ['dv_operators', 'operators'],
+  ['dv_instance_config', 'instance_config'],
+  ['dv_approval_votes', 'approval_votes'],
+  ['dv_webhook_deliveries', 'webhook_deliveries'],
+  ['dv_channels', 'channels'],
+  ['dv_channel_members', 'channel_members'],
+  ['dv_agent_savepoints', 'agent_savepoints'],
+  ['dv_channel_reads', 'channel_reads'],
+  ['dv_operator_inbox', 'operator_inbox'],
+  ['dv_feedback', 'feedback'],
+  ['dv_drone_profiles', 'drone_profiles'],
+  ['dv_drone_profile_assignments', 'drone_profile_assignments'],
+  ['dv_job_templates', 'job_templates'],
+  ['dv_plugin_config', 'plugin_config'],
+  ['dv_runner_spawns', 'runner_spawns'],
+  ['dv_node_profiles', 'node_profiles'],
+  ['dv_customer_instances', 'customer_instances'],
+  ['dv_message_reads', 'message_reads'],
+  ['dv_team_settings', 'team_settings'],
+
+  // Plugin tables (24)
+  ['dv_subscriptions', 'subscriptions'],
+  ['dv_bip_drafts', 'bip_drafts'],
+  ['dv_cost_entries', 'cost_entries'],
+  ['dv_cost_daily', 'cost_daily'],
+  ['dv_cost_alerts', 'cost_alerts'],
+  ['dv_digest_reports', 'digest_reports'],
+  ['dv_digest_metrics', 'digest_metrics'],
+  ['dv_error_events', 'error_events'],
+  ['dv_github_events', 'github_events'],
+  ['dv_github_links', 'github_links'],
+  ['dv_guardrail_rules', 'guardrail_rules'],
+  ['dv_guardrail_violations', 'guardrail_violations'],
+  ['dv_outreach_campaigns', 'outreach_campaigns'],
+  ['dv_outreach_contacts', 'outreach_contacts'],
+  ['dv_social_accounts', 'social_accounts'],
+  ['dv_social_posts', 'social_posts'],
+  ['dv_steam_assets', 'steam_assets'],
+  ['dv_video_sessions', 'video_sessions'],
+  ['dv_video_clips', 'video_clips'],
+  ['dv_automation_rules', 'automation_rules'],
+  ['dv_automation_log', 'automation_log'],
+  ['dv_automation_templates', 'automation_templates'],
+  ['dv_x_posts', 'x_posts'],
+  ['dv_template_items', 'template_items'],
+];
+
+export default function migrateTableNames(db) {
+  // Get all existing table names from the database
+  var existingTables = new Set(
+    db.prepare("SELECT name FROM sqlite_master WHERE type='table'")
+      .all()
+      .map(function (row) { return row.name; })
+  );
+
+  var renamed = 0;
+
+  for (var [oldName, newName] of TABLE_RENAMES) {
+    if (existingTables.has(oldName) && !existingTables.has(newName)) {
+      db.exec('ALTER TABLE "' + oldName + '" RENAME TO "' + newName + '"');
+      process.stdout.write('[migrate] renamed ' + oldName + ' -> ' + newName + '\n');
+      renamed++;
+    }
+  }
+
+  if (renamed > 0) {
+    process.stdout.write('[migrate] table rename complete: ' + renamed + ' tables renamed\n');
+  }
+}

--- a/server/plugins/_template/db.js
+++ b/server/plugins/_template/db.js
@@ -4,13 +4,13 @@ export default function createTemplateDB(db) {
   return {
     create(title, data, createdBy) {
       var r = db.prepare(
-        'INSERT INTO dv_template_items (title, data, created_by) VALUES (?, ?, ?) RETURNING id'
+        'INSERT INTO template_items (title, data, created_by) VALUES (?, ?, ?) RETURNING id'
       ).get(title || '', JSON.stringify(data || {}), createdBy || '');
       return r.id;
     },
 
     get(id) {
-      var row = db.prepare('SELECT * FROM dv_template_items WHERE id = ?').get(id);
+      var row = db.prepare('SELECT * FROM template_items WHERE id = ?').get(id);
       if (row) {
         try { row.data = JSON.parse(row.data); } catch (e) { row.data = {}; }
       }
@@ -25,7 +25,7 @@ export default function createTemplateDB(db) {
       var offset = filters.offset || 0;
       params.push(limit, offset);
       var rows = db.prepare(
-        'SELECT * FROM dv_template_items WHERE ' + where.join(' AND ') +
+        'SELECT * FROM template_items WHERE ' + where.join(' AND ') +
         ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
       ).all(...params);
       return rows.map(function (row) {
@@ -43,11 +43,11 @@ export default function createTemplateDB(db) {
       if (sets.length === 0) return;
       sets.push("updated_at = datetime('now')");
       values.push(id);
-      db.prepare('UPDATE dv_template_items SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      db.prepare('UPDATE template_items SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     delete(id) {
-      db.prepare('DELETE FROM dv_template_items WHERE id = ?').run(id);
+      db.prepare('DELETE FROM template_items WHERE id = ?').run(id);
     }
   };
 }

--- a/server/plugins/_template/schema.sql
+++ b/server/plugins/_template/schema.sql
@@ -1,7 +1,7 @@
 -- Plugin: _template
--- Rename table prefix from dv_template_ to dv_YOURPLUGIN_
+-- Rename table prefix from template_ to YOURPLUGIN_
 
-CREATE TABLE IF NOT EXISTS dv_template_items (
+CREATE TABLE IF NOT EXISTS template_items (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   title       TEXT NOT NULL DEFAULT '',
   status      TEXT NOT NULL DEFAULT 'active',
@@ -11,4 +11,4 @@ CREATE TABLE IF NOT EXISTS dv_template_items (
   updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_template_items_status ON dv_template_items(status);
+CREATE INDEX IF NOT EXISTS idx_template_items_status ON template_items(status);

--- a/server/plugins/billing/db.js
+++ b/server/plugins/billing/db.js
@@ -2,25 +2,25 @@ export default function createBillingDB(db) {
   return {
     getSubscriptionByOrg(orgId) {
       return db.prepare(
-        'SELECT * FROM dv_subscriptions WHERE org_id = ? ORDER BY created_at DESC LIMIT 1'
+        'SELECT * FROM subscriptions WHERE org_id = ? ORDER BY created_at DESC LIMIT 1'
       ).get(orgId) || null;
     },
 
     getSubscriptionByStripeId(stripeSubscriptionId) {
       return db.prepare(
-        'SELECT * FROM dv_subscriptions WHERE stripe_subscription_id = ?'
+        'SELECT * FROM subscriptions WHERE stripe_subscription_id = ?'
       ).get(stripeSubscriptionId) || null;
     },
 
     getSubscriptionByCustomer(stripeCustomerId) {
       return db.prepare(
-        'SELECT * FROM dv_subscriptions WHERE stripe_customer_id = ? ORDER BY created_at DESC LIMIT 1'
+        'SELECT * FROM subscriptions WHERE stripe_customer_id = ? ORDER BY created_at DESC LIMIT 1'
       ).get(stripeCustomerId) || null;
     },
 
     createSubscription(orgId, stripeCustomerId, stripeSubscriptionId, status, plan, periodEnd) {
       var result = db.prepare(
-        `INSERT INTO dv_subscriptions (org_id, stripe_customer_id, stripe_subscription_id, status, plan, current_period_end)
+        `INSERT INTO subscriptions (org_id, stripe_customer_id, stripe_subscription_id, status, plan, current_period_end)
          VALUES (?, ?, ?, ?, ?, ?)`
       ).run(orgId, stripeCustomerId, stripeSubscriptionId, status, plan, periodEnd);
       return result.lastInsertRowid;
@@ -28,23 +28,23 @@ export default function createBillingDB(db) {
 
     updateSubscriptionStatus(stripeSubscriptionId, status, periodEnd) {
       db.prepare(
-        `UPDATE dv_subscriptions SET status = ?, current_period_end = ?, updated_at = datetime('now')
+        `UPDATE subscriptions SET status = ?, current_period_end = ?, updated_at = datetime('now')
          WHERE stripe_subscription_id = ?`
       ).run(status, periodEnd || '', stripeSubscriptionId);
     },
 
     listSubscriptions() {
-      return db.prepare('SELECT * FROM dv_subscriptions ORDER BY created_at DESC').all();
+      return db.prepare('SELECT * FROM subscriptions ORDER BY created_at DESC').all();
     },
 
     updateOrgPlan(orgId, plan) {
       db.prepare(
-        'UPDATE dv_organizations SET plan = ? WHERE id = ?'
+        'UPDATE organizations SET plan = ? WHERE id = ?'
       ).run(plan, orgId);
     },
 
     getOrg(orgId) {
-      return db.prepare('SELECT * FROM dv_organizations WHERE id = ?').get(orgId) || null;
+      return db.prepare('SELECT * FROM organizations WHERE id = ?').get(orgId) || null;
     }
   };
 }

--- a/server/plugins/billing/routes.js
+++ b/server/plugins/billing/routes.js
@@ -21,7 +21,7 @@ export default function (core) {
 
   function getConfig(key, fallback) {
     var row = core.db.prepare(
-      "SELECT value FROM dv_plugin_config WHERE plugin_name = 'billing' AND key = ?"
+      "SELECT value FROM plugin_config WHERE plugin_name = 'billing' AND key = ?"
     ).get(key);
     return row ? row.value : fallback;
   }
@@ -175,7 +175,7 @@ export default function (core) {
           var org = db.getOrg(orgId);
           if (!org) {
             core.db.prepare(
-              "INSERT INTO dv_organizations (id, name, description, plan) VALUES (?, ?, ?, 'managed')"
+              "INSERT INTO organizations (id, name, description, plan) VALUES (?, ?, ?, 'managed')"
             ).run(orgId, customerEmail || 'Customer ' + customerId, customerEmail ? 'email:' + customerEmail : '');
           } else {
             db.updateOrgPlan(orgId, 'managed');

--- a/server/plugins/billing/schema.sql
+++ b/server/plugins/billing/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS dv_subscriptions (
+CREATE TABLE IF NOT EXISTS subscriptions (
   id                      INTEGER PRIMARY KEY AUTOINCREMENT,
   org_id                  TEXT NOT NULL DEFAULT '',
   stripe_customer_id      TEXT NOT NULL DEFAULT '',
@@ -10,6 +10,6 @@ CREATE TABLE IF NOT EXISTS dv_subscriptions (
   updated_at              TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_subscriptions_org ON dv_subscriptions(org_id);
-CREATE INDEX IF NOT EXISTS idx_subscriptions_stripe_cust ON dv_subscriptions(stripe_customer_id);
-CREATE INDEX IF NOT EXISTS idx_subscriptions_status ON dv_subscriptions(status);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_org ON subscriptions(org_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_stripe_cust ON subscriptions(stripe_customer_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_status ON subscriptions(status);

--- a/server/plugins/build-in-public/README.md
+++ b/server/plugins/build-in-public/README.md
@@ -6,7 +6,7 @@ Watches for task completions, bug fixes, plan step completions, and drone job co
 
 ## Configuration
 
-No config schema fields. The plugin reads `instance_url` from `dv_instance_config` to include in draft content.
+No config schema fields. The plugin reads `instance_url` from `instance_config` to include in draft content.
 
 ## Gated Actions
 
@@ -49,7 +49,7 @@ All routes are prefixed with `/bip`.
 
 ## Database Tables
 
-### `dv_bip_drafts`
+### `bip_drafts`
 
 | Column | Type | Description |
 |--------|------|-------------|

--- a/server/plugins/build-in-public/db.js
+++ b/server/plugins/build-in-public/db.js
@@ -4,7 +4,7 @@ export default function createBipDB(db) {
   return {
     createDraft(triggerEvent, triggerData, title, content, platforms) {
       var r = db.prepare(
-        'INSERT INTO dv_bip_drafts (trigger_event, trigger_data, title, content, platforms) VALUES (?, ?, ?, ?, ?) RETURNING id'
+        'INSERT INTO bip_drafts (trigger_event, trigger_data, title, content, platforms) VALUES (?, ?, ?, ?, ?) RETURNING id'
       ).get(
         triggerEvent || '',
         JSON.stringify(triggerData || {}),
@@ -16,7 +16,7 @@ export default function createBipDB(db) {
     },
 
     getDraft(id) {
-      var row = db.prepare('SELECT * FROM dv_bip_drafts WHERE id = ?').get(id);
+      var row = db.prepare('SELECT * FROM bip_drafts WHERE id = ?').get(id);
       if (!row) return null;
       try { row.trigger_data = JSON.parse(row.trigger_data); } catch (e) { row.trigger_data = {}; }
       try { row.platforms = JSON.parse(row.platforms); } catch (e) { row.platforms = ['twitter']; }
@@ -33,7 +33,7 @@ export default function createBipDB(db) {
       var limit = Math.min(filters.limit || 50, 200);
       var offset = filters.offset || 0;
       var rows = db.prepare(
-        'SELECT * FROM dv_bip_drafts WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
+        'SELECT * FROM bip_drafts WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
       ).all(...params, limit, offset);
       return rows.map(function (row) {
         try { row.trigger_data = JSON.parse(row.trigger_data); } catch (e) { row.trigger_data = {}; }
@@ -59,15 +59,15 @@ export default function createBipDB(db) {
       if (sets.length === 0) return;
       sets.push("updated_at = datetime('now')");
       values.push(id);
-      db.prepare('UPDATE dv_bip_drafts SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      db.prepare('UPDATE bip_drafts SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     deleteDraft(id) {
-      db.prepare('DELETE FROM dv_bip_drafts WHERE id = ?').run(id);
+      db.prepare('DELETE FROM bip_drafts WHERE id = ?').run(id);
     },
 
     countByStatus() {
-      return db.prepare('SELECT status, COUNT(*) as count FROM dv_bip_drafts GROUP BY status').all();
+      return db.prepare('SELECT status, COUNT(*) as count FROM bip_drafts GROUP BY status').all();
     }
   };
 }

--- a/server/plugins/build-in-public/handlers.js
+++ b/server/plugins/build-in-public/handlers.js
@@ -65,7 +65,7 @@ export function registerHooks(core) {
       core.onEvent(eventType, function (eventData) {
         try {
           var instanceUrl = '';
-          try { instanceUrl = core.db.prepare("SELECT value FROM dv_instance_config WHERE key = 'instance_url'").get()?.value || ''; } catch (e) { /* */ }
+          try { instanceUrl = core.db.prepare("SELECT value FROM instance_config WHERE key = 'instance_url'").get()?.value || ''; } catch (e) { /* */ }
           var draft = draftContent(eventType, eventData, instanceUrl);
 
           // Create the draft

--- a/server/plugins/build-in-public/routes.js
+++ b/server/plugins/build-in-public/routes.js
@@ -66,7 +66,7 @@ export default function (core) {
     // Mark linked inbox items as actioned
     if (Array.isArray(draft.inbox_item_id)) {
       for (var inboxId of draft.inbox_item_id) {
-        try { core.db.prepare("UPDATE dv_operator_inbox SET status = 'actioned' WHERE id = ?").run(inboxId); } catch (e) {}
+        try { core.db.prepare("UPDATE operator_inbox SET status = 'actioned' WHERE id = ?").run(inboxId); } catch (e) {}
       }
     }
 
@@ -75,7 +75,7 @@ export default function (core) {
       { draft_id: draft.id, title: draft.title });
 
     // Hand off to social-posting plugin if available
-    var socialPlugin = core.db.prepare("SELECT enabled FROM dv_plugins WHERE name = 'social-posting'").get();
+    var socialPlugin = core.db.prepare("SELECT enabled FROM plugins WHERE name = 'social-posting'").get();
     if (socialPlugin && socialPlugin.enabled) {
       res.json({
         ok: true,
@@ -106,7 +106,7 @@ export default function (core) {
     // Mark linked inbox items as actioned
     if (Array.isArray(draft.inbox_item_id)) {
       for (var inboxId of draft.inbox_item_id) {
-        try { core.db.prepare("UPDATE dv_operator_inbox SET status = 'actioned' WHERE id = ?").run(inboxId); } catch (e) {}
+        try { core.db.prepare("UPDATE operator_inbox SET status = 'actioned' WHERE id = ?").run(inboxId); } catch (e) {}
       }
     }
 

--- a/server/plugins/build-in-public/schema.sql
+++ b/server/plugins/build-in-public/schema.sql
@@ -1,7 +1,7 @@
 -- Build-in-Public plugin schema
 -- Drafts of social content generated from agent events, pending operator approval.
 
-CREATE TABLE IF NOT EXISTS dv_bip_drafts (
+CREATE TABLE IF NOT EXISTS bip_drafts (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   trigger_event   TEXT NOT NULL DEFAULT '',         -- 'task_completed', 'plan_step_completed', etc.
   trigger_data    TEXT NOT NULL DEFAULT '{}',       -- the event payload that triggered this
@@ -9,8 +9,8 @@ CREATE TABLE IF NOT EXISTS dv_bip_drafts (
   content         TEXT NOT NULL DEFAULT '',         -- draft post content
   platforms       TEXT NOT NULL DEFAULT '["twitter"]',
   status          TEXT NOT NULL DEFAULT 'pending',  -- 'pending','approved','rejected','published','skipped'
-  approval_id     INTEGER,                          -- linked dv_approvals entry
-  inbox_item_id   TEXT NOT NULL DEFAULT '[]',       -- JSON array of linked dv_operator_inbox ids
+  approval_id     INTEGER,                          -- linked approvals entry
+  inbox_item_id   TEXT NOT NULL DEFAULT '[]',       -- JSON array of linked operator_inbox ids
   rejection_note  TEXT NOT NULL DEFAULT '',
   posted_at       TEXT,
   post_ids        TEXT NOT NULL DEFAULT '{}',       -- platform -> post id
@@ -18,6 +18,6 @@ CREATE TABLE IF NOT EXISTS dv_bip_drafts (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_bip_drafts_status ON dv_bip_drafts(status);
-CREATE INDEX IF NOT EXISTS idx_dv_bip_drafts_event ON dv_bip_drafts(trigger_event);
-CREATE INDEX IF NOT EXISTS idx_dv_bip_drafts_created ON dv_bip_drafts(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_bip_drafts_status ON bip_drafts(status);
+CREATE INDEX IF NOT EXISTS idx_bip_drafts_event ON bip_drafts(trigger_event);
+CREATE INDEX IF NOT EXISTS idx_bip_drafts_created ON bip_drafts(created_at DESC);

--- a/server/plugins/cost-tracker/README.md
+++ b/server/plugins/cost-tracker/README.md
@@ -51,7 +51,7 @@ All routes are prefixed with `/costs`.
 
 ## Database Tables
 
-### `dv_cost_entries`
+### `cost_entries`
 Individual token usage records.
 
 | Column | Type | Description |
@@ -67,7 +67,7 @@ Individual token usage records.
 | session_id | TEXT | Agent session identifier |
 | recorded_at | TEXT | Timestamp |
 
-### `dv_cost_daily`
+### `cost_daily`
 Daily aggregated cost summaries (unique per date + agent + project).
 
 | Column | Type | Description |
@@ -82,7 +82,7 @@ Daily aggregated cost summaries (unique per date + agent + project).
 | total_cost | REAL | Total cost in USD |
 | entry_count | INTEGER | Number of entries aggregated |
 
-### `dv_cost_alerts`
+### `cost_alerts`
 Budget alert history.
 
 | Column | Type | Description |

--- a/server/plugins/cost-tracker/db.js
+++ b/server/plugins/cost-tracker/db.js
@@ -4,7 +4,7 @@ export default function createCostDB(db) {
   return {
     recordUsage(agentId, projectId, taskId, inputTokens, outputTokens, cacheReadTokens, costUsd, sessionId) {
       var r = db.prepare(
-        'INSERT INTO dv_cost_entries (agent_id, project_id, task_id, input_tokens, output_tokens, cache_read_tokens, cost_usd, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id'
+        'INSERT INTO cost_entries (agent_id, project_id, task_id, input_tokens, output_tokens, cache_read_tokens, cost_usd, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id'
       ).get(
         agentId || '', projectId || '', taskId || null,
         inputTokens || 0, outputTokens || 0, cacheReadTokens || 0,
@@ -14,7 +14,7 @@ export default function createCostDB(db) {
       // Upsert daily aggregate
       var today = new Date().toISOString().split('T')[0];
       db.prepare(
-        "INSERT INTO dv_cost_daily (date, agent_id, project_id, total_input, total_output, total_cache, total_cost, entry_count) " +
+        "INSERT INTO cost_daily (date, agent_id, project_id, total_input, total_output, total_cache, total_cost, entry_count) " +
         "VALUES (?, ?, ?, ?, ?, ?, ?, 1) " +
         "ON CONFLICT(date, agent_id, project_id) DO UPDATE SET " +
         "total_input = total_input + excluded.total_input, " +
@@ -29,7 +29,7 @@ export default function createCostDB(db) {
     },
 
     getEntry(id) {
-      return db.prepare('SELECT * FROM dv_cost_entries WHERE id = ?').get(id);
+      return db.prepare('SELECT * FROM cost_entries WHERE id = ?').get(id);
     },
 
     listEntries(filters) {
@@ -43,16 +43,16 @@ export default function createCostDB(db) {
       var offset = filters.offset || 0;
       params.push(limit, offset);
       return db.prepare(
-        'SELECT * FROM dv_cost_entries WHERE ' + where.join(' AND ') +
+        'SELECT * FROM cost_entries WHERE ' + where.join(' AND ') +
         ' ORDER BY recorded_at DESC LIMIT ? OFFSET ?'
       ).all.apply(
-        db.prepare('SELECT * FROM dv_cost_entries WHERE ' + where.join(' AND ') + ' ORDER BY recorded_at DESC LIMIT ? OFFSET ?'),
+        db.prepare('SELECT * FROM cost_entries WHERE ' + where.join(' AND ') + ' ORDER BY recorded_at DESC LIMIT ? OFFSET ?'),
         params
       );
     },
 
     getDailySummary(date) {
-      return db.prepare('SELECT * FROM dv_cost_daily WHERE date = ?').all(date);
+      return db.prepare('SELECT * FROM cost_daily WHERE date = ?').all(date);
     },
 
     getAgentCosts(agentId, dateFrom, dateTo) {
@@ -61,9 +61,9 @@ export default function createCostDB(db) {
       if (dateFrom) { where.push('date >= ?'); params.push(dateFrom); }
       if (dateTo) { where.push('date <= ?'); params.push(dateTo); }
       return db.prepare(
-        'SELECT * FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'
+        'SELECT * FROM cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'
       ).all.apply(
-        db.prepare('SELECT * FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'),
+        db.prepare('SELECT * FROM cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'),
         params
       );
     },
@@ -74,9 +74,9 @@ export default function createCostDB(db) {
       if (dateFrom) { where.push('date >= ?'); params.push(dateFrom); }
       if (dateTo) { where.push('date <= ?'); params.push(dateTo); }
       return db.prepare(
-        'SELECT * FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'
+        'SELECT * FROM cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'
       ).all.apply(
-        db.prepare('SELECT * FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'),
+        db.prepare('SELECT * FROM cost_daily WHERE ' + where.join(' AND ') + ' ORDER BY date DESC'),
         params
       );
     },
@@ -89,11 +89,11 @@ export default function createCostDB(db) {
       var row = db.prepare(
         'SELECT COALESCE(SUM(total_input), 0) as total_input, COALESCE(SUM(total_output), 0) as total_output, ' +
         'COALESCE(SUM(total_cache), 0) as total_cache, COALESCE(SUM(total_cost), 0) as total_cost, ' +
-        'COALESCE(SUM(entry_count), 0) as entry_count FROM dv_cost_daily WHERE ' + where.join(' AND ')
+        'COALESCE(SUM(entry_count), 0) as entry_count FROM cost_daily WHERE ' + where.join(' AND ')
       ).get.apply(
         db.prepare('SELECT COALESCE(SUM(total_input), 0) as total_input, COALESCE(SUM(total_output), 0) as total_output, ' +
           'COALESCE(SUM(total_cache), 0) as total_cache, COALESCE(SUM(total_cost), 0) as total_cost, ' +
-          'COALESCE(SUM(entry_count), 0) as entry_count FROM dv_cost_daily WHERE ' + where.join(' AND ')),
+          'COALESCE(SUM(entry_count), 0) as entry_count FROM cost_daily WHERE ' + where.join(' AND ')),
         params
       );
       return row;
@@ -102,7 +102,7 @@ export default function createCostDB(db) {
     getSpendToday() {
       var today = new Date().toISOString().split('T')[0];
       var row = db.prepare(
-        'SELECT COALESCE(SUM(total_cost), 0) as spend FROM dv_cost_daily WHERE date = ?'
+        'SELECT COALESCE(SUM(total_cost), 0) as spend FROM cost_daily WHERE date = ?'
       ).get(today);
       return row.spend;
     },
@@ -110,7 +110,7 @@ export default function createCostDB(db) {
     getSpendThisWeek() {
       var weekStart = getWeekStart();
       var row = db.prepare(
-        'SELECT COALESCE(SUM(total_cost), 0) as spend FROM dv_cost_daily WHERE date >= ?'
+        'SELECT COALESCE(SUM(total_cost), 0) as spend FROM cost_daily WHERE date >= ?'
       ).get(weekStart);
       return row.spend;
     },
@@ -120,7 +120,7 @@ export default function createCostDB(db) {
       return db.prepare(
         'SELECT date, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
         'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
-        'FROM dv_cost_daily WHERE date >= date("now", "-" || ? || " days") ' +
+        'FROM cost_daily WHERE date >= date("now", "-" || ? || " days") ' +
         'GROUP BY date ORDER BY date ASC'
       ).all(d);
     },
@@ -135,25 +135,25 @@ export default function createCostDB(db) {
       return db.prepare(
         'SELECT agent_id, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
         'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
-        'FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY agent_id ORDER BY total_cost DESC LIMIT ?'
+        'FROM cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY agent_id ORDER BY total_cost DESC LIMIT ?'
       ).all.apply(
         db.prepare('SELECT agent_id, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
           'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
-          'FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY agent_id ORDER BY total_cost DESC LIMIT ?'),
+          'FROM cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY agent_id ORDER BY total_cost DESC LIMIT ?'),
         params
       );
     },
 
     logAlert(alertType, thresholdPct, currentSpend, budgetLimit) {
       db.prepare(
-        'INSERT INTO dv_cost_alerts (alert_type, threshold_pct, current_spend, budget_limit) VALUES (?, ?, ?, ?)'
+        'INSERT INTO cost_alerts (alert_type, threshold_pct, current_spend, budget_limit) VALUES (?, ?, ?, ?)'
       ).run(alertType, thresholdPct, currentSpend, budgetLimit);
     },
 
     getAlerts(limit) {
       var lim = limit || 20;
       return db.prepare(
-        'SELECT * FROM dv_cost_alerts ORDER BY triggered_at DESC LIMIT ?'
+        'SELECT * FROM cost_alerts ORDER BY triggered_at DESC LIMIT ?'
       ).all(lim);
     }
   };

--- a/server/plugins/cost-tracker/handlers.js
+++ b/server/plugins/cost-tracker/handlers.js
@@ -21,7 +21,7 @@ function checkBudgetAlerts(db, core, config) {
     if (pct >= alertThreshold) {
       var today = new Date().toISOString().split('T')[0];
       var existing = core.db.prepare(
-        "SELECT id FROM dv_cost_alerts WHERE alert_type = 'daily_budget' AND triggered_at >= ?"
+        "SELECT id FROM cost_alerts WHERE alert_type = 'daily_budget' AND triggered_at >= ?"
       ).get(today);
       if (!existing) {
         db.logAlert('daily_budget', pct * 100, todaySpend, dailyBudget);
@@ -44,7 +44,7 @@ function checkBudgetAlerts(db, core, config) {
     if (weekPct >= alertThreshold) {
       var weekStart = getWeekStart();
       var existingWeek = core.db.prepare(
-        "SELECT id FROM dv_cost_alerts WHERE alert_type = 'weekly_budget' AND triggered_at >= ?"
+        "SELECT id FROM cost_alerts WHERE alert_type = 'weekly_budget' AND triggered_at >= ?"
       ).get(weekStart);
       if (!existingWeek) {
         db.logAlert('weekly_budget', weekPct * 100, weekSpend, weeklyBudget);
@@ -73,7 +73,7 @@ export function registerHooks(core) {
       // Get pricing config
       var getConfig = function (key, fallback) {
         var row = core.db.prepare(
-          "SELECT value FROM dv_plugin_config WHERE plugin_name = 'cost-tracker' AND key = ?"
+          "SELECT value FROM plugin_config WHERE plugin_name = 'cost-tracker' AND key = ?"
         ).get(key);
         return row ? parseFloat(row.value) : fallback;
       };
@@ -94,7 +94,7 @@ export function registerHooks(core) {
       // Check budgets
       var config = {};
       var rows = core.db.prepare(
-        "SELECT key, value FROM dv_plugin_config WHERE plugin_name = 'cost-tracker'"
+        "SELECT key, value FROM plugin_config WHERE plugin_name = 'cost-tracker'"
       ).all();
       for (var r of rows) config[r.key] = r.value;
       checkBudgetAlerts(db, core, config);

--- a/server/plugins/cost-tracker/routes.js
+++ b/server/plugins/cost-tracker/routes.js
@@ -13,7 +13,7 @@ function getWeekStart() {
 
 function getConfigValue(coreDb, key, fallback) {
   var row = coreDb.prepare(
-    "SELECT value FROM dv_plugin_config WHERE plugin_name = 'cost-tracker' AND key = ?"
+    "SELECT value FROM plugin_config WHERE plugin_name = 'cost-tracker' AND key = ?"
   ).get(key);
   return row ? parseFloat(row.value) : fallback;
 }
@@ -21,7 +21,7 @@ function getConfigValue(coreDb, key, fallback) {
 function getAllConfig(coreDb) {
   var config = {};
   var rows = coreDb.prepare(
-    "SELECT key, value FROM dv_plugin_config WHERE plugin_name = 'cost-tracker'"
+    "SELECT key, value FROM plugin_config WHERE plugin_name = 'cost-tracker'"
   ).all();
   for (var r of rows) config[r.key] = r.value;
   return config;
@@ -38,7 +38,7 @@ function checkBudgetAlerts(db, core, config) {
     if (pct >= alertThreshold) {
       var today = new Date().toISOString().split('T')[0];
       var existing = core.db.prepare(
-        "SELECT id FROM dv_cost_alerts WHERE alert_type = 'daily_budget' AND triggered_at >= ?"
+        "SELECT id FROM cost_alerts WHERE alert_type = 'daily_budget' AND triggered_at >= ?"
       ).get(today);
       if (!existing) {
         db.logAlert('daily_budget', pct * 100, todaySpend, dailyBudget);
@@ -61,7 +61,7 @@ function checkBudgetAlerts(db, core, config) {
     if (weekPct >= alertThreshold) {
       var weekStart = getWeekStart();
       var existingWeek = core.db.prepare(
-        "SELECT id FROM dv_cost_alerts WHERE alert_type = 'weekly_budget' AND triggered_at >= ?"
+        "SELECT id FROM cost_alerts WHERE alert_type = 'weekly_budget' AND triggered_at >= ?"
       ).get(weekStart);
       if (!existingWeek) {
         db.logAlert('weekly_budget', weekPct * 100, weekSpend, weeklyBudget);
@@ -169,11 +169,11 @@ export default function (core) {
     var projects = core.db.prepare(
       'SELECT project_id, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
       'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
-      'FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY project_id ORDER BY total_cost DESC'
+      'FROM cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY project_id ORDER BY total_cost DESC'
     ).all.apply(
       core.db.prepare('SELECT project_id, SUM(total_input) as total_input, SUM(total_output) as total_output, ' +
         'SUM(total_cache) as total_cache, SUM(total_cost) as total_cost, SUM(entry_count) as entry_count ' +
-        'FROM dv_cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY project_id ORDER BY total_cost DESC'),
+        'FROM cost_daily WHERE ' + where.join(' AND ') + ' GROUP BY project_id ORDER BY total_cost DESC'),
       params
     );
     res.json({ date_from: dateFrom, date_to: dateTo, projects: projects });

--- a/server/plugins/cost-tracker/schema.sql
+++ b/server/plugins/cost-tracker/schema.sql
@@ -1,7 +1,7 @@
 -- Plugin: cost-tracker
 -- Tracks AI API token usage and costs per agent, project, and task.
 
-CREATE TABLE IF NOT EXISTS dv_cost_entries (
+CREATE TABLE IF NOT EXISTS cost_entries (
   id                INTEGER PRIMARY KEY AUTOINCREMENT,
   agent_id          TEXT NOT NULL DEFAULT '',
   project_id        TEXT NOT NULL DEFAULT '',
@@ -14,11 +14,11 @@ CREATE TABLE IF NOT EXISTS dv_cost_entries (
   recorded_at       TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_cost_entries_agent ON dv_cost_entries(agent_id);
-CREATE INDEX IF NOT EXISTS idx_cost_entries_project ON dv_cost_entries(project_id);
-CREATE INDEX IF NOT EXISTS idx_cost_entries_recorded ON dv_cost_entries(recorded_at);
+CREATE INDEX IF NOT EXISTS idx_cost_entries_agent ON cost_entries(agent_id);
+CREATE INDEX IF NOT EXISTS idx_cost_entries_project ON cost_entries(project_id);
+CREATE INDEX IF NOT EXISTS idx_cost_entries_recorded ON cost_entries(recorded_at);
 
-CREATE TABLE IF NOT EXISTS dv_cost_daily (
+CREATE TABLE IF NOT EXISTS cost_daily (
   id                INTEGER PRIMARY KEY AUTOINCREMENT,
   date              TEXT NOT NULL DEFAULT '',
   agent_id          TEXT NOT NULL DEFAULT '',
@@ -32,11 +32,11 @@ CREATE TABLE IF NOT EXISTS dv_cost_daily (
   UNIQUE(date, agent_id, project_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_cost_daily_date ON dv_cost_daily(date);
-CREATE INDEX IF NOT EXISTS idx_cost_daily_agent ON dv_cost_daily(agent_id);
-CREATE INDEX IF NOT EXISTS idx_cost_daily_project ON dv_cost_daily(project_id);
+CREATE INDEX IF NOT EXISTS idx_cost_daily_date ON cost_daily(date);
+CREATE INDEX IF NOT EXISTS idx_cost_daily_agent ON cost_daily(agent_id);
+CREATE INDEX IF NOT EXISTS idx_cost_daily_project ON cost_daily(project_id);
 
-CREATE TABLE IF NOT EXISTS dv_cost_alerts (
+CREATE TABLE IF NOT EXISTS cost_alerts (
   id                INTEGER PRIMARY KEY AUTOINCREMENT,
   alert_type        TEXT NOT NULL DEFAULT '',
   threshold_pct     REAL NOT NULL DEFAULT 0,

--- a/server/plugins/daily-digest/README.md
+++ b/server/plugins/daily-digest/README.md
@@ -49,7 +49,7 @@ All routes are prefixed with `/digest`.
 
 ## Database Tables
 
-### `dv_digest_reports`
+### `digest_reports`
 Stored digest reports.
 
 | Column | Type | Description |
@@ -63,7 +63,7 @@ Stored digest reports.
 | delivered_to | TEXT (JSON) | Array of delivery targets (e.g. `["inbox", "slack"]`) |
 | created_at | TEXT | Creation timestamp |
 
-### `dv_digest_metrics`
+### `digest_metrics`
 Time-series metric snapshots for trend tracking.
 
 | Column | Type | Description |

--- a/server/plugins/daily-digest/db.js
+++ b/server/plugins/daily-digest/db.js
@@ -4,13 +4,13 @@ export default function createDigestDB(db) {
   return {
     createReport(type, periodStart, periodEnd, content, summary) {
       var r = db.prepare(
-        'INSERT INTO dv_digest_reports (digest_type, period_start, period_end, content, summary) VALUES (?, ?, ?, ?, ?) RETURNING id'
+        'INSERT INTO digest_reports (digest_type, period_start, period_end, content, summary) VALUES (?, ?, ?, ?, ?) RETURNING id'
       ).get(type, periodStart, periodEnd, JSON.stringify(content), summary);
       return r.id;
     },
 
     getReport(id) {
-      var row = db.prepare('SELECT * FROM dv_digest_reports WHERE id = ?').get(id);
+      var row = db.prepare('SELECT * FROM digest_reports WHERE id = ?').get(id);
       if (!row) return null;
       try { row.content = JSON.parse(row.content); } catch (e) { row.content = {}; }
       try { row.delivered_to = JSON.parse(row.delivered_to); } catch (e) { row.delivered_to = []; }
@@ -24,7 +24,7 @@ export default function createDigestDB(db) {
       var limit = Math.min(filters.limit || 50, 200);
       var offset = filters.offset || 0;
       var rows = db.prepare(
-        'SELECT * FROM dv_digest_reports WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
+        'SELECT * FROM digest_reports WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
       ).all(...params, limit, offset);
       return rows.map(function (row) {
         try { row.content = JSON.parse(row.content); } catch (e) { row.content = {}; }
@@ -35,7 +35,7 @@ export default function createDigestDB(db) {
 
     getLatestReport(type) {
       var row = db.prepare(
-        'SELECT * FROM dv_digest_reports WHERE digest_type = ? ORDER BY created_at DESC LIMIT 1'
+        'SELECT * FROM digest_reports WHERE digest_type = ? ORDER BY created_at DESC LIMIT 1'
       ).get(type);
       if (!row) return null;
       try { row.content = JSON.parse(row.content); } catch (e) { row.content = {}; }
@@ -44,26 +44,26 @@ export default function createDigestDB(db) {
     },
 
     updateReportDelivery(id, deliveredTo) {
-      db.prepare('UPDATE dv_digest_reports SET delivered_to = ? WHERE id = ?').run(
+      db.prepare('UPDATE digest_reports SET delivered_to = ? WHERE id = ?').run(
         JSON.stringify(deliveredTo), id
       );
     },
 
     recordMetric(metricType, metricKey, value, period) {
       db.prepare(
-        'INSERT INTO dv_digest_metrics (metric_type, metric_key, value, period) VALUES (?, ?, ?, ?)'
+        'INSERT INTO digest_metrics (metric_type, metric_key, value, period) VALUES (?, ?, ?, ?)'
       ).run(metricType, metricKey, value, period);
     },
 
     getMetrics(metricType, period) {
       return db.prepare(
-        'SELECT * FROM dv_digest_metrics WHERE metric_type = ? AND period = ? ORDER BY recorded_at DESC'
+        'SELECT * FROM digest_metrics WHERE metric_type = ? AND period = ? ORDER BY recorded_at DESC'
       ).all(metricType, period);
     },
 
     getTrends(metricType, limit) {
       return db.prepare(
-        'SELECT period, SUM(value) as total FROM dv_digest_metrics WHERE metric_type = ? GROUP BY period ORDER BY period DESC LIMIT ?'
+        'SELECT period, SUM(value) as total FROM digest_metrics WHERE metric_type = ? GROUP BY period ORDER BY period DESC LIMIT ?'
       ).all(metricType, limit || 14);
     }
   };

--- a/server/plugins/daily-digest/routes.js
+++ b/server/plugins/daily-digest/routes.js
@@ -5,29 +5,29 @@ import { Router } from 'express';
 import createDigestDB from './db.js';
 
 function gatherDigestData(db, coreDb, periodStart, periodEnd) {
-  // Query dv_tasks for completed tasks in period
+  // Query tasks for completed tasks in period
   var tasks = coreDb.prepare(
-    "SELECT * FROM dv_tasks WHERE status = 'done' AND updated_at BETWEEN ? AND ?"
+    "SELECT * FROM tasks WHERE status = 'done' AND updated_at BETWEEN ? AND ?"
   ).all(periodStart, periodEnd);
 
-  // Query dv_bugs for fixed bugs
+  // Query bugs for fixed bugs
   var bugs = coreDb.prepare(
-    "SELECT * FROM dv_bugs WHERE status = 'fixed' AND updated_at BETWEEN ? AND ?"
+    "SELECT * FROM bugs WHERE status = 'fixed' AND updated_at BETWEEN ? AND ?"
   ).all(periodStart, periodEnd);
 
-  // Query dv_plan_steps for completed steps
+  // Query plan_steps for completed steps
   var steps = coreDb.prepare(
-    "SELECT ps.*, p.title as plan_title FROM dv_plan_steps ps JOIN dv_plans p ON ps.plan_id = p.id WHERE ps.status = 'completed' AND ps.updated_at BETWEEN ? AND ?"
+    "SELECT ps.*, p.title as plan_title FROM plan_steps ps JOIN plans p ON ps.plan_id = p.id WHERE ps.status = 'completed' AND ps.updated_at BETWEEN ? AND ?"
   ).all(periodStart, periodEnd);
 
-  // Query dv_agents for agent activity (heartbeat counts)
+  // Query agents for agent activity (heartbeat counts)
   var agents = coreDb.prepare(
-    "SELECT id, display_name, status, working_on, last_heartbeat FROM dv_agents"
+    "SELECT id, display_name, status, working_on, last_heartbeat FROM agents"
   ).all();
 
   // Query messages sent in period
   var messageCount = coreDb.prepare(
-    "SELECT COUNT(*) as count FROM dv_messages WHERE created_at BETWEEN ? AND ?"
+    "SELECT COUNT(*) as count FROM messages WHERE created_at BETWEEN ? AND ?"
   ).get(periodStart, periodEnd).count;
 
   // Build per-agent stats
@@ -165,7 +165,7 @@ export default function (core) {
       );
 
       // Optional Slack delivery
-      var slackWebhook = core.db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'daily-digest' AND key = 'slack_webhook'").get();
+      var slackWebhook = core.db.prepare("SELECT value FROM plugin_config WHERE plugin_name = 'daily-digest' AND key = 'slack_webhook'").get();
       if (slackWebhook && slackWebhook.value) {
         try {
           await fetch(slackWebhook.value, {
@@ -236,7 +236,7 @@ export default function (core) {
       );
 
       // Optional Slack re-delivery
-      var slackWebhook = core.db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'daily-digest' AND key = 'slack_webhook'").get();
+      var slackWebhook = core.db.prepare("SELECT value FROM plugin_config WHERE plugin_name = 'daily-digest' AND key = 'slack_webhook'").get();
       if (slackWebhook && slackWebhook.value) {
         try {
           await fetch(slackWebhook.value, {

--- a/server/plugins/daily-digest/schema.sql
+++ b/server/plugins/daily-digest/schema.sql
@@ -1,7 +1,7 @@
 -- Daily Digest plugin schema
 -- Stores generated digest reports and time-series metrics snapshots.
 
-CREATE TABLE IF NOT EXISTS dv_digest_reports (
+CREATE TABLE IF NOT EXISTS digest_reports (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   period_start    TEXT NOT NULL,                          -- ISO date start of period
   period_end      TEXT NOT NULL,                          -- ISO date end of period
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS dv_digest_reports (
   created_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE TABLE IF NOT EXISTS dv_digest_metrics (
+CREATE TABLE IF NOT EXISTS digest_metrics (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   metric_type     TEXT NOT NULL,                          -- 'tasks_completed', 'bugs_fixed', etc.
   metric_key      TEXT NOT NULL DEFAULT '',               -- e.g. agent id or 'total'
@@ -21,6 +21,6 @@ CREATE TABLE IF NOT EXISTS dv_digest_metrics (
   recorded_at     TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_digest_reports_type ON dv_digest_reports(digest_type);
-CREATE INDEX IF NOT EXISTS idx_dv_digest_reports_period ON dv_digest_reports(period_start);
-CREATE INDEX IF NOT EXISTS idx_dv_digest_metrics_type_period ON dv_digest_metrics(metric_type, period);
+CREATE INDEX IF NOT EXISTS idx_digest_reports_type ON digest_reports(digest_type);
+CREATE INDEX IF NOT EXISTS idx_digest_reports_period ON digest_reports(period_start);
+CREATE INDEX IF NOT EXISTS idx_digest_metrics_type_period ON digest_metrics(metric_type, period);

--- a/server/plugins/error-monitor/README.md
+++ b/server/plugins/error-monitor/README.md
@@ -51,7 +51,7 @@ All routes are prefixed with `/errors`.
 
 ## Database Tables
 
-### `dv_error_events`
+### `error_events`
 
 | Column | Type | Description |
 |--------|------|-------------|

--- a/server/plugins/error-monitor/db.js
+++ b/server/plugins/error-monitor/db.js
@@ -10,18 +10,18 @@ export default function createErrorDB(db) {
   return {
     logError(provider, errorKey, title, message, stackTrace, url, payload) {
       var existing = stmt('emGetByKey',
-        'SELECT id, occurrences FROM dv_error_events WHERE error_key = ?'
+        'SELECT id, occurrences FROM error_events WHERE error_key = ?'
       ).get(errorKey);
 
       if (existing) {
         stmt('emBump',
-          "UPDATE dv_error_events SET occurrences = occurrences + 1, last_seen = datetime('now'), payload = ?, updated_at = datetime('now') WHERE id = ?"
+          "UPDATE error_events SET occurrences = occurrences + 1, last_seen = datetime('now'), payload = ?, updated_at = datetime('now') WHERE id = ?"
         ).run(JSON.stringify(payload || {}), existing.id);
         return { id: existing.id, is_new: false, occurrences: existing.occurrences + 1 };
       }
 
       var r = stmt('emInsert',
-        'INSERT INTO dv_error_events (provider, error_key, title, message, stack_trace, url, payload) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
+        'INSERT INTO error_events (provider, error_key, title, message, stack_trace, url, payload) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
       ).get(
         provider || '', errorKey || '', title || '', message || '',
         stackTrace || '', url || '', JSON.stringify(payload || {})
@@ -30,7 +30,7 @@ export default function createErrorDB(db) {
     },
 
     getError(id) {
-      var row = stmt('emGet', 'SELECT * FROM dv_error_events WHERE id = ?').get(id);
+      var row = stmt('emGet', 'SELECT * FROM error_events WHERE id = ?').get(id);
       if (row) {
         try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
       }
@@ -38,7 +38,7 @@ export default function createErrorDB(db) {
     },
 
     getErrorByKey(errorKey) {
-      var row = stmt('emGetByKey2', 'SELECT * FROM dv_error_events WHERE error_key = ?').get(errorKey);
+      var row = stmt('emGetByKey2', 'SELECT * FROM error_events WHERE error_key = ?').get(errorKey);
       if (row) {
         try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
       }
@@ -54,7 +54,7 @@ export default function createErrorDB(db) {
       var offset = filters.offset || 0;
       params.push(limit, offset);
       var rows = db.prepare(
-        'SELECT * FROM dv_error_events WHERE ' + where.join(' AND ') +
+        'SELECT * FROM error_events WHERE ' + where.join(' AND ') +
         ' ORDER BY last_seen DESC LIMIT ? OFFSET ?'
       ).all(...params);
       return rows.map(function (row) {
@@ -75,30 +75,30 @@ export default function createErrorDB(db) {
       if (sets.length === 0) return;
       sets.push("updated_at = datetime('now')");
       values.push(id);
-      db.prepare('UPDATE dv_error_events SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      db.prepare('UPDATE error_events SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     muteError(id) {
       stmt('emMute',
-        "UPDATE dv_error_events SET status = 'muted', updated_at = datetime('now') WHERE id = ?"
+        "UPDATE error_events SET status = 'muted', updated_at = datetime('now') WHERE id = ?"
       ).run(id);
     },
 
     resolveError(id) {
       stmt('emResolve',
-        "UPDATE dv_error_events SET status = 'resolved', updated_at = datetime('now') WHERE id = ?"
+        "UPDATE error_events SET status = 'resolved', updated_at = datetime('now') WHERE id = ?"
       ).run(id);
     },
 
     getStats() {
       var byProvider = db.prepare(
-        'SELECT provider, COUNT(*) as count FROM dv_error_events GROUP BY provider'
+        'SELECT provider, COUNT(*) as count FROM error_events GROUP BY provider'
       ).all();
       var byStatus = db.prepare(
-        'SELECT status, COUNT(*) as count FROM dv_error_events GROUP BY status'
+        'SELECT status, COUNT(*) as count FROM error_events GROUP BY status'
       ).all();
       var last24h = db.prepare(
-        "SELECT COUNT(*) as count FROM dv_error_events WHERE last_seen >= datetime('now', '-1 day')"
+        "SELECT COUNT(*) as count FROM error_events WHERE last_seen >= datetime('now', '-1 day')"
       ).get();
       return {
         by_provider: byProvider,
@@ -109,7 +109,7 @@ export default function createErrorDB(db) {
 
     getTopErrors(limit) {
       var rows = db.prepare(
-        'SELECT * FROM dv_error_events ORDER BY occurrences DESC LIMIT ?'
+        'SELECT * FROM error_events ORDER BY occurrences DESC LIMIT ?'
       ).all(limit || 10);
       return rows.map(function (row) {
         try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }

--- a/server/plugins/error-monitor/handlers.js
+++ b/server/plugins/error-monitor/handlers.js
@@ -13,7 +13,7 @@ export function registerHooks(core) {
       if (!bugId) return;
 
       var errors = core.db.prepare(
-        "SELECT id FROM dv_error_events WHERE bug_id = ? AND status = 'open'"
+        "SELECT id FROM error_events WHERE bug_id = ? AND status = 'open'"
       ).all(bugId);
 
       for (var err of errors) {

--- a/server/plugins/error-monitor/mcp-tools.json
+++ b/server/plugins/error-monitor/mcp-tools.json
@@ -48,7 +48,7 @@
   },
   {
     "name": "mycelium_errors_file_bug",
-    "description": "Manually file a Mycelium bug from an error event. Creates a bug in dv_bugs and links it to the error.",
+    "description": "Manually file a Mycelium bug from an error event. Creates a bug in bugs and links it to the error.",
     "inputSchema": {
       "type": "object",
       "required": ["error_id"],

--- a/server/plugins/error-monitor/routes.js
+++ b/server/plugins/error-monitor/routes.js
@@ -5,14 +5,14 @@ import createErrorDB from './db.js';
 
 function getConfig(db, key) {
   var row = db.prepare(
-    "SELECT value FROM dv_plugin_config WHERE plugin_name = 'error-monitor' AND key = ?"
+    "SELECT value FROM plugin_config WHERE plugin_name = 'error-monitor' AND key = ?"
   ).get(key);
   return row ? row.value : null;
 }
 
 function getAllConfig(db) {
   var rows = db.prepare(
-    "SELECT key, value FROM dv_plugin_config WHERE plugin_name = 'error-monitor'"
+    "SELECT key, value FROM plugin_config WHERE plugin_name = 'error-monitor'"
   ).all();
   var config = {};
   for (var row of rows) {
@@ -26,7 +26,7 @@ function autoFileBug(core, db, errorRecord, config) {
   var severity = config.default_severity || 'normal';
 
   var result = core.db.prepare(
-    "INSERT INTO dv_bugs (title, description, project_id, severity, status, reporter) VALUES (?, ?, ?, ?, 'open', '__system__') RETURNING id"
+    "INSERT INTO bugs (title, description, project_id, severity, status, reporter) VALUES (?, ?, ?, ?, 'open', '__system__') RETURNING id"
   ).get(
     '[' + errorRecord.provider + '] ' + errorRecord.title,
     'Auto-filed from error monitor.\n\nMessage: ' + errorRecord.message + '\n\nStack trace:\n' + (errorRecord.stack_trace || 'N/A') + '\n\nLink: ' + (errorRecord.url || 'N/A') + '\n\nOccurrences: ' + errorRecord.occurrences,
@@ -54,10 +54,10 @@ function autoFileBug(core, db, errorRecord, config) {
 function autoAssignBug(core, bugId, projectId) {
   // Find most recently active agent on the project
   var agent = core.db.prepare(
-    "SELECT agent_id FROM dv_agents WHERE last_heartbeat >= datetime('now', '-1 hour') ORDER BY last_heartbeat DESC LIMIT 1"
+    "SELECT agent_id FROM agents WHERE last_heartbeat >= datetime('now', '-1 hour') ORDER BY last_heartbeat DESC LIMIT 1"
   ).get();
   if (agent) {
-    core.db.prepare('UPDATE dv_bugs SET assignee = ? WHERE id = ?').run(agent.agent_id, bugId);
+    core.db.prepare('UPDATE bugs SET assignee = ? WHERE id = ?').run(agent.agent_id, bugId);
   }
   return agent ? agent.agent_id : null;
 }

--- a/server/plugins/error-monitor/schema.sql
+++ b/server/plugins/error-monitor/schema.sql
@@ -1,7 +1,7 @@
 -- Plugin: error-monitor
 -- Stores raw error events from Sentry, Bugsnag, and Datadog webhooks
 
-CREATE TABLE IF NOT EXISTS dv_error_events (
+CREATE TABLE IF NOT EXISTS error_events (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   provider    TEXT NOT NULL DEFAULT '',
   error_key   TEXT NOT NULL DEFAULT '',
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS dv_error_events (
   updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_error_events_error_key ON dv_error_events(error_key);
-CREATE INDEX IF NOT EXISTS idx_error_events_provider ON dv_error_events(provider);
-CREATE INDEX IF NOT EXISTS idx_error_events_status ON dv_error_events(status);
-CREATE INDEX IF NOT EXISTS idx_error_events_bug_id ON dv_error_events(bug_id);
+CREATE INDEX IF NOT EXISTS idx_error_events_error_key ON error_events(error_key);
+CREATE INDEX IF NOT EXISTS idx_error_events_provider ON error_events(provider);
+CREATE INDEX IF NOT EXISTS idx_error_events_status ON error_events(status);
+CREATE INDEX IF NOT EXISTS idx_error_events_bug_id ON error_events(bug_id);

--- a/server/plugins/github-sync/README.md
+++ b/server/plugins/github-sync/README.md
@@ -59,7 +59,7 @@ All routes are prefixed with `/github`.
 
 ## Database Tables
 
-### `dv_github_events`
+### `github_events`
 Log of all received GitHub webhook events.
 
 | Column | Type | Description |
@@ -72,7 +72,7 @@ Log of all received GitHub webhook events.
 | processed | INTEGER | 0 = pending, 1 = processed |
 | created_at | TEXT | Timestamp |
 
-### `dv_github_links`
+### `github_links`
 Entity links between GitHub and Mycelium.
 
 | Column | Type | Description |

--- a/server/plugins/github-sync/db.js
+++ b/server/plugins/github-sync/db.js
@@ -4,7 +4,7 @@ export default function createGithubDB(db) {
   return {
     logEvent(eventType, action, repo, payload) {
       var r = db.prepare(
-        'INSERT INTO dv_github_events (event_type, action, repo, payload) VALUES (?, ?, ?, ?) RETURNING id'
+        'INSERT INTO github_events (event_type, action, repo, payload) VALUES (?, ?, ?, ?) RETURNING id'
       ).get(
         eventType || '',
         action || '',
@@ -15,7 +15,7 @@ export default function createGithubDB(db) {
     },
 
     getEvent(id) {
-      var row = db.prepare('SELECT * FROM dv_github_events WHERE id = ?').get(id);
+      var row = db.prepare('SELECT * FROM github_events WHERE id = ?').get(id);
       if (!row) return null;
       try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
       return row;
@@ -30,7 +30,7 @@ export default function createGithubDB(db) {
       var limit = Math.min(filters.limit || 50, 200);
       var offset = filters.offset || 0;
       var rows = db.prepare(
-        'SELECT * FROM dv_github_events WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
+        'SELECT * FROM github_events WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
       ).all(...params, limit, offset);
       return rows.map(function (row) {
         try { row.payload = JSON.parse(row.payload); } catch (e) { row.payload = {}; }
@@ -39,12 +39,12 @@ export default function createGithubDB(db) {
     },
 
     markProcessed(id) {
-      db.prepare('UPDATE dv_github_events SET processed = 1 WHERE id = ?').run(id);
+      db.prepare('UPDATE github_events SET processed = 1 WHERE id = ?').run(id);
     },
 
     createLink(githubType, githubRepo, githubNumber, myceliumType, myceliumId) {
       var r = db.prepare(
-        'INSERT INTO dv_github_links (github_type, github_repo, github_number, mycelium_type, mycelium_id) VALUES (?, ?, ?, ?, ?) RETURNING id'
+        'INSERT INTO github_links (github_type, github_repo, github_number, mycelium_type, mycelium_id) VALUES (?, ?, ?, ?, ?) RETURNING id'
       ).get(
         githubType || '',
         githubRepo || '',
@@ -57,13 +57,13 @@ export default function createGithubDB(db) {
 
     getLink(githubType, githubRepo, githubNumber) {
       return db.prepare(
-        'SELECT * FROM dv_github_links WHERE github_type = ? AND github_repo = ? AND github_number = ?'
+        'SELECT * FROM github_links WHERE github_type = ? AND github_repo = ? AND github_number = ?'
       ).get(githubType, githubRepo, githubNumber) || null;
     },
 
     getLinkByMycelium(myceliumType, myceliumId) {
       return db.prepare(
-        'SELECT * FROM dv_github_links WHERE mycelium_type = ? AND mycelium_id = ?'
+        'SELECT * FROM github_links WHERE mycelium_type = ? AND mycelium_id = ?'
       ).get(myceliumType, myceliumId) || null;
     },
 
@@ -76,24 +76,24 @@ export default function createGithubDB(db) {
       var limit = Math.min(filters.limit || 50, 200);
       var offset = filters.offset || 0;
       return db.prepare(
-        'SELECT * FROM dv_github_links WHERE ' + where.join(' AND ') + ' ORDER BY synced_at DESC LIMIT ? OFFSET ?'
+        'SELECT * FROM github_links WHERE ' + where.join(' AND ') + ' ORDER BY synced_at DESC LIMIT ? OFFSET ?'
       ).all(...params, limit, offset);
     },
 
     deleteLink(id) {
-      db.prepare('DELETE FROM dv_github_links WHERE id = ?').run(id);
+      db.prepare('DELETE FROM github_links WHERE id = ?').run(id);
     },
 
     getStats() {
       var eventCounts = db.prepare(
-        'SELECT event_type, COUNT(*) as count FROM dv_github_events GROUP BY event_type'
+        'SELECT event_type, COUNT(*) as count FROM github_events GROUP BY event_type'
       ).all();
       var linkCounts = db.prepare(
-        'SELECT github_type, COUNT(*) as count FROM dv_github_links GROUP BY github_type'
+        'SELECT github_type, COUNT(*) as count FROM github_links GROUP BY github_type'
       ).all();
-      var totalEvents = db.prepare('SELECT COUNT(*) as count FROM dv_github_events').get().count;
-      var totalLinks = db.prepare('SELECT COUNT(*) as count FROM dv_github_links').get().count;
-      var unprocessed = db.prepare('SELECT COUNT(*) as count FROM dv_github_events WHERE processed = 0').get().count;
+      var totalEvents = db.prepare('SELECT COUNT(*) as count FROM github_events').get().count;
+      var totalLinks = db.prepare('SELECT COUNT(*) as count FROM github_links').get().count;
+      var unprocessed = db.prepare('SELECT COUNT(*) as count FROM github_events WHERE processed = 0').get().count;
       return {
         total_events: totalEvents,
         total_links: totalLinks,

--- a/server/plugins/github-sync/routes.js
+++ b/server/plugins/github-sync/routes.js
@@ -301,7 +301,7 @@ function handleIssue(core, db, payload, action, repo, eventId) {
     // Auto-create a Mycelium bug from the GitHub issue
     try {
       var bugResult = core.db.prepare(
-        "INSERT INTO dv_bugs (title, description, project_id, category, severity, status) VALUES (?, ?, ?, ?, ?, ?) RETURNING id"
+        "INSERT INTO bugs (title, description, project_id, category, severity, status) VALUES (?, ?, ?, ?, ?, ?) RETURNING id"
       ).get(
         '[GH] ' + title,
         body + '\n\n---\nSource: ' + repo + '#' + number + (issue.html_url ? '\n' + issue.html_url : ''),
@@ -408,7 +408,7 @@ function handleIssueComment(core, db, payload, action, repo, eventId) {
 }
 
 function getConfig(db, key) {
-  var row = db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'github-sync' AND key = ?").get(key);
+  var row = db.prepare("SELECT value FROM plugin_config WHERE plugin_name = 'github-sync' AND key = ?").get(key);
   return row ? row.value : null;
 }
 

--- a/server/plugins/github-sync/schema.sql
+++ b/server/plugins/github-sync/schema.sql
@@ -1,7 +1,7 @@
 -- GitHub Sync plugin schema
 -- Webhook event log and entity link mapping between GitHub and Mycelium.
 
-CREATE TABLE IF NOT EXISTS dv_github_events (
+CREATE TABLE IF NOT EXISTS github_events (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   event_type  TEXT NOT NULL DEFAULT '',           -- 'push', 'pull_request', 'issues', etc.
   action      TEXT NOT NULL DEFAULT '',           -- 'opened', 'closed', 'merged', etc.
@@ -11,11 +11,11 @@ CREATE TABLE IF NOT EXISTS dv_github_events (
   created_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_github_events_repo ON dv_github_events(repo);
-CREATE INDEX IF NOT EXISTS idx_dv_github_events_type ON dv_github_events(event_type);
-CREATE INDEX IF NOT EXISTS idx_dv_github_events_created ON dv_github_events(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_github_events_repo ON github_events(repo);
+CREATE INDEX IF NOT EXISTS idx_github_events_type ON github_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_github_events_created ON github_events(created_at DESC);
 
-CREATE TABLE IF NOT EXISTS dv_github_links (
+CREATE TABLE IF NOT EXISTS github_links (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   github_type     TEXT NOT NULL DEFAULT '',        -- 'pr', 'issue', 'check'
   github_repo     TEXT NOT NULL DEFAULT '',        -- 'owner/repo'
@@ -25,6 +25,6 @@ CREATE TABLE IF NOT EXISTS dv_github_links (
   synced_at       TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_github_links_repo ON dv_github_links(github_repo);
-CREATE INDEX IF NOT EXISTS idx_dv_github_links_github ON dv_github_links(github_type, github_number);
-CREATE INDEX IF NOT EXISTS idx_dv_github_links_mycelium ON dv_github_links(mycelium_type, mycelium_id);
+CREATE INDEX IF NOT EXISTS idx_github_links_repo ON github_links(github_repo);
+CREATE INDEX IF NOT EXISTS idx_github_links_github ON github_links(github_type, github_number);
+CREATE INDEX IF NOT EXISTS idx_github_links_mycelium ON github_links(mycelium_type, mycelium_id);

--- a/server/plugins/guardrails/README.md
+++ b/server/plugins/guardrails/README.md
@@ -58,6 +58,6 @@ Rules use a `conditions` JSON object with a `type` field:
 
 ## Database Tables
 
-**`dv_guardrail_rules`** -- Rule definitions (name, trigger_event, conditions JSON, enforcement, project_id, enabled).
+**`guardrail_rules`** -- Rule definitions (name, trigger_event, conditions JSON, enforcement, project_id, enabled).
 
-**`dv_guardrail_violations`** -- Violation log (rule_id, trigger_event, agent_id, project_id, enforcement, event_data JSON, violation_detail, overridden flag).
+**`guardrail_violations`** -- Violation log (rule_id, trigger_event, agent_id, project_id, enforcement, event_data JSON, violation_detail, overridden flag).

--- a/server/plugins/guardrails/db.js
+++ b/server/plugins/guardrails/db.js
@@ -5,7 +5,7 @@ export default function createGuardrailsDB(db) {
     createRule(name, description, triggerEvent, conditions, enforcement, projectId, createdBy) {
       var conditionsJson = typeof conditions === 'string' ? conditions : JSON.stringify(conditions);
       var r = db.prepare(
-        'INSERT INTO dv_guardrail_rules (name, description, trigger_event, conditions, enforcement, project_id, created_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
+        'INSERT INTO guardrail_rules (name, description, trigger_event, conditions, enforcement, project_id, created_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
       ).get(
         name, description || '', triggerEvent, conditionsJson,
         enforcement || 'warn', projectId || null, createdBy || ''
@@ -14,7 +14,7 @@ export default function createGuardrailsDB(db) {
     },
 
     getRule(id) {
-      var row = db.prepare('SELECT * FROM dv_guardrail_rules WHERE id = ?').get(id);
+      var row = db.prepare('SELECT * FROM guardrail_rules WHERE id = ?').get(id);
       if (row && row.conditions) {
         try { row.conditions = JSON.parse(row.conditions); } catch (e) { /* keep as string */ }
       }
@@ -28,7 +28,7 @@ export default function createGuardrailsDB(db) {
       if (filters.trigger_event) { where.push('trigger_event = ?'); params.push(filters.trigger_event); }
       if (filters.project_id) { where.push('project_id = ?'); params.push(filters.project_id); }
 
-      var sql = 'SELECT * FROM dv_guardrail_rules WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC';
+      var sql = 'SELECT * FROM guardrail_rules WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC';
       var stmt = db.prepare(sql);
       var rows = params.length > 0 ? stmt.all.apply(stmt, params) : stmt.all();
 
@@ -58,19 +58,19 @@ export default function createGuardrailsDB(db) {
 
       sets.push("updated_at = datetime('now')");
       params.push(id);
-      var sql = 'UPDATE dv_guardrail_rules SET ' + sets.join(', ') + ' WHERE id = ?';
+      var sql = 'UPDATE guardrail_rules SET ' + sets.join(', ') + ' WHERE id = ?';
       var stmt = db.prepare(sql);
       stmt.run.apply(stmt, params);
     },
 
     deleteRule(id) {
-      db.prepare('DELETE FROM dv_guardrail_rules WHERE id = ?').run(id);
+      db.prepare('DELETE FROM guardrail_rules WHERE id = ?').run(id);
     },
 
     logViolation(ruleId, ruleName, triggerEvent, agentId, projectId, enforcement, eventData, violationDetail) {
       var eventDataJson = typeof eventData === 'string' ? eventData : JSON.stringify(eventData);
       var r = db.prepare(
-        'INSERT INTO dv_guardrail_violations (rule_id, rule_name, trigger_event, agent_id, project_id, enforcement, event_data, violation_detail) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id'
+        'INSERT INTO guardrail_violations (rule_id, rule_name, trigger_event, agent_id, project_id, enforcement, event_data, violation_detail) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id'
       ).get(
         ruleId, ruleName, triggerEvent, agentId || '', projectId || '',
         enforcement, eventDataJson, violationDetail || ''
@@ -79,7 +79,7 @@ export default function createGuardrailsDB(db) {
     },
 
     getViolation(id) {
-      var row = db.prepare('SELECT * FROM dv_guardrail_violations WHERE id = ?').get(id);
+      var row = db.prepare('SELECT * FROM guardrail_violations WHERE id = ?').get(id);
       if (row && row.event_data) {
         try { row.event_data = JSON.parse(row.event_data); } catch (e) { /* keep as string */ }
       }
@@ -97,7 +97,7 @@ export default function createGuardrailsDB(db) {
       var offset = filters.offset || 0;
       params.push(limit, offset);
 
-      var sql = 'SELECT * FROM dv_guardrail_violations WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?';
+      var sql = 'SELECT * FROM guardrail_violations WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?';
       var stmt = db.prepare(sql);
       var rows = stmt.all.apply(stmt, params);
 
@@ -111,21 +111,21 @@ export default function createGuardrailsDB(db) {
 
     overrideViolation(id, overriddenBy) {
       db.prepare(
-        'UPDATE dv_guardrail_violations SET overridden = 1, overridden_by = ? WHERE id = ?'
+        'UPDATE guardrail_violations SET overridden = 1, overridden_by = ? WHERE id = ?'
       ).run(overriddenBy || '', id);
     },
 
     getStats() {
       var byEnforcement = db.prepare(
-        'SELECT enforcement, COUNT(*) as count FROM dv_guardrail_violations GROUP BY enforcement'
+        'SELECT enforcement, COUNT(*) as count FROM guardrail_violations GROUP BY enforcement'
       ).all();
 
       var byRule = db.prepare(
-        'SELECT rule_id, rule_name, enforcement, COUNT(*) as count FROM dv_guardrail_violations GROUP BY rule_id, rule_name, enforcement ORDER BY count DESC'
+        'SELECT rule_id, rule_name, enforcement, COUNT(*) as count FROM guardrail_violations GROUP BY rule_id, rule_name, enforcement ORDER BY count DESC'
       ).all();
 
       var last24h = db.prepare(
-        "SELECT COUNT(*) as count FROM dv_guardrail_violations WHERE created_at >= datetime('now', '-1 day')"
+        "SELECT COUNT(*) as count FROM guardrail_violations WHERE created_at >= datetime('now', '-1 day')"
       ).get();
 
       return {
@@ -138,7 +138,7 @@ export default function createGuardrailsDB(db) {
     getTopViolators(limit) {
       var lim = limit || 10;
       return db.prepare(
-        'SELECT agent_id, COUNT(*) as violation_count FROM dv_guardrail_violations WHERE agent_id != \'\' GROUP BY agent_id ORDER BY violation_count DESC LIMIT ?'
+        'SELECT agent_id, COUNT(*) as violation_count FROM guardrail_violations WHERE agent_id != \'\' GROUP BY agent_id ORDER BY violation_count DESC LIMIT ?'
       ).all(lim);
     }
   };

--- a/server/plugins/guardrails/handlers.js
+++ b/server/plugins/guardrails/handlers.js
@@ -37,7 +37,7 @@ export function registerHooks(core) {
             { rule_id: rule.id, agent: agentId });
         }
 
-        var notifyConfig = core.db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'guardrails' AND key = 'notify_on_violation'").get();
+        var notifyConfig = core.db.prepare("SELECT value FROM plugin_config WHERE plugin_name = 'guardrails' AND key = 'notify_on_violation'").get();
         if (!notifyConfig || notifyConfig.value !== 'false') {
           core.inbox.createInboxItemForAllOperators(
             'guardrail_violation', 'guardrail_rule', String(rule.id),

--- a/server/plugins/guardrails/schema.sql
+++ b/server/plugins/guardrails/schema.sql
@@ -1,7 +1,7 @@
 -- Plugin: guardrails
 -- Pre-action quality checks and rule enforcement.
 
-CREATE TABLE IF NOT EXISTS dv_guardrail_rules (
+CREATE TABLE IF NOT EXISTS guardrail_rules (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   name            TEXT NOT NULL,
   description     TEXT DEFAULT '',
@@ -15,9 +15,9 @@ CREATE TABLE IF NOT EXISTS dv_guardrail_rules (
   updated_at      TEXT DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_guardrail_rules_trigger ON dv_guardrail_rules(trigger_event);
+CREATE INDEX IF NOT EXISTS idx_guardrail_rules_trigger ON guardrail_rules(trigger_event);
 
-CREATE TABLE IF NOT EXISTS dv_guardrail_violations (
+CREATE TABLE IF NOT EXISTS guardrail_violations (
   id                INTEGER PRIMARY KEY AUTOINCREMENT,
   rule_id           INTEGER NOT NULL,
   rule_name         TEXT NOT NULL,
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS dv_guardrail_violations (
   created_at        TEXT DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_guardrail_violations_rule ON dv_guardrail_violations(rule_id);
-CREATE INDEX IF NOT EXISTS idx_guardrail_violations_agent ON dv_guardrail_violations(agent_id);
-CREATE INDEX IF NOT EXISTS idx_guardrail_violations_project ON dv_guardrail_violations(project_id);
-CREATE INDEX IF NOT EXISTS idx_guardrail_violations_created ON dv_guardrail_violations(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_guardrail_violations_rule ON guardrail_violations(rule_id);
+CREATE INDEX IF NOT EXISTS idx_guardrail_violations_agent ON guardrail_violations(agent_id);
+CREATE INDEX IF NOT EXISTS idx_guardrail_violations_project ON guardrail_violations(project_id);
+CREATE INDEX IF NOT EXISTS idx_guardrail_violations_created ON guardrail_violations(created_at DESC);

--- a/server/plugins/outreach/README.md
+++ b/server/plugins/outreach/README.md
@@ -70,7 +70,7 @@ All routes are prefixed with `/api/mycelium/outreach`.
 
 ## Database Tables
 
-**`dv_outreach_campaigns`** -- Campaign configuration for outreach runs.
+**`outreach_campaigns`** -- Campaign configuration for outreach runs.
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -84,7 +84,7 @@ All routes are prefixed with `/api/mycelium/outreach`.
 | status | TEXT | active, paused, completed |
 | created_by | TEXT | Who created the campaign |
 
-**`dv_outreach_contacts`** -- Press, creator, and influencer contacts.
+**`outreach_contacts`** -- Press, creator, and influencer contacts.
 
 | Column | Type | Description |
 |--------|------|-------------|

--- a/server/plugins/outreach/db.js
+++ b/server/plugins/outreach/db.js
@@ -9,13 +9,13 @@ export default function createOutreachDB(db) {
 
   return {
     createCampaign(projectId, name, personaPrompt, projectFacts, templates, config, createdBy) {
-      var result = stmt('orCreateCampaign', `INSERT INTO dv_outreach_campaigns (project_id, name, persona_prompt, project_facts, templates, config, created_by)
+      var result = stmt('orCreateCampaign', `INSERT INTO outreach_campaigns (project_id, name, persona_prompt, project_facts, templates, config, created_by)
         VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id`).get(projectId, name, personaPrompt || '', projectFacts || '', templates || '{}', config || '{}', createdBy || '');
       return result.id;
     },
 
     getCampaign(id) {
-      return stmt('orGetCampaign', 'SELECT * FROM dv_outreach_campaigns WHERE id = ?').get(id);
+      return stmt('orGetCampaign', 'SELECT * FROM outreach_campaigns WHERE id = ?').get(id);
     },
 
     listCampaigns(filters) {
@@ -23,7 +23,7 @@ export default function createOutreachDB(db) {
       if (filters.project_id) { where.push('project_id = ?'); params.push(filters.project_id); }
       if (filters.status) { where.push('status = ?'); params.push(filters.status); }
       params.push(filters.limit || 50);
-      return db.prepare('SELECT * FROM dv_outreach_campaigns WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
+      return db.prepare('SELECT * FROM outreach_campaigns WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
     },
 
     updateCampaign(id, fields) {
@@ -32,11 +32,11 @@ export default function createOutreachDB(db) {
         if (fields[key] !== undefined) { sets.push(key + ' = ?'); values.push(fields[key]); }
       }
       values.push(id);
-      return db.prepare('UPDATE dv_outreach_campaigns SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      return db.prepare('UPDATE outreach_campaigns SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     createContact(fields) {
-      var result = db.prepare(`INSERT INTO dv_outreach_contacts
+      var result = db.prepare(`INSERT INTO outreach_contacts
         (project_id, campaign_id, type, name, email, outlet, tier, archetype, subscriber_count, status, last_content, notes, metadata, created_by)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`).get(
         fields.project_id, fields.campaign_id || null, fields.type || 'creator', fields.name,
@@ -48,7 +48,7 @@ export default function createOutreachDB(db) {
     },
 
     getContact(id) {
-      return stmt('orGetContact', 'SELECT * FROM dv_outreach_contacts WHERE id = ?').get(id);
+      return stmt('orGetContact', 'SELECT * FROM outreach_contacts WHERE id = ?').get(id);
     },
 
     listContacts(filters) {
@@ -60,7 +60,7 @@ export default function createOutreachDB(db) {
       var limit = filters.limit || 50;
       var offset = filters.offset || 0;
       params.push(limit, offset);
-      return db.prepare('SELECT * FROM dv_outreach_contacts WHERE ' + where.join(' AND ') + ' ORDER BY updated_at DESC LIMIT ? OFFSET ?').all(...params);
+      return db.prepare('SELECT * FROM outreach_contacts WHERE ' + where.join(' AND ') + ' ORDER BY updated_at DESC LIMIT ? OFFSET ?').all(...params);
     },
 
     updateContact(id, fields) {
@@ -72,16 +72,16 @@ export default function createOutreachDB(db) {
         if (fields[key] !== undefined) { sets.push(key + ' = ?'); values.push(fields[key]); }
       }
       values.push(id);
-      return db.prepare('UPDATE dv_outreach_contacts SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      return db.prepare('UPDATE outreach_contacts SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     deleteContact(id) {
-      return db.prepare('DELETE FROM dv_outreach_contacts WHERE id = ?').run(id);
+      return db.prepare('DELETE FROM outreach_contacts WHERE id = ?').run(id);
     },
 
     countContacts(projectId) {
       var rows = db.prepare(
-        'SELECT status, COUNT(*) as count FROM dv_outreach_contacts WHERE project_id = ? GROUP BY status'
+        'SELECT status, COUNT(*) as count FROM outreach_contacts WHERE project_id = ? GROUP BY status'
       ).all(projectId);
       var counts = {};
       for (var r of rows) counts[r.status] = r.count;
@@ -89,7 +89,7 @@ export default function createOutreachDB(db) {
     },
 
     findContactByEmail(projectId, email) {
-      return db.prepare('SELECT * FROM dv_outreach_contacts WHERE project_id = ? AND email = ?').get(projectId, email);
+      return db.prepare('SELECT * FROM outreach_contacts WHERE project_id = ? AND email = ?').get(projectId, email);
     }
   };
 }

--- a/server/plugins/outreach/schema.sql
+++ b/server/plugins/outreach/schema.sql
@@ -1,5 +1,5 @@
 -- Outreach campaigns (per-project config for press/creator outreach)
-CREATE TABLE IF NOT EXISTS dv_outreach_campaigns (
+CREATE TABLE IF NOT EXISTS outreach_campaigns (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   project_id      TEXT NOT NULL,
   name            TEXT NOT NULL,
@@ -14,10 +14,10 @@ CREATE TABLE IF NOT EXISTS dv_outreach_campaigns (
 );
 
 -- Outreach contacts (press, creators, influencers)
-CREATE TABLE IF NOT EXISTS dv_outreach_contacts (
+CREATE TABLE IF NOT EXISTS outreach_contacts (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   project_id      TEXT NOT NULL,
-  campaign_id     INTEGER REFERENCES dv_outreach_campaigns(id),
+  campaign_id     INTEGER REFERENCES outreach_campaigns(id),
   type            TEXT NOT NULL DEFAULT 'creator',
   name            TEXT NOT NULL,
   email           TEXT NOT NULL DEFAULT '',
@@ -42,11 +42,11 @@ CREATE TABLE IF NOT EXISTS dv_outreach_contacts (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_outreach_campaigns_project ON dv_outreach_campaigns(project_id);
-CREATE INDEX IF NOT EXISTS idx_outreach_campaigns_status ON dv_outreach_campaigns(status);
-CREATE INDEX IF NOT EXISTS idx_outreach_contacts_project ON dv_outreach_contacts(project_id);
-CREATE INDEX IF NOT EXISTS idx_outreach_contacts_status ON dv_outreach_contacts(status);
-CREATE INDEX IF NOT EXISTS idx_outreach_contacts_campaign ON dv_outreach_contacts(campaign_id);
-CREATE INDEX IF NOT EXISTS idx_outreach_contacts_email ON dv_outreach_contacts(email);
-CREATE INDEX IF NOT EXISTS idx_outreach_contacts_outlet ON dv_outreach_contacts(outlet);
-CREATE INDEX IF NOT EXISTS idx_outreach_contacts_tier ON dv_outreach_contacts(tier);
+CREATE INDEX IF NOT EXISTS idx_outreach_campaigns_project ON outreach_campaigns(project_id);
+CREATE INDEX IF NOT EXISTS idx_outreach_campaigns_status ON outreach_campaigns(status);
+CREATE INDEX IF NOT EXISTS idx_outreach_contacts_project ON outreach_contacts(project_id);
+CREATE INDEX IF NOT EXISTS idx_outreach_contacts_status ON outreach_contacts(status);
+CREATE INDEX IF NOT EXISTS idx_outreach_contacts_campaign ON outreach_contacts(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_outreach_contacts_email ON outreach_contacts(email);
+CREATE INDEX IF NOT EXISTS idx_outreach_contacts_outlet ON outreach_contacts(outlet);
+CREATE INDEX IF NOT EXISTS idx_outreach_contacts_tier ON outreach_contacts(tier);

--- a/server/plugins/social-posting/README.md
+++ b/server/plugins/social-posting/README.md
@@ -55,7 +55,7 @@ All routes are prefixed with `/api/mycelium/social`.
 
 ## Database Tables
 
-**`dv_social_accounts`** -- Registered social media accounts with platform credentials.
+**`social_accounts`** -- Registered social media accounts with platform credentials.
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -67,13 +67,13 @@ All routes are prefixed with `/api/mycelium/social`.
 | config | TEXT (JSON) | Account-specific config |
 | enabled | INTEGER | 1 = active |
 
-**`dv_social_posts`** -- Post queue with scheduling and publishing state.
+**`social_posts`** -- Post queue with scheduling and publishing state.
 
 | Column | Type | Description |
 |--------|------|-------------|
 | id | INTEGER PK | Auto-increment |
 | project_id | TEXT | Project identifier |
-| account_id | INTEGER FK | Links to dv_social_accounts |
+| account_id | INTEGER FK | Links to social_accounts |
 | platform | TEXT | Target platform |
 | clip_id | TEXT | Video pipeline clip ID (tracking) |
 | video_session_id | INTEGER | Video pipeline session ID |

--- a/server/plugins/social-posting/db.js
+++ b/server/plugins/social-posting/db.js
@@ -10,7 +10,7 @@ export default function createSocialDB(db) {
     // ── Accounts ──
     createAccount(projectId, platform, accountName, credentials, config) {
       var result = stmt('spCreateAcct',
-        `INSERT INTO dv_social_accounts (project_id, platform, account_name, credentials, config)
+        `INSERT INTO social_accounts (project_id, platform, account_name, credentials, config)
          VALUES (?, ?, ?, ?, ?) RETURNING id`
       ).get(projectId, platform, accountName || '',
         typeof credentials === 'string' ? credentials : JSON.stringify(credentials || {}),
@@ -19,14 +19,14 @@ export default function createSocialDB(db) {
     },
 
     getAccount(id) {
-      return stmt('spGetAcct', 'SELECT * FROM dv_social_accounts WHERE id = ?').get(id);
+      return stmt('spGetAcct', 'SELECT * FROM social_accounts WHERE id = ?').get(id);
     },
 
     listAccounts(projectId) {
       if (projectId) {
-        return stmt('spListAcctP', 'SELECT * FROM dv_social_accounts WHERE project_id = ? ORDER BY platform').all(projectId);
+        return stmt('spListAcctP', 'SELECT * FROM social_accounts WHERE project_id = ? ORDER BY platform').all(projectId);
       }
-      return db.prepare('SELECT * FROM dv_social_accounts ORDER BY project_id, platform').all();
+      return db.prepare('SELECT * FROM social_accounts ORDER BY project_id, platform').all();
     },
 
     updateAccount(id, fields) {
@@ -39,17 +39,17 @@ export default function createSocialDB(db) {
         }
       }
       values.push(id);
-      return db.prepare('UPDATE dv_social_accounts SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      return db.prepare('UPDATE social_accounts SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     deleteAccount(id) {
-      return db.prepare('DELETE FROM dv_social_accounts WHERE id = ?').run(id);
+      return db.prepare('DELETE FROM social_accounts WHERE id = ?').run(id);
     },
 
     // ── Posts ──
     createPost(fields) {
       var result = db.prepare(
-        `INSERT INTO dv_social_posts (project_id, account_id, platform, clip_id, video_session_id,
+        `INSERT INTO social_posts (project_id, account_id, platform, clip_id, video_session_id,
          event_type, tier, caption, media_url, status, scheduled_at, created_by)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`
       ).get(
@@ -64,7 +64,7 @@ export default function createSocialDB(db) {
     },
 
     getPost(id) {
-      return stmt('spGetPost', 'SELECT * FROM dv_social_posts WHERE id = ?').get(id);
+      return stmt('spGetPost', 'SELECT * FROM social_posts WHERE id = ?').get(id);
     },
 
     listPosts(filters) {
@@ -74,7 +74,7 @@ export default function createSocialDB(db) {
       if (filters.status) { where.push('status = ?'); params.push(filters.status); }
       if (filters.video_session_id) { where.push('video_session_id = ?'); params.push(filters.video_session_id); }
       params.push(filters.limit || 50);
-      return db.prepare('SELECT * FROM dv_social_posts WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
+      return db.prepare('SELECT * FROM social_posts WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
     },
 
     updatePost(id, fields) {
@@ -88,30 +88,30 @@ export default function createSocialDB(db) {
         }
       }
       values.push(id);
-      return db.prepare('UPDATE dv_social_posts SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      return db.prepare('UPDATE social_posts SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     deletePost(id) {
-      return db.prepare('DELETE FROM dv_social_posts WHERE id = ?').run(id);
+      return db.prepare('DELETE FROM social_posts WHERE id = ?').run(id);
     },
 
     // ── Scheduling ──
     getScheduledPosts(platform) {
       var where = ["status = 'scheduled'"]; var params = [];
       if (platform) { where.push('platform = ?'); params.push(platform); }
-      return db.prepare('SELECT * FROM dv_social_posts WHERE ' + where.join(' AND ') + ' ORDER BY scheduled_at ASC').all(...params);
+      return db.prepare('SELECT * FROM social_posts WHERE ' + where.join(' AND ') + ' ORDER BY scheduled_at ASC').all(...params);
     },
 
     getPostHistory(projectId, platform, days) {
       var since = new Date(Date.now() - (days || 7) * 86400000).toISOString().slice(0, 10);
       var where = ['project_id = ?', "posted_at >= ?"]; var params = [projectId, since];
       if (platform) { where.push('platform = ?'); params.push(platform); }
-      return db.prepare('SELECT * FROM dv_social_posts WHERE ' + where.join(' AND ') + " AND status = 'posted' ORDER BY posted_at DESC").all(...params);
+      return db.prepare('SELECT * FROM social_posts WHERE ' + where.join(' AND ') + " AND status = 'posted' ORDER BY posted_at DESC").all(...params);
     },
 
     getPostStats(projectId) {
       var rows = db.prepare(
-        'SELECT platform, status, COUNT(*) as count FROM dv_social_posts WHERE project_id = ? GROUP BY platform, status'
+        'SELECT platform, status, COUNT(*) as count FROM social_posts WHERE project_id = ? GROUP BY platform, status'
       ).all(projectId);
       var stats = {};
       for (var r of rows) {

--- a/server/plugins/social-posting/routes.js
+++ b/server/plugins/social-posting/routes.js
@@ -37,7 +37,7 @@ var DEFAULT_WINDOWS = {
 
 function getConfigValue(core, key) {
   try {
-    var row = core.db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'social-posting' AND key = ?").get(key);
+    var row = core.db.prepare("SELECT value FROM plugin_config WHERE plugin_name = 'social-posting' AND key = ?").get(key);
     return row ? row.value : null;
   } catch (e) { return null; }
 }

--- a/server/plugins/social-posting/schema.sql
+++ b/server/plugins/social-posting/schema.sql
@@ -1,6 +1,6 @@
 -- Social Posting plugin tables
 
-CREATE TABLE IF NOT EXISTS dv_social_accounts (
+CREATE TABLE IF NOT EXISTS social_accounts (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   project_id      TEXT NOT NULL,
   platform        TEXT NOT NULL,
@@ -12,10 +12,10 @@ CREATE TABLE IF NOT EXISTS dv_social_accounts (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE TABLE IF NOT EXISTS dv_social_posts (
+CREATE TABLE IF NOT EXISTS social_posts (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   project_id      TEXT NOT NULL,
-  account_id      INTEGER REFERENCES dv_social_accounts(id),
+  account_id      INTEGER REFERENCES social_accounts(id),
   platform        TEXT NOT NULL,
   clip_id         TEXT,
   video_session_id INTEGER,
@@ -34,8 +34,8 @@ CREATE TABLE IF NOT EXISTS dv_social_posts (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_social_accounts_project ON dv_social_accounts(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_social_posts_project ON dv_social_posts(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_social_posts_status ON dv_social_posts(status);
-CREATE INDEX IF NOT EXISTS idx_dv_social_posts_platform ON dv_social_posts(platform);
-CREATE INDEX IF NOT EXISTS idx_dv_social_posts_scheduled ON dv_social_posts(scheduled_at);
+CREATE INDEX IF NOT EXISTS idx_social_accounts_project ON social_accounts(project_id);
+CREATE INDEX IF NOT EXISTS idx_social_posts_project ON social_posts(project_id);
+CREATE INDEX IF NOT EXISTS idx_social_posts_status ON social_posts(status);
+CREATE INDEX IF NOT EXISTS idx_social_posts_platform ON social_posts(platform);
+CREATE INDEX IF NOT EXISTS idx_social_posts_scheduled ON social_posts(scheduled_at);

--- a/server/plugins/steam-assets/README.md
+++ b/server/plugins/steam-assets/README.md
@@ -41,7 +41,7 @@ All routes are prefixed with `/api/mycelium/steam`.
 
 ## Database Tables
 
-**`dv_steam_assets`** -- Steam asset generation tracking.
+**`steam_assets`** -- Steam asset generation tracking.
 
 | Column | Type | Description |
 |--------|------|-------------|

--- a/server/plugins/steam-assets/db.js
+++ b/server/plugins/steam-assets/db.js
@@ -9,7 +9,7 @@ export default function createSteamDB(db) {
   return {
     createAsset(projectId, assetType, title, config, createdBy) {
       var result = stmt('saCreate',
-        `INSERT INTO dv_steam_assets (project_id, asset_type, title, config, created_by)
+        `INSERT INTO steam_assets (project_id, asset_type, title, config, created_by)
          VALUES (?, ?, ?, ?, ?) RETURNING id`
       ).get(projectId, assetType, title,
         typeof config === 'string' ? config : JSON.stringify(config || {}), createdBy);
@@ -17,7 +17,7 @@ export default function createSteamDB(db) {
     },
 
     getAsset(id) {
-      return stmt('saGet', 'SELECT * FROM dv_steam_assets WHERE id = ?').get(id);
+      return stmt('saGet', 'SELECT * FROM steam_assets WHERE id = ?').get(id);
     },
 
     listAssets(filters) {
@@ -26,7 +26,7 @@ export default function createSteamDB(db) {
       if (filters.asset_type) { where.push('asset_type = ?'); params.push(filters.asset_type); }
       if (filters.status) { where.push('status = ?'); params.push(filters.status); }
       params.push(filters.limit || 50);
-      return db.prepare('SELECT * FROM dv_steam_assets WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
+      return db.prepare('SELECT * FROM steam_assets WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
     },
 
     updateAsset(id, fields) {
@@ -39,11 +39,11 @@ export default function createSteamDB(db) {
         }
       }
       values.push(id);
-      return db.prepare('UPDATE dv_steam_assets SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      return db.prepare('UPDATE steam_assets SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     deleteAsset(id) {
-      return db.prepare('DELETE FROM dv_steam_assets WHERE id = ?').run(id);
+      return db.prepare('DELETE FROM steam_assets WHERE id = ?').run(id);
     }
   };
 }

--- a/server/plugins/steam-assets/routes.js
+++ b/server/plugins/steam-assets/routes.js
@@ -8,7 +8,7 @@ var WORKER_REPO = 'https://github.com/SoftBacon-Software/wsac-agent';
 // No defaults — keeps the plugin project-agnostic.
 function getGameFacts(core) {
   try {
-    var row = core.db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'steam-assets' AND key = 'game_facts'").get();
+    var row = core.db.prepare("SELECT value FROM plugin_config WHERE plugin_name = 'steam-assets' AND key = 'game_facts'").get();
     return row ? JSON.parse(row.value) : null;
   } catch (e) { return null; }
 }

--- a/server/plugins/steam-assets/schema.sql
+++ b/server/plugins/steam-assets/schema.sql
@@ -1,6 +1,6 @@
 -- Steam Assets plugin tables
 
-CREATE TABLE IF NOT EXISTS dv_steam_assets (
+CREATE TABLE IF NOT EXISTS steam_assets (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   project_id      TEXT NOT NULL,
   asset_type      TEXT NOT NULL,
@@ -15,6 +15,6 @@ CREATE TABLE IF NOT EXISTS dv_steam_assets (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_steam_assets_project ON dv_steam_assets(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_steam_assets_type ON dv_steam_assets(asset_type);
-CREATE INDEX IF NOT EXISTS idx_dv_steam_assets_status ON dv_steam_assets(status);
+CREATE INDEX IF NOT EXISTS idx_steam_assets_project ON steam_assets(project_id);
+CREATE INDEX IF NOT EXISTS idx_steam_assets_type ON steam_assets(asset_type);
+CREATE INDEX IF NOT EXISTS idx_steam_assets_status ON steam_assets(status);

--- a/server/plugins/video-pipeline/README.md
+++ b/server/plugins/video-pipeline/README.md
@@ -52,7 +52,7 @@ All routes are prefixed with `/api/mycelium/video`.
 
 ## Database Tables
 
-**`dv_video_sessions`** -- Video processing sessions tracking footage through the pipeline.
+**`video_sessions`** -- Video processing sessions tracking footage through the pipeline.
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -70,7 +70,7 @@ All routes are prefixed with `/api/mycelium/video`.
 | result_data | TEXT (JSON) | Pipeline output data |
 | created_by | TEXT | Who created the session |
 
-**`dv_video_clips`** -- Individual highlight clips within a session.
+**`video_clips`** -- Individual highlight clips within a session.
 
 | Column | Type | Description |
 |--------|------|-------------|

--- a/server/plugins/video-pipeline/db.js
+++ b/server/plugins/video-pipeline/db.js
@@ -10,7 +10,7 @@ export default function createVideoDB(db) {
     // ── Sessions ──
     createSession(projectId, title, footageUrl, eventLogUrl, config, createdBy) {
       var result = stmt('vpCreateSession',
-        `INSERT INTO dv_video_sessions (project_id, title, footage_url, event_log_url, config, created_by)
+        `INSERT INTO video_sessions (project_id, title, footage_url, event_log_url, config, created_by)
          VALUES (?, ?, ?, ?, ?, ?) RETURNING id`
       ).get(projectId, title, footageUrl || '', eventLogUrl || '',
         typeof config === 'string' ? config : JSON.stringify(config || {}), createdBy);
@@ -18,7 +18,7 @@ export default function createVideoDB(db) {
     },
 
     getSession(id) {
-      return stmt('vpGetSession', 'SELECT * FROM dv_video_sessions WHERE id = ?').get(id);
+      return stmt('vpGetSession', 'SELECT * FROM video_sessions WHERE id = ?').get(id);
     },
 
     listSessions(filters) {
@@ -26,7 +26,7 @@ export default function createVideoDB(db) {
       if (filters.project_id) { where.push('project_id = ?'); params.push(filters.project_id); }
       if (filters.status) { where.push('status = ?'); params.push(filters.status); }
       params.push(filters.limit || 50);
-      return db.prepare('SELECT * FROM dv_video_sessions WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
+      return db.prepare('SELECT * FROM video_sessions WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all(...params);
     },
 
     updateSession(id, fields) {
@@ -40,18 +40,18 @@ export default function createVideoDB(db) {
         }
       }
       values.push(id);
-      return db.prepare('UPDATE dv_video_sessions SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      return db.prepare('UPDATE video_sessions SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     deleteSession(id) {
-      db.prepare('DELETE FROM dv_video_clips WHERE session_id = ?').run(id);
-      return db.prepare('DELETE FROM dv_video_sessions WHERE id = ?').run(id);
+      db.prepare('DELETE FROM video_clips WHERE session_id = ?').run(id);
+      return db.prepare('DELETE FROM video_sessions WHERE id = ?').run(id);
     },
 
     // ── Clips ──
     createClip(sessionId, clipId, tier, eventType, startSec, endSec, metadata) {
       var result = stmt('vpCreateClip',
-        `INSERT INTO dv_video_clips (session_id, clip_id, tier, event_type, start_sec, end_sec, duration_sec, metadata)
+        `INSERT INTO video_clips (session_id, clip_id, tier, event_type, start_sec, end_sec, duration_sec, metadata)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`
       ).get(sessionId, clipId, tier || 'C', eventType, startSec, endSec, endSec - startSec,
         typeof metadata === 'string' ? metadata : JSON.stringify(metadata || {}));
@@ -59,14 +59,14 @@ export default function createVideoDB(db) {
     },
 
     getClip(id) {
-      return stmt('vpGetClip', 'SELECT * FROM dv_video_clips WHERE id = ?').get(id);
+      return stmt('vpGetClip', 'SELECT * FROM video_clips WHERE id = ?').get(id);
     },
 
     listClips(sessionId, filters) {
       var where = ['session_id = ?']; var params = [sessionId];
       if (filters && filters.tier) { where.push('tier = ?'); params.push(filters.tier); }
       if (filters && filters.status) { where.push('status = ?'); params.push(filters.status); }
-      return db.prepare('SELECT * FROM dv_video_clips WHERE ' + where.join(' AND ') + ' ORDER BY start_sec ASC').all(...params);
+      return db.prepare('SELECT * FROM video_clips WHERE ' + where.join(' AND ') + ' ORDER BY start_sec ASC').all(...params);
     },
 
     updateClip(id, fields) {
@@ -79,12 +79,12 @@ export default function createVideoDB(db) {
         }
       }
       values.push(id);
-      return db.prepare('UPDATE dv_video_clips SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      return db.prepare('UPDATE video_clips SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     bulkCreateClips(sessionId, clips) {
       var insert = db.prepare(
-        `INSERT INTO dv_video_clips (session_id, clip_id, tier, event_type, start_sec, end_sec, duration_sec, metadata)
+        `INSERT INTO video_clips (session_id, clip_id, tier, event_type, start_sec, end_sec, duration_sec, metadata)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       );
       var insertMany = db.transaction(function (rows) {
@@ -97,17 +97,17 @@ export default function createVideoDB(db) {
       insertMany(clips);
       // Update session clip count
       stmt('vpUpdateClipCount',
-        'UPDATE dv_video_sessions SET clip_count = (SELECT COUNT(*) FROM dv_video_clips WHERE session_id = ?), updated_at = datetime(\'now\') WHERE id = ?'
+        'UPDATE video_sessions SET clip_count = (SELECT COUNT(*) FROM video_clips WHERE session_id = ?), updated_at = datetime(\'now\') WHERE id = ?'
       ).run(sessionId, sessionId);
       return clips.length;
     },
 
     getSessionStats(sessionId) {
       var tiers = db.prepare(
-        'SELECT tier, COUNT(*) as count FROM dv_video_clips WHERE session_id = ? GROUP BY tier'
+        'SELECT tier, COUNT(*) as count FROM video_clips WHERE session_id = ? GROUP BY tier'
       ).all(sessionId);
       var statuses = db.prepare(
-        'SELECT status, COUNT(*) as count FROM dv_video_clips WHERE session_id = ? GROUP BY status'
+        'SELECT status, COUNT(*) as count FROM video_clips WHERE session_id = ? GROUP BY status'
       ).all(sessionId);
       return { tiers: Object.fromEntries(tiers.map(function (r) { return [r.tier, r.count]; })),
                statuses: Object.fromEntries(statuses.map(function (r) { return [r.status, r.count]; })) };

--- a/server/plugins/video-pipeline/schema.sql
+++ b/server/plugins/video-pipeline/schema.sql
@@ -1,6 +1,6 @@
 -- Video Pipeline plugin tables
 
-CREATE TABLE IF NOT EXISTS dv_video_sessions (
+CREATE TABLE IF NOT EXISTS video_sessions (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   project_id      TEXT NOT NULL,
   title           TEXT NOT NULL,
@@ -18,9 +18,9 @@ CREATE TABLE IF NOT EXISTS dv_video_sessions (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE TABLE IF NOT EXISTS dv_video_clips (
+CREATE TABLE IF NOT EXISTS video_clips (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id      INTEGER NOT NULL REFERENCES dv_video_sessions(id),
+  session_id      INTEGER NOT NULL REFERENCES video_sessions(id),
   clip_id         TEXT NOT NULL,
   tier            TEXT NOT NULL DEFAULT 'C',
   event_type      TEXT NOT NULL,
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS dv_video_clips (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_video_sessions_project ON dv_video_sessions(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_video_sessions_status ON dv_video_sessions(status);
-CREATE INDEX IF NOT EXISTS idx_dv_video_clips_session ON dv_video_clips(session_id);
-CREATE INDEX IF NOT EXISTS idx_dv_video_clips_tier ON dv_video_clips(tier);
+CREATE INDEX IF NOT EXISTS idx_video_sessions_project ON video_sessions(project_id);
+CREATE INDEX IF NOT EXISTS idx_video_sessions_status ON video_sessions(status);
+CREATE INDEX IF NOT EXISTS idx_video_clips_session ON video_clips(session_id);
+CREATE INDEX IF NOT EXISTS idx_video_clips_tier ON video_clips(tier);

--- a/server/plugins/workflow-automations/README.md
+++ b/server/plugins/workflow-automations/README.md
@@ -82,8 +82,8 @@ Action string fields support template variables: `{{agent}}`, `{{event_type}}`, 
 
 ## Database Tables
 
-**`dv_automation_rules`** -- Rule definitions (name, trigger_event, conditions JSON, actions JSON, project_id, enabled, run_count, last_run).
+**`automation_rules`** -- Rule definitions (name, trigger_event, conditions JSON, actions JSON, project_id, enabled, run_count, last_run).
 
-**`dv_automation_log`** -- Execution log (rule_id, trigger_event, matched, actions_taken JSON, event_data JSON, status, error, dry_run).
+**`automation_log`** -- Execution log (rule_id, trigger_event, matched, actions_taken JSON, event_data JSON, status, error, dry_run).
 
-**`dv_automation_templates`** -- Built-in templates (name, trigger_event, conditions, actions, category). Seeded with 4 default templates.
+**`automation_templates`** -- Built-in templates (name, trigger_event, conditions, actions, category). Seeded with 4 default templates.

--- a/server/plugins/workflow-automations/db.js
+++ b/server/plugins/workflow-automations/db.js
@@ -4,7 +4,7 @@ export default function createAutomationDB(db) {
   return {
     createRule(name, description, triggerEvent, conditions, actions, projectId, createdBy) {
       var r = db.prepare(
-        'INSERT INTO dv_automation_rules (name, description, trigger_event, conditions, actions, project_id, created_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
+        'INSERT INTO automation_rules (name, description, trigger_event, conditions, actions, project_id, created_by) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id'
       ).get(
         name || '',
         description || '',
@@ -18,7 +18,7 @@ export default function createAutomationDB(db) {
     },
 
     getRule(id) {
-      var row = db.prepare('SELECT * FROM dv_automation_rules WHERE id = ?').get(id);
+      var row = db.prepare('SELECT * FROM automation_rules WHERE id = ?').get(id);
       if (!row) return null;
       try { row.conditions = JSON.parse(row.conditions); } catch (e) { row.conditions = {}; }
       try { row.actions = JSON.parse(row.actions); } catch (e) { row.actions = []; }
@@ -35,7 +35,7 @@ export default function createAutomationDB(db) {
       var offset = filters.offset || 0;
       params.push(limit, offset);
       var rows = db.prepare(
-        'SELECT * FROM dv_automation_rules WHERE ' + where.join(' AND ') +
+        'SELECT * FROM automation_rules WHERE ' + where.join(' AND ') +
         ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
       ).all(...params);
       return rows.map(function (row) {
@@ -58,20 +58,20 @@ export default function createAutomationDB(db) {
       if (sets.length === 0) return;
       sets.push("updated_at = datetime('now')");
       values.push(id);
-      db.prepare('UPDATE dv_automation_rules SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
+      db.prepare('UPDATE automation_rules SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
     },
 
     deleteRule(id) {
-      db.prepare('DELETE FROM dv_automation_rules WHERE id = ?').run(id);
+      db.prepare('DELETE FROM automation_rules WHERE id = ?').run(id);
     },
 
     incrementRunCount(id) {
-      db.prepare("UPDATE dv_automation_rules SET run_count = run_count + 1, last_run = datetime('now') WHERE id = ?").run(id);
+      db.prepare("UPDATE automation_rules SET run_count = run_count + 1, last_run = datetime('now') WHERE id = ?").run(id);
     },
 
     logExecution(ruleId, ruleName, triggerEvent, matched, actionsTaken, eventData, status, error, dryRun) {
       db.prepare(
-        'INSERT INTO dv_automation_log (rule_id, rule_name, trigger_event, matched, actions_taken, event_data, status, error, dry_run) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        'INSERT INTO automation_log (rule_id, rule_name, trigger_event, matched, actions_taken, event_data, status, error, dry_run) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
       ).run(
         ruleId,
         ruleName || '',
@@ -93,7 +93,7 @@ export default function createAutomationDB(db) {
       var limit = Math.min(filters.limit || 50, 500);
       params.push(limit);
       var rows = db.prepare(
-        'SELECT * FROM dv_automation_log WHERE ' + where.join(' AND ') +
+        'SELECT * FROM automation_log WHERE ' + where.join(' AND ') +
         ' ORDER BY created_at DESC LIMIT ?'
       ).all(...params);
       return rows.map(function (row) {
@@ -105,13 +105,13 @@ export default function createAutomationDB(db) {
 
     getLogStats() {
       var byStatus = db.prepare(
-        'SELECT status, COUNT(*) as count FROM dv_automation_log GROUP BY status'
+        'SELECT status, COUNT(*) as count FROM automation_log GROUP BY status'
       ).all();
       var byRule = db.prepare(
-        'SELECT rule_id, rule_name, COUNT(*) as count FROM dv_automation_log GROUP BY rule_id, rule_name ORDER BY count DESC LIMIT 20'
+        'SELECT rule_id, rule_name, COUNT(*) as count FROM automation_log GROUP BY rule_id, rule_name ORDER BY count DESC LIMIT 20'
       ).all();
       var last24h = db.prepare(
-        "SELECT COUNT(*) as count FROM dv_automation_log WHERE created_at >= datetime('now', '-24 hours')"
+        "SELECT COUNT(*) as count FROM automation_log WHERE created_at >= datetime('now', '-24 hours')"
       ).get();
       return {
         by_status: byStatus,
@@ -122,7 +122,7 @@ export default function createAutomationDB(db) {
 
     createTemplate(name, description, triggerEvent, conditions, actions, category) {
       var r = db.prepare(
-        'INSERT INTO dv_automation_templates (name, description, trigger_event, conditions, actions, category) VALUES (?, ?, ?, ?, ?, ?) RETURNING id'
+        'INSERT INTO automation_templates (name, description, trigger_event, conditions, actions, category) VALUES (?, ?, ?, ?, ?, ?) RETURNING id'
       ).get(
         name || '',
         description || '',
@@ -135,7 +135,7 @@ export default function createAutomationDB(db) {
     },
 
     listTemplates(category) {
-      var sql = 'SELECT * FROM dv_automation_templates';
+      var sql = 'SELECT * FROM automation_templates';
       var params = [];
       if (category) {
         sql += ' WHERE category = ?';
@@ -151,7 +151,7 @@ export default function createAutomationDB(db) {
     },
 
     getTemplate(id) {
-      var row = db.prepare('SELECT * FROM dv_automation_templates WHERE id = ?').get(id);
+      var row = db.prepare('SELECT * FROM automation_templates WHERE id = ?').get(id);
       if (!row) return null;
       try { row.conditions = JSON.parse(row.conditions); } catch (e) { row.conditions = {}; }
       try { row.actions = JSON.parse(row.actions); } catch (e) { row.actions = []; }

--- a/server/plugins/workflow-automations/handlers.js
+++ b/server/plugins/workflow-automations/handlers.js
@@ -55,7 +55,7 @@ function executeAction(action, eventData, core) {
   switch (action.type) {
     case 'create_task': {
       var result = core.db.prepare(
-        "INSERT INTO dv_tasks (title, description, project_id, assignee, status) VALUES (?, ?, ?, ?, 'open') RETURNING id"
+        "INSERT INTO tasks (title, description, project_id, assignee, status) VALUES (?, ?, ?, ?, 'open') RETURNING id"
       ).get(interpolate(action.title), interpolate(action.description || ''), action.project_id || eventData.project_id || '', action.assignee || '');
       core.emitEvent('task_created', '__system__', action.project_id || eventData.project_id || '',
         'Automation created task: ' + interpolate(action.title), { task_id: result.id });
@@ -63,13 +63,13 @@ function executeAction(action, eventData, core) {
     }
     case 'send_message': {
       core.db.prepare(
-        "INSERT INTO dv_messages (from_agent, to_agent, content, msg_type, project_id) VALUES ('__system__', ?, ?, 'message', ?)"
+        "INSERT INTO messages (from_agent, to_agent, content, msg_type, project_id) VALUES ('__system__', ?, ?, 'message', ?)"
       ).run(action.to || '', interpolate(action.content), action.project_id || eventData.project_id || '');
       return { type: 'send_message', to: action.to };
     }
     case 'file_bug': {
       var bugResult = core.db.prepare(
-        "INSERT INTO dv_bugs (title, description, project_id, severity, status, reporter) VALUES (?, ?, ?, ?, 'open', '__system__') RETURNING id"
+        "INSERT INTO bugs (title, description, project_id, severity, status, reporter) VALUES (?, ?, ?, ?, 'open', '__system__') RETURNING id"
       ).get(interpolate(action.title), interpolate(action.description || ''), action.project_id || eventData.project_id || '', action.severity || 'normal');
       core.emitEvent('bug_filed', '__system__', action.project_id || eventData.project_id || '',
         'Automation filed bug: ' + interpolate(action.title), { bug_id: bugResult.id });
@@ -77,7 +77,7 @@ function executeAction(action, eventData, core) {
     }
     case 'assign_agent': {
       if (data.task_id || data.id) {
-        core.db.prepare("UPDATE dv_tasks SET assignee = ? WHERE id = ?").run(action.agent_id, data.task_id || data.id);
+        core.db.prepare("UPDATE tasks SET assignee = ? WHERE id = ?").run(action.agent_id, data.task_id || data.id);
         return { type: 'assign_agent', agent: action.agent_id, task_id: data.task_id || data.id };
       }
       return { type: 'assign_agent', skipped: true };
@@ -129,7 +129,7 @@ export function registerHooks(core) {
   var actionCounts = {}; // minute -> count
 
   function getConfig(key, fallback) {
-    var row = core.db.prepare("SELECT value FROM dv_plugin_config WHERE plugin_name = 'workflow-automations' AND key = ?").get(key);
+    var row = core.db.prepare("SELECT value FROM plugin_config WHERE plugin_name = 'workflow-automations' AND key = ?").get(key);
     return row ? row.value : (fallback || '');
   }
 

--- a/server/plugins/workflow-automations/schema.sql
+++ b/server/plugins/workflow-automations/schema.sql
@@ -1,7 +1,7 @@
 -- Plugin: workflow-automations
 -- Event-driven automation rules
 
-CREATE TABLE IF NOT EXISTS dv_automation_rules (
+CREATE TABLE IF NOT EXISTS automation_rules (
   id            INTEGER PRIMARY KEY AUTOINCREMENT,
   name          TEXT NOT NULL,
   description   TEXT DEFAULT '',
@@ -17,10 +17,10 @@ CREATE TABLE IF NOT EXISTS dv_automation_rules (
   updated_at    TEXT DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_automation_rules_trigger ON dv_automation_rules(trigger_event);
-CREATE INDEX IF NOT EXISTS idx_automation_rules_enabled ON dv_automation_rules(enabled);
+CREATE INDEX IF NOT EXISTS idx_automation_rules_trigger ON automation_rules(trigger_event);
+CREATE INDEX IF NOT EXISTS idx_automation_rules_enabled ON automation_rules(enabled);
 
-CREATE TABLE IF NOT EXISTS dv_automation_log (
+CREATE TABLE IF NOT EXISTS automation_log (
   id            INTEGER PRIMARY KEY AUTOINCREMENT,
   rule_id       INTEGER NOT NULL,
   rule_name     TEXT NOT NULL,
@@ -34,10 +34,10 @@ CREATE TABLE IF NOT EXISTS dv_automation_log (
   created_at    TEXT DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_automation_log_rule ON dv_automation_log(rule_id);
-CREATE INDEX IF NOT EXISTS idx_automation_log_status ON dv_automation_log(status);
+CREATE INDEX IF NOT EXISTS idx_automation_log_rule ON automation_log(rule_id);
+CREATE INDEX IF NOT EXISTS idx_automation_log_status ON automation_log(status);
 
-CREATE TABLE IF NOT EXISTS dv_automation_templates (
+CREATE TABLE IF NOT EXISTS automation_templates (
   id            INTEGER PRIMARY KEY AUTOINCREMENT,
   name          TEXT NOT NULL,
   description   TEXT DEFAULT '',
@@ -48,28 +48,28 @@ CREATE TABLE IF NOT EXISTS dv_automation_templates (
   created_at    TEXT DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_automation_templates_category ON dv_automation_templates(category);
+CREATE INDEX IF NOT EXISTS idx_automation_templates_category ON automation_templates(category);
 
 -- Built-in templates
-INSERT OR IGNORE INTO dv_automation_templates (id, name, description, trigger_event, conditions, actions, category) VALUES
+INSERT OR IGNORE INTO automation_templates (id, name, description, trigger_event, conditions, actions, category) VALUES
 (1, 'Auto-assign critical bugs', 'Automatically assign critical bugs to a configured agent and notify operators.', 'bug_filed',
   '{"field_equals":{"severity":"critical"}}',
   '[{"type":"assign_agent","agent_id":"__configure_me__"},{"type":"inbox_notify","title":"Critical bug filed: {{title}}","summary":"A critical bug was filed and auto-assigned: {{title}}","priority":"high"}]',
   'bugs');
 
-INSERT OR IGNORE INTO dv_automation_templates (id, name, description, trigger_event, conditions, actions, category) VALUES
+INSERT OR IGNORE INTO automation_templates (id, name, description, trigger_event, conditions, actions, category) VALUES
 (2, 'Notify on plan completion', 'Send an inbox notification when a plan step is completed.', 'plan_step_completed',
   '{}',
   '[{"type":"inbox_notify","title":"Plan step completed: {{title}}","summary":"{{agent}} completed step: {{title}}","priority":"normal"}]',
   'plans');
 
-INSERT OR IGNORE INTO dv_automation_templates (id, name, description, trigger_event, conditions, actions, category) VALUES
+INSERT OR IGNORE INTO automation_templates (id, name, description, trigger_event, conditions, actions, category) VALUES
 (3, 'Webhook on deploy', 'Send a webhook when a deploy approval is executed.', 'approval_executed',
   '{"field_equals":{"action_type":"deploy"}}',
   '[{"type":"send_webhook","url":"__configure_me__"}]',
   'integrations');
 
-INSERT OR IGNORE INTO dv_automation_templates (id, name, description, trigger_event, conditions, actions, category) VALUES
+INSERT OR IGNORE INTO automation_templates (id, name, description, trigger_event, conditions, actions, category) VALUES
 (4, 'Create review task on PR', 'Automatically create a review task when a GitHub PR is opened.', 'github_pr_opened',
   '{}',
   '[{"type":"create_task","title":"Review PR: {{title}}","description":"Review pull request #{{number}} by {{author}}: {{title}}"}]',

--- a/server/plugins/x-posting/README.md
+++ b/server/plugins/x-posting/README.md
@@ -58,4 +58,4 @@ All routes are under `/api/mycelium/x`.
 
 ## Database Tables
 
-**`dv_x_posts`** -- Tweet drafts and published posts (project_id, tweet_text, tweet_id, tweet_url, thread_id, thread_position, source, source_id, status, error, posted_by, posted_at).
+**`x_posts`** -- Tweet drafts and published posts (project_id, tweet_text, tweet_id, tweet_url, thread_id, thread_position, source, source_id, status, error, posted_by, posted_at).

--- a/server/plugins/x-posting/db.js
+++ b/server/plugins/x-posting/db.js
@@ -9,7 +9,7 @@ export default function createXDB(db) {
   return {
     createPost(fields) {
       var result = stmt('xCreate',
-        "INSERT INTO dv_x_posts (project_id, tweet_text, thread_id, thread_position, source, source_id, status, posted_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
+        "INSERT INTO x_posts (project_id, tweet_text, thread_id, thread_position, source, source_id, status, posted_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
       ).get(
         fields.project_id || '',
         fields.tweet_text || '',
@@ -24,7 +24,7 @@ export default function createXDB(db) {
     },
 
     getPost(id) {
-      return stmt('xGet', 'SELECT * FROM dv_x_posts WHERE id = ?').get(id);
+      return stmt('xGet', 'SELECT * FROM x_posts WHERE id = ?').get(id);
     },
 
     listPosts(filters) {
@@ -34,8 +34,8 @@ export default function createXDB(db) {
       if (filters.thread_id) { where.push('thread_id = ?'); params.push(filters.thread_id); }
       if (filters.source) { where.push('source = ?'); params.push(filters.source); }
       params.push(filters.limit || 50);
-      return db.prepare('SELECT * FROM dv_x_posts WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all.apply(
-        db.prepare('SELECT * FROM dv_x_posts WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?'),
+      return db.prepare('SELECT * FROM x_posts WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?').all.apply(
+        db.prepare('SELECT * FROM x_posts WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ?'),
         params
       );
     },
@@ -51,21 +51,21 @@ export default function createXDB(db) {
         }
       }
       values.push(id);
-      return db.prepare('UPDATE dv_x_posts SET ' + sets.join(', ') + ' WHERE id = ?').run.apply(
-        db.prepare('UPDATE dv_x_posts SET ' + sets.join(', ') + ' WHERE id = ?'),
+      return db.prepare('UPDATE x_posts SET ' + sets.join(', ') + ' WHERE id = ?').run.apply(
+        db.prepare('UPDATE x_posts SET ' + sets.join(', ') + ' WHERE id = ?'),
         values
       );
     },
 
     deletePost(id) {
-      return db.prepare('DELETE FROM dv_x_posts WHERE id = ?').run(id);
+      return db.prepare('DELETE FROM x_posts WHERE id = ?').run(id);
     },
 
     getStats(projectId) {
       var where = projectId ? 'WHERE project_id = ?' : '';
       var params = projectId ? [projectId] : [];
-      var rows = db.prepare('SELECT status, COUNT(*) as count FROM dv_x_posts ' + where + ' GROUP BY status').all.apply(
-        db.prepare('SELECT status, COUNT(*) as count FROM dv_x_posts ' + where + ' GROUP BY status'),
+      var rows = db.prepare('SELECT status, COUNT(*) as count FROM x_posts ' + where + ' GROUP BY status').all.apply(
+        db.prepare('SELECT status, COUNT(*) as count FROM x_posts ' + where + ' GROUP BY status'),
         params
       );
       var stats = {};
@@ -76,7 +76,7 @@ export default function createXDB(db) {
     },
 
     getThread(threadId) {
-      return db.prepare('SELECT * FROM dv_x_posts WHERE thread_id = ? ORDER BY thread_position ASC').all(threadId);
+      return db.prepare('SELECT * FROM x_posts WHERE thread_id = ? ORDER BY thread_position ASC').all(threadId);
     }
   };
 }

--- a/server/plugins/x-posting/handlers.js
+++ b/server/plugins/x-posting/handlers.js
@@ -17,7 +17,7 @@ export function registerHooks(core) {
 
       // Create a real approval record so it appears in the Approvals page
       var result = core.db.prepare(
-        "INSERT INTO dv_approvals (action_type, requested_by, title, payload, project_id, risk_tier, required_approvals) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
+        "INSERT INTO approvals (action_type, requested_by, title, payload, project_id, risk_tier, required_approvals) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
       ).get(
         'x_publish',
         data.posted_by || '__system__',
@@ -54,7 +54,7 @@ export function registerHooks(core) {
       var approvalId = parsed.approval_id;
       if (!approvalId) return;
 
-      var approval = core.db.prepare('SELECT * FROM dv_approvals WHERE id = ?').get(approvalId);
+      var approval = core.db.prepare('SELECT * FROM approvals WHERE id = ?').get(approvalId);
       if (!approval || approval.action_type !== 'x_publish') return;
 
       var payload = JSON.parse(approval.payload || '{}');
@@ -75,7 +75,7 @@ export function registerHooks(core) {
       var replyTo = null;
       if (post.thread_id && post.thread_position > 0) {
         var prev = core.db.prepare(
-          "SELECT tweet_id FROM dv_x_posts WHERE thread_id = ? AND thread_position = ? AND status = 'published'"
+          "SELECT tweet_id FROM x_posts WHERE thread_id = ? AND thread_position = ? AND status = 'published'"
         ).get(post.thread_id, post.thread_position - 1);
         if (prev) replyTo = prev.tweet_id;
       }
@@ -97,7 +97,7 @@ export function registerHooks(core) {
 
           // Mark approval as executed
           core.db.prepare(
-            "UPDATE dv_approvals SET status = 'executed', executed_at = datetime('now'), updated_at = datetime('now') WHERE id = ?"
+            "UPDATE approvals SET status = 'executed', executed_at = datetime('now'), updated_at = datetime('now') WHERE id = ?"
           ).run(approvalId);
 
           core.emitEvent('x_tweet_published', '__system__', post.project_id,
@@ -124,7 +124,7 @@ export function registerHooks(core) {
     try {
       // Check if auto-posting is enabled
       var autoPost = core.db.prepare(
-        "SELECT value FROM dv_plugin_config WHERE plugin_name = 'x-posting' AND key = 'auto_post_bip'"
+        "SELECT value FROM plugin_config WHERE plugin_name = 'x-posting' AND key = 'auto_post_bip'"
       ).get();
       if (!autoPost || autoPost.value !== 'true') return;
 
@@ -133,7 +133,7 @@ export function registerHooks(core) {
       if (!draftId) return;
 
       // Get the BIP draft content
-      var draft = core.db.prepare('SELECT * FROM dv_bip_drafts WHERE id = ?').get(draftId);
+      var draft = core.db.prepare('SELECT * FROM bip_drafts WHERE id = ?').get(draftId);
       if (!draft) return;
 
       var content = draft.content || '';
@@ -144,7 +144,7 @@ export function registerHooks(core) {
 
       // Get default project from config
       var projectConfig = core.db.prepare(
-        "SELECT value FROM dv_plugin_config WHERE plugin_name = 'x-posting' AND key = 'default_project'"
+        "SELECT value FROM plugin_config WHERE plugin_name = 'x-posting' AND key = 'default_project'"
       ).get();
       var projectId = (projectConfig && projectConfig.value) || 'mycelium';
 

--- a/server/plugins/x-posting/routes.js
+++ b/server/plugins/x-posting/routes.js
@@ -115,7 +115,7 @@ export default function (core) {
     var replyTo = null;
     if (post.thread_id && post.thread_position > 0) {
       var prev = core.db.prepare(
-        "SELECT tweet_id FROM dv_x_posts WHERE thread_id = ? AND thread_position = ? AND status = 'published'"
+        "SELECT tweet_id FROM x_posts WHERE thread_id = ? AND thread_position = ? AND status = 'published'"
       ).get(post.thread_id, post.thread_position - 1);
       if (prev) replyTo = prev.tweet_id;
     }

--- a/server/plugins/x-posting/schema.sql
+++ b/server/plugins/x-posting/schema.sql
@@ -1,6 +1,6 @@
 -- X/Twitter Posting plugin tables
 
-CREATE TABLE IF NOT EXISTS dv_x_posts (
+CREATE TABLE IF NOT EXISTS x_posts (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   project_id      TEXT NOT NULL DEFAULT '',
   tweet_text      TEXT NOT NULL,
@@ -18,6 +18,6 @@ CREATE TABLE IF NOT EXISTS dv_x_posts (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_x_posts_status ON dv_x_posts(status);
-CREATE INDEX IF NOT EXISTS idx_dv_x_posts_thread ON dv_x_posts(thread_id);
-CREATE INDEX IF NOT EXISTS idx_dv_x_posts_source ON dv_x_posts(source, source_id);
+CREATE INDEX IF NOT EXISTS idx_x_posts_status ON x_posts(status);
+CREATE INDEX IF NOT EXISTS idx_x_posts_thread ON x_posts(thread_id);
+CREATE INDEX IF NOT EXISTS idx_x_posts_source ON x_posts(source, source_id);

--- a/server/plugins/x-posting/twitter.js
+++ b/server/plugins/x-posting/twitter.js
@@ -54,7 +54,7 @@ export function sendTweet(text, replyToId, creds) {
 
 export function getCredentials(db) {
   try {
-    var rows = db.prepare("SELECT key, value FROM dv_plugin_config WHERE plugin_name = 'x-posting'").all();
+    var rows = db.prepare("SELECT key, value FROM plugin_config WHERE plugin_name = 'x-posting'").all();
     var config = {};
     for (var i = 0; i < rows.length; i++) {
       config[rows[i].key] = rows[i].value;

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -158,7 +158,10 @@ import {
   resolveProfileChain, buildCalibrationBlock,
   createInstance, getInstance, getInstanceByOrg, getInstanceByDomain, listInstances, updateInstance,
   listTeamSettings, getTeamSetting, upsertTeamSetting, deleteTeamSetting,
-  getAllTeamSettingsGrouped, syncTeamSettingsToProfile
+  getAllTeamSettingsGrouped, syncTeamSettingsToProfile,
+  createTeam, getTeam, listTeams, updateTeam, deleteTeam,
+  addTeamMember, updateTeamMember, removeTeamMember,
+  getTeamsForUser, getTeamProjects
 } from '../db.js';
 import { loadPlugins, getLoadedPlugins, getPluginMcpTools, callEventHooks, registerEventHook, getWorkerStatus } from '../plugins.js';
 
@@ -5182,6 +5185,102 @@ router.post('/team-settings/sync', function (req, res) {
   if (!checkAdmin(req, res)) return;
   syncTeamSettingsToProfile();
   res.json({ ok: true, message: 'Profile sync complete' });
+});
+
+// ======== TEAMS ========
+
+// GET /teams — list teams
+router.get('/teams', function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  res.json({ teams: listTeams(req.query.org_id || null) });
+});
+
+// GET /teams/:id — team detail with members and projects
+router.get('/teams/:id', function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  var team = getTeam(req.params.id);
+  if (!team) return apiError(res, 404, 'Team not found');
+  team.projects = getTeamProjects(req.params.id);
+  res.json(team);
+});
+
+// POST /teams — create team (admin only)
+router.post('/teams', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var { id, org_id, name, description } = req.body;
+  if (!id || !org_id || !name) return apiError(res, 400, 'id, org_id, and name required');
+  try {
+    var who = getAdminDisplayName(req);
+    var team = createTeam(id, org_id, name, description, who);
+    // Auto-create team channel
+    try {
+      var channelSlug = 'team-' + id;
+      createChannel('#team-' + id, channelSlug, 'team', 'team', id, 'Team channel for ' + name, who);
+    } catch (chErr) { console.log('[teams] Auto-channel creation failed:', chErr.message); }
+    res.json(team);
+  } catch (err) {
+    return apiError(res, 400, err.message);
+  }
+});
+
+// PUT /teams/:id — update team (admin only)
+router.put('/teams/:id', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var team = updateTeam(req.params.id, req.body);
+  if (!team) return apiError(res, 404, 'Team not found');
+  res.json(team);
+});
+
+// DELETE /teams/:id — delete empty team (admin only)
+router.delete('/teams/:id', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  try {
+    deleteTeam(req.params.id);
+    res.json({ ok: true });
+  } catch (err) {
+    return apiError(res, 400, err.message);
+  }
+});
+
+// POST /teams/:id/members — add member
+router.post('/teams/:id/members', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var { user_id, user_type, role, is_primary } = req.body;
+  if (!user_id) return apiError(res, 400, 'user_id required');
+  try {
+    var member = addTeamMember(req.params.id, user_id, user_type, role, is_primary);
+    // Auto-join team channel
+    try {
+      var ch = getChannelBySlug('team-' + req.params.id);
+      if (ch) addChannelMember(ch.id, user_id, user_type || 'operator', 'member');
+    } catch (_) {}
+    res.json(member);
+  } catch (err) {
+    return apiError(res, 400, err.message);
+  }
+});
+
+// PUT /teams/:id/members/:userId — update member role/primary
+router.put('/teams/:id/members/:userId', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  updateTeamMember(req.params.id, req.params.userId, req.body);
+  res.json({ ok: true });
+});
+
+// DELETE /teams/:id/members/:userId — remove member
+router.delete('/teams/:id/members/:userId', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  removeTeamMember(req.params.id, req.params.userId);
+  res.json({ ok: true });
+});
+
+// GET /teams/:id/projects — team's projects
+router.get('/teams/:id/projects', function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  res.json({ projects: getTeamProjects(req.params.id) });
 });
 
 // ======== SUPPORT TICKETS ========

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -370,7 +370,7 @@ function checkAgent(req, res) {
     return cached.id;
   }
   // DB lookup: O(1) SHA-256 direct lookup first, then bcrypt fallback for legacy hashes
-  var directMatch = getDB().prepare("SELECT id, project_id FROM dv_agents WHERE api_key_hash = ?").get(keyHash);
+  var directMatch = getDB().prepare("SELECT id, project_id FROM agents WHERE api_key_hash = ?").get(keyHash);
   if (directMatch) {
     agentKeyCache.set(keyHash, { id: directMatch.id, project_id: directMatch.project_id || null });
     req._authAgentId = directMatch.id;
@@ -460,12 +460,12 @@ function checkBillingEnforcement(req, res, next) {
 
   try {
     var db = getDB();
-    var org = db.prepare('SELECT * FROM dv_organizations WHERE id = ?').get(orgId);
+    var org = db.prepare('SELECT * FROM organizations WHERE id = ?').get(orgId);
     if (!org) return next();
     if (org.plan === 'free') return next();
 
     var sub = db.prepare(
-      'SELECT * FROM dv_subscriptions WHERE org_id = ? ORDER BY created_at DESC LIMIT 1'
+      'SELECT * FROM subscriptions WHERE org_id = ? ORDER BY created_at DESC LIMIT 1'
     ).get(orgId);
 
     if (!sub) {
@@ -478,7 +478,7 @@ function checkBillingEnforcement(req, res, next) {
       var graceDays = 7;
       try {
         var row = db.prepare(
-          "SELECT value FROM dv_plugin_config WHERE plugin_name = 'billing' AND key = 'grace_period_days'"
+          "SELECT value FROM plugin_config WHERE plugin_name = 'billing' AND key = 'grace_period_days'"
         ).get();
         if (row) graceDays = parseInt(row.value) || 7;
       } catch (e) { /* use default */ }
@@ -514,7 +514,7 @@ function checkOrgPlanEnforcement(req, res, next) {
   if (!orgId) return next(); // No org context, skip
 
   var db = getDB();
-  var org = db.prepare('SELECT plan FROM dv_organizations WHERE id = ?').get(orgId);
+  var org = db.prepare('SELECT plan FROM organizations WHERE id = ?').get(orgId);
   if (!org) return next(); // Unknown org, skip
 
   var plan = org.plan || 'free';
@@ -678,7 +678,7 @@ router.post('/waitlist', waitlistLimiter, asyncHandler(async function (req, res)
   if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return apiError(res, 400, 'Valid email is required');
   var db = getDB();
   // Ensure table exists (created on first use if migration hasn't run yet)
-  db.prepare(`CREATE TABLE IF NOT EXISTS dv_waitlist (
+  db.prepare(`CREATE TABLE IF NOT EXISTS waitlist (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     name        TEXT NOT NULL DEFAULT '',
     email       TEXT NOT NULL,
@@ -688,7 +688,7 @@ router.post('/waitlist', waitlistLimiter, asyncHandler(async function (req, res)
     created_at  TEXT NOT NULL DEFAULT (datetime('now'))
   )`).run();
   var result = db.prepare(
-    'INSERT INTO dv_waitlist (name, email, subdomain, use_case) VALUES (?, ?, ?, ?)'
+    'INSERT INTO waitlist (name, email, subdomain, use_case) VALUES (?, ?, ?, ?)'
   ).run(name || '', email, subdomain || '', use_case || '');
   var waitlistId = result.lastInsertRowid;
   // Create inbox item for all operators
@@ -714,13 +714,13 @@ router.post('/waitlist', waitlistLimiter, asyncHandler(async function (req, res)
 router.get('/stats/public', function (req, res) {
   try {
     var db = getDB();
-    var agents = db.prepare("SELECT COUNT(*) as total, SUM(CASE WHEN status='online' THEN 1 ELSE 0 END) as online FROM dv_agents WHERE role != 'drone'").get();
-    var tasks = db.prepare("SELECT COUNT(*) as total, SUM(CASE WHEN status='done' THEN 1 ELSE 0 END) as completed FROM dv_tasks").get();
-    var plans = db.prepare("SELECT COUNT(*) as total, SUM(CASE WHEN status='completed' THEN 1 ELSE 0 END) as completed FROM dv_plans").get();
-    var bugs = db.prepare("SELECT COUNT(*) as total, SUM(CASE WHEN status IN ('fixed','closed') THEN 1 ELSE 0 END) as resolved FROM dv_bugs").get();
-    var messages = db.prepare("SELECT COUNT(*) as total FROM dv_messages").get();
-    var projects = db.prepare("SELECT COUNT(*) as total FROM dv_projects").get();
-    var recentActivity = db.prepare("SELECT type, agent FROM dv_events ORDER BY created_at DESC LIMIT 5").all().map(function (e) { return e.type.replace(/_/g, ' '); });
+    var agents = db.prepare("SELECT COUNT(*) as total, SUM(CASE WHEN status='online' THEN 1 ELSE 0 END) as online FROM agents WHERE role != 'drone'").get();
+    var tasks = db.prepare("SELECT COUNT(*) as total, SUM(CASE WHEN status='done' THEN 1 ELSE 0 END) as completed FROM tasks").get();
+    var plans = db.prepare("SELECT COUNT(*) as total, SUM(CASE WHEN status='completed' THEN 1 ELSE 0 END) as completed FROM plans").get();
+    var bugs = db.prepare("SELECT COUNT(*) as total, SUM(CASE WHEN status IN ('fixed','closed') THEN 1 ELSE 0 END) as resolved FROM bugs").get();
+    var messages = db.prepare("SELECT COUNT(*) as total FROM messages").get();
+    var projects = db.prepare("SELECT COUNT(*) as total FROM projects").get();
+    var recentActivity = db.prepare("SELECT type, agent FROM events ORDER BY created_at DESC LIMIT 5").all().map(function (e) { return e.type.replace(/_/g, ' '); });
     res.json({
       agents: { total: agents.total, online: agents.online },
       tasks: { total: tasks.total, completed: tasks.completed },
@@ -745,36 +745,36 @@ router.get('/public/activity', function (req, res) {
 
     // Online agents — names and status only, no working_on details
     var agents = db.prepare(
-      "SELECT name, status FROM dv_agents WHERE role != 'drone' ORDER BY CASE WHEN status='online' THEN 0 ELSE 1 END, name"
+      "SELECT name, status FROM agents WHERE role != 'drone' ORDER BY CASE WHEN status='online' THEN 0 ELSE 1 END, name"
     ).all().map(function (a) {
       return { name: a.name, online: a.status === 'online' };
     });
 
     // Drones — separate from agents
     var drones = db.prepare(
-      "SELECT name, status FROM dv_agents WHERE role = 'drone' ORDER BY CASE WHEN status='online' THEN 0 ELSE 1 END, name"
+      "SELECT name, status FROM agents WHERE role = 'drone' ORDER BY CASE WHEN status='online' THEN 0 ELSE 1 END, name"
     ).all().map(function (d) {
       return { name: d.name, online: d.status === 'online' };
     });
 
     // Aggregate stats — counts only, no details
     var tasksToday = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_tasks WHERE status = 'done' AND updated_at >= ?"
+      "SELECT COUNT(*) as c FROM tasks WHERE status = 'done' AND updated_at >= ?"
     ).get(today).c;
     var bugsToday = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_bugs WHERE status IN ('fixed','closed') AND updated_at >= ?"
+      "SELECT COUNT(*) as c FROM bugs WHERE status IN ('fixed','closed') AND updated_at >= ?"
     ).get(today).c;
     var plansActive = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_plans WHERE status = 'active'"
+      "SELECT COUNT(*) as c FROM plans WHERE status = 'active'"
     ).get().c;
     var agentsOnline = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_agents WHERE status = 'online' AND role != 'drone'"
+      "SELECT COUNT(*) as c FROM agents WHERE status = 'online' AND role != 'drone'"
     ).get().c;
     var totalTasksDone = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_tasks WHERE status = 'done'"
+      "SELECT COUNT(*) as c FROM tasks WHERE status = 'done'"
     ).get().c;
     var totalBugsFixed = db.prepare(
-      "SELECT COUNT(*) as c FROM dv_bugs WHERE status IN ('fixed','closed')"
+      "SELECT COUNT(*) as c FROM bugs WHERE status IN ('fixed','closed')"
     ).get().c;
 
     // Recent events — ONLY event type + agent + timestamp, NO descriptions or data
@@ -786,7 +786,7 @@ router.get('/public/activity', function (req, res) {
     ];
     var placeholders = safeEventTypes.map(function () { return '?'; }).join(',');
     var evtStmt = db.prepare(
-      'SELECT type, agent, created_at FROM dv_events WHERE type IN (' + placeholders + ') ORDER BY created_at DESC LIMIT 30'
+      'SELECT type, agent, created_at FROM events WHERE type IN (' + placeholders + ') ORDER BY created_at DESC LIMIT 30'
     );
     var events = evtStmt.all.apply(evtStmt, safeEventTypes).map(function (e) {
       return {
@@ -799,10 +799,10 @@ router.get('/public/activity', function (req, res) {
     // Active plans — progress only, titles genericized for public view
     var genericLabels = ['Initiative A', 'Initiative B', 'Initiative C', 'Initiative D', 'Initiative E'];
     var plans = db.prepare(
-      "SELECT id FROM dv_plans WHERE status = 'active' ORDER BY updated_at DESC LIMIT 5"
+      "SELECT id FROM plans WHERE status = 'active' ORDER BY updated_at DESC LIMIT 5"
     ).all().map(function (p, i) {
       var steps = db.prepare(
-        'SELECT COUNT(*) as total, SUM(CASE WHEN status = \'completed\' THEN 1 ELSE 0 END) as done FROM dv_plan_steps WHERE plan_id = ?'
+        'SELECT COUNT(*) as total, SUM(CASE WHEN status = \'completed\' THEN 1 ELSE 0 END) as done FROM plan_steps WHERE plan_id = ?'
       ).get(p.id);
       return {
         title: genericLabels[i] || 'Initiative ' + (i + 1),
@@ -811,13 +811,13 @@ router.get('/public/activity', function (req, res) {
     });
 
     // Calibration / alignment — sanitized: status only, no rules or CLAUDE.md content
-    var profileCount = db.prepare('SELECT COUNT(*) as c FROM dv_node_profiles').get().c;
+    var profileCount = db.prepare('SELECT COUNT(*) as c FROM node_profiles').get().c;
     var agentRows = db.prepare(
-      "SELECT id, name, status FROM dv_agents WHERE role != 'drone' ORDER BY name"
+      "SELECT id, name, status FROM agents WHERE role != 'drone' ORDER BY name"
     ).all();
     var alignmentAgents = agentRows.map(function (a) {
       var entry = db.prepare(
-        "SELECT data FROM dv_context_keys WHERE namespace = ? AND key = 'standup'"
+        "SELECT data FROM context_keys WHERE namespace = ? AND key = 'standup'"
       ).get(a.id);
       var status = 'unknown';
       var driftCount = 0;
@@ -870,7 +870,7 @@ router.get('/public/activity', function (req, res) {
 router.get('/waitlist', function (req, res) {
   if (!checkAdmin(req, res)) return;
   try {
-    var items = getDB().prepare('SELECT * FROM dv_waitlist ORDER BY created_at DESC').all();
+    var items = getDB().prepare('SELECT * FROM waitlist ORDER BY created_at DESC').all();
     res.json(items);
   } catch (e) {
     res.json([]);
@@ -925,11 +925,11 @@ router.get('/work/:agentId', function (req, res) {
   // Build work queue directly — no full boot payload needed
   var db = getDB();
   var pendingDirectives = db.prepare(
-    "SELECT * FROM dv_messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
+    "SELECT * FROM messages WHERE to_agent = ? AND msg_type = 'directive' AND status IN ('sent', 'pending') ORDER BY created_at ASC"
   ).all(agentId);
   var pendingRequests = listPendingRequests(agentId);
   var myTasks = db.prepare(
-    "SELECT * FROM dv_tasks WHERE assignee = ? AND status IN ('open', 'in_progress') ORDER BY priority DESC, updated_at DESC"
+    "SELECT * FROM tasks WHERE assignee = ? AND status IN ('open', 'in_progress') ORDER BY priority DESC, updated_at DESC"
   ).all(agentId);
   var openBugs = listBugs({ status: 'open', limit: 20 });
   var myPlans = listPlans({ project_id: agent.project_id, limit: 20 });
@@ -2255,9 +2255,9 @@ router.delete('/studio/users/:id', function (req, res) {
 
 // ======== PASSWORD RESET (public, rate-limited) ========
 
-// Ensure dv_password_resets table exists (inline migration pattern, same as dv_waitlist)
+// Ensure password_resets table exists (inline migration pattern, same as waitlist)
 try {
-  getDB().prepare(`CREATE TABLE IF NOT EXISTS dv_password_resets (
+  getDB().prepare(`CREATE TABLE IF NOT EXISTS password_resets (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     email       TEXT NOT NULL,
     token_hash  TEXT NOT NULL,
@@ -2278,7 +2278,7 @@ router.post('/studio/forgot-password', forgotPasswordLimiter, asyncHandler(async
   var GENERIC = { ok: true, message: 'If that email is associated with an account, a reset link has been sent.' };
   // Find operator by email → get their studio_user_id
   var db = getDB();
-  var operator = db.prepare('SELECT * FROM dv_operators WHERE LOWER(email) = ? AND status = ?').get(email, 'active');
+  var operator = db.prepare('SELECT * FROM operators WHERE LOWER(email) = ? AND status = ?').get(email, 'active');
   if (!operator || !operator.studio_user_id) return res.json(GENERIC);
   var studioUser = getStudioUserById(operator.studio_user_id);
   if (!studioUser) return res.json(GENERIC);
@@ -2287,7 +2287,7 @@ router.post('/studio/forgot-password', forgotPasswordLimiter, asyncHandler(async
   var tokenHash = crypto.createHash('sha256').update(token).digest('hex');
   var expiresMinutes = 30;
   var expiresAt = new Date(Date.now() + expiresMinutes * 60 * 1000).toISOString();
-  db.prepare('INSERT INTO dv_password_resets (email, token_hash, expires_at) VALUES (?, ?, ?)').run(email, tokenHash, expiresAt);
+  db.prepare('INSERT INTO password_resets (email, token_hash, expires_at) VALUES (?, ?, ?)').run(email, tokenHash, expiresAt);
   // Build reset URL (dashboard handles the UI)
   var resetUrl = 'https://mycelium.fyi/studio/#/reset-password?token=' + token;
   sendEmail(templatePasswordReset(email, studioUser.display_name, resetUrl, expiresMinutes));
@@ -2302,10 +2302,10 @@ router.post('/studio/reset-password', resetPasswordLimiter, asyncHandler(async f
   if (newPassword.length < 4) return res.status(400).json({ error: 'Password must be at least 4 characters' });
   var tokenHash = crypto.createHash('sha256').update(token).digest('hex');
   var db = getDB();
-  var row = db.prepare("SELECT * FROM dv_password_resets WHERE token_hash = ? AND used = 0 AND expires_at > datetime('now')").get(tokenHash);
+  var row = db.prepare("SELECT * FROM password_resets WHERE token_hash = ? AND used = 0 AND expires_at > datetime('now')").get(tokenHash);
   if (!row) return res.status(400).json({ error: 'Invalid or expired reset token' });
   // Find operator → studio user
-  var operator = db.prepare('SELECT * FROM dv_operators WHERE LOWER(email) = ?').get(row.email);
+  var operator = db.prepare('SELECT * FROM operators WHERE LOWER(email) = ?').get(row.email);
   if (!operator || !operator.studio_user_id) return res.status(400).json({ error: 'Account not found' });
   var studioUser = getStudioUserById(operator.studio_user_id);
   if (!studioUser) return res.status(400).json({ error: 'Account not found' });
@@ -2313,7 +2313,7 @@ router.post('/studio/reset-password', resetPasswordLimiter, asyncHandler(async f
   var hash = await bcrypt.hash(newPassword, BCRYPT_ROUNDS_PASSWORD);
   updateStudioUser(studioUser.id, { password_hash: hash });
   // Mark token as used
-  db.prepare('UPDATE dv_password_resets SET used = 1 WHERE id = ?').run(row.id);
+  db.prepare('UPDATE password_resets SET used = 1 WHERE id = ?').run(row.id);
   emitEvent('password_reset', '__system__', null, 'Password reset for ' + studioUser.display_name + ' (' + studioUser.username + ')');
   res.json({ ok: true, message: 'Password has been reset. You can now log in.' });
 }));
@@ -3204,7 +3204,7 @@ router.post('/admin/churn-check', async function (req, res) {
       try {
         // TODO: delete S3/R2 snapshot
         updateInstance(inst.id, { status: 'deleted', snapshot_url: null });
-        getDB().prepare("UPDATE dv_organizations SET plan = 'deleted' WHERE id = ?").run(inst.org_id);
+        getDB().prepare("UPDATE organizations SET plan = 'deleted' WHERE id = ?").run(inst.org_id);
         var { sendEmail: sendDeleteEmail, templateDataDeleted } = await import('../email.js');
         if (inst.customer_email) {
           await sendDeleteEmail(templateDataDeleted(null, inst.customer_email));
@@ -3884,7 +3884,7 @@ router.post('/drones/claim', function (req, res) {
       // Incompatible — unclaim and skip
       updateDroneJob(job.id, { status: 'pending' });
       // Remove drone_id by updating the raw record
-      try { var db2 = getDB(); db2.prepare("UPDATE dv_drone_jobs SET status = 'pending', drone_id = NULL, started_at = NULL WHERE id = ?").run(job.id); } catch (e) { /* fallback already set status */ }
+      try { var db2 = getDB(); db2.prepare("UPDATE drone_jobs SET status = 'pending', drone_id = NULL, started_at = NULL WHERE id = ?").run(job.id); } catch (e) { /* fallback already set status */ }
       return res.json({ job: null, skipped: { job_id: job.id, reason: rendered.error } });
     }
     // Write rendered command back to the job
@@ -3928,7 +3928,7 @@ router.post('/drones/jobs', function (req, res) {
   }
   var id = createDroneJob(title, command, inputData, requires, who, priority, workspaceRepo, workspaceBranch, profileId);
   if (jobType) {
-    try { getDB().prepare("UPDATE dv_drone_jobs SET job_type = ? WHERE id = ?").run(jobType, id); } catch (e) { /* col may not exist */ }
+    try { getDB().prepare("UPDATE drone_jobs SET job_type = ? WHERE id = ?").run(jobType, id); } catch (e) { /* col may not exist */ }
   }
   emitEvent('drone_job_created', who, 'drone', who + ' submitted drone job: ' + title, { job_id: id, job_type: jobType });
   dispatchWebhook('drone_job_created', who, { job_id: id, title: title, requires: requires, requester: who, job_type: jobType });
@@ -3950,7 +3950,7 @@ router.post('/drones/jobs/from-template', function (req, res) {
   var title = template.name;
   if (inputData.batch) title += ' (batch ' + inputData.batch + ')';
   var id = createDroneJob(title, '', inputData, requires, who, priority, null, 'main', null);
-  try { getDB().prepare("UPDATE dv_drone_jobs SET job_type = ? WHERE id = ?").run(templateId, id); } catch (e) { /* col may not exist */ }
+  try { getDB().prepare("UPDATE drone_jobs SET job_type = ? WHERE id = ?").run(templateId, id); } catch (e) { /* col may not exist */ }
   emitEvent('drone_job_created', who, 'drone', who + ' submitted ' + templateId + ' job: ' + title, { job_id: id, job_type: templateId });
   dispatchWebhook('drone_job_created', who, { job_id: id, title: title, requires: requires, requester: who, job_type: templateId });
   res.json({ ok: true, id: id, title: title, job_type: templateId });
@@ -4858,7 +4858,7 @@ router.get('/inbox', function (req, res) {
   if (!operatorId) {
     if (!user) return apiError(res, 400, 'operator_id is required');
     // Resolve operator from studio_user_id
-    var op = getDB().prepare('SELECT id FROM dv_operators WHERE studio_user_id = ?').get(user.userId);
+    var op = getDB().prepare('SELECT id FROM operators WHERE studio_user_id = ?').get(user.userId);
     if (!op) return apiError(res, 404, 'No operator linked to this account');
     operatorId = op.id;
   }
@@ -4884,7 +4884,7 @@ router.get('/inbox/count', function (req, res) {
   if (!user && adminKey !== ADMIN_KEY) return apiError(res, 401, 'Authentication required');
   var operatorId = req.query.operator_id;
   if (!operatorId && user) {
-    var op = getDB().prepare('SELECT id FROM dv_operators WHERE studio_user_id = ?').get(user.userId);
+    var op = getDB().prepare('SELECT id FROM operators WHERE studio_user_id = ?').get(user.userId);
     if (op) operatorId = op.id;
   }
   if (operatorId) {
@@ -4962,13 +4962,13 @@ router.post('/inbox/bulk-dismiss', function (req, res) {
   var all = req.body.all;
   var operatorId = req.body.operator_id;
   if (!operatorId && user) {
-    var op = getDB().prepare('SELECT id FROM dv_operators WHERE studio_user_id = ?').get(user.userId);
+    var op = getDB().prepare('SELECT id FROM operators WHERE studio_user_id = ?').get(user.userId);
     if (op) operatorId = op.id;
   }
   var dismissed = 0;
   if (all && operatorId) {
     // Dismiss all non-dismissed items for this operator
-    var result = getDB().prepare("UPDATE dv_operator_inbox SET status = 'dismissed' WHERE operator_id = ? AND status != 'dismissed'").run(operatorId);
+    var result = getDB().prepare("UPDATE operator_inbox SET status = 'dismissed' WHERE operator_id = ? AND status != 'dismissed'").run(operatorId);
     dismissed = result.changes;
   } else if (Array.isArray(ids) && ids.length > 0) {
     for (var i = 0; i < ids.length; i++) {
@@ -5215,15 +5215,15 @@ function classifyTicket(subject, description) {
 // ---- Ticket ↔ Bug bridge: migrations ----
 try {
   var db = getDB();
-  var bugCols = db.pragma('table_info(dv_bugs)').map(function(c) { return c.name; });
+  var bugCols = db.pragma('table_info(bugs)').map(function(c) { return c.name; });
   if (!bugCols.includes('linked_ticket_id')) {
-    db.prepare("ALTER TABLE dv_bugs ADD COLUMN linked_ticket_id INTEGER").run();
-    process.stdout.write('[boot] migrated dv_bugs: added linked_ticket_id\n');
+    db.prepare("ALTER TABLE bugs ADD COLUMN linked_ticket_id INTEGER").run();
+    process.stdout.write('[boot] migrated bugs: added linked_ticket_id\n');
   }
-  var ticketCols = db.pragma('table_info(dv_support_tickets)').map(function(c) { return c.name; });
+  var ticketCols = db.pragma('table_info(support_tickets)').map(function(c) { return c.name; });
   if (!ticketCols.includes('linked_bug_id')) {
-    db.prepare("ALTER TABLE dv_support_tickets ADD COLUMN linked_bug_id INTEGER").run();
-    process.stdout.write('[boot] migrated dv_support_tickets: added linked_bug_id\n');
+    db.prepare("ALTER TABLE support_tickets ADD COLUMN linked_bug_id INTEGER").run();
+    process.stdout.write('[boot] migrated support_tickets: added linked_bug_id\n');
   }
 } catch (e) { /* already exists or table not yet created */ }
 
@@ -5259,8 +5259,8 @@ router.post('/support/tickets', ticketCreateLimiter, function (req, res) {
     );
     // Link ticket ↔ bug
     var db = getDB();
-    db.prepare('UPDATE dv_support_tickets SET linked_bug_id = ? WHERE id = ?').run(bugId, ticket.id);
-    db.prepare('UPDATE dv_bugs SET linked_ticket_id = ? WHERE id = ?').run(ticket.id, bugId);
+    db.prepare('UPDATE support_tickets SET linked_bug_id = ? WHERE id = ?').run(bugId, ticket.id);
+    db.prepare('UPDATE bugs SET linked_ticket_id = ? WHERE id = ?').run(ticket.id, bugId);
     ticket.linked_bug_id = bugId;
     emitEvent('bug_created', '__customer__', req.body.instance_id || '', 'Customer filed support ticket → bug #' + bugId + ': ' + subject, { bug_id: bugId, ticket_id: ticket.id });
   } catch (e) {

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -2,7 +2,7 @@
 -- Distributed development platform.
 
 -- Registered agents (AI instances, bots, etc.)
-CREATE TABLE IF NOT EXISTS dv_agents (
+CREATE TABLE IF NOT EXISTS agents (
   id              TEXT PRIMARY KEY,
   name            TEXT NOT NULL,
   project_id      TEXT NOT NULL,
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS dv_agents (
 );
 
 -- Organizations (multi-tenant)
-CREATE TABLE IF NOT EXISTS dv_organizations (
+CREATE TABLE IF NOT EXISTS organizations (
   id              TEXT PRIMARY KEY,
   name            TEXT NOT NULL,
   description     TEXT NOT NULL DEFAULT '',
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS dv_organizations (
 );
 
 -- Projects registry
-CREATE TABLE IF NOT EXISTS dv_projects (
+CREATE TABLE IF NOT EXISTS projects (
   id              TEXT PRIMARY KEY,
   name            TEXT NOT NULL,
   description     TEXT NOT NULL DEFAULT '',
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS dv_projects (
 );
 
 -- Cross-project tasks
-CREATE TABLE IF NOT EXISTS dv_tasks (
+CREATE TABLE IF NOT EXISTS tasks (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   title           TEXT NOT NULL,
   description     TEXT NOT NULL DEFAULT '',
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS dv_tasks (
 );
 
 -- Per-project context snapshots (legacy)
-CREATE TABLE IF NOT EXISTS dv_context (
+CREATE TABLE IF NOT EXISTS context (
   project_id      TEXT PRIMARY KEY,
   data            TEXT NOT NULL DEFAULT '{}',
   updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS dv_context (
 );
 
 -- Cross-project asset registry
-CREATE TABLE IF NOT EXISTS dv_assets (
+CREATE TABLE IF NOT EXISTS assets (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   name            TEXT NOT NULL,
   type            TEXT NOT NULL DEFAULT 'asset',
@@ -83,7 +83,7 @@ CREATE TABLE IF NOT EXISTS dv_assets (
 );
 
 -- Activity feed
-CREATE TABLE IF NOT EXISTS dv_events (
+CREATE TABLE IF NOT EXISTS events (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   type            TEXT NOT NULL,
   agent           TEXT NOT NULL DEFAULT '',
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS dv_events (
 );
 
 -- Inter-agent messages
-CREATE TABLE IF NOT EXISTS dv_messages (
+CREATE TABLE IF NOT EXISTS messages (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   from_agent      TEXT NOT NULL,
   to_agent        TEXT,
@@ -107,7 +107,7 @@ CREATE TABLE IF NOT EXISTS dv_messages (
 );
 
 -- Namespaced context storage
-CREATE TABLE IF NOT EXISTS dv_context_keys (
+CREATE TABLE IF NOT EXISTS context_keys (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   namespace   TEXT NOT NULL,
   key         TEXT NOT NULL,
@@ -120,7 +120,7 @@ CREATE TABLE IF NOT EXISTS dv_context_keys (
 );
 
 -- Bug tracking
-CREATE TABLE IF NOT EXISTS dv_bugs (
+CREATE TABLE IF NOT EXISTS bugs (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   project_id      TEXT NOT NULL DEFAULT '',
   title           TEXT NOT NULL,
@@ -138,7 +138,7 @@ CREATE TABLE IF NOT EXISTS dv_bugs (
 );
 
 -- Plans (multi-step initiatives)
-CREATE TABLE IF NOT EXISTS dv_plans (
+CREATE TABLE IF NOT EXISTS plans (
   id           INTEGER PRIMARY KEY AUTOINCREMENT,
   title        TEXT NOT NULL,
   description  TEXT NOT NULL DEFAULT '',
@@ -152,9 +152,9 @@ CREATE TABLE IF NOT EXISTS dv_plans (
   updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE TABLE IF NOT EXISTS dv_plan_steps (
+CREATE TABLE IF NOT EXISTS plan_steps (
   id             INTEGER PRIMARY KEY AUTOINCREMENT,
-  plan_id        INTEGER NOT NULL REFERENCES dv_plans(id) ON DELETE CASCADE,
+  plan_id        INTEGER NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
   step_order     INTEGER NOT NULL DEFAULT 0,
   title          TEXT NOT NULL,
   description    TEXT NOT NULL DEFAULT '',
@@ -169,17 +169,17 @@ CREATE TABLE IF NOT EXISTS dv_plan_steps (
   updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE TABLE IF NOT EXISTS dv_plan_step_comments (
+CREATE TABLE IF NOT EXISTS plan_step_comments (
   id         INTEGER PRIMARY KEY AUTOINCREMENT,
-  step_id    INTEGER NOT NULL REFERENCES dv_plan_steps(id) ON DELETE CASCADE,
-  plan_id    INTEGER NOT NULL REFERENCES dv_plans(id) ON DELETE CASCADE,
+  step_id    INTEGER NOT NULL REFERENCES plan_steps(id) ON DELETE CASCADE,
+  plan_id    INTEGER NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
   author     TEXT NOT NULL,
   content    TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 -- Studio users (human operators)
-CREATE TABLE IF NOT EXISTS dv_studio_users (
+CREATE TABLE IF NOT EXISTS studio_users (
   id            INTEGER PRIMARY KEY AUTOINCREMENT,
   username      TEXT UNIQUE NOT NULL,
   display_name  TEXT NOT NULL,
@@ -189,7 +189,7 @@ CREATE TABLE IF NOT EXISTS dv_studio_users (
 );
 
 -- Password reset tokens (SHA-256 hashed, single-use, 30-min expiry)
-CREATE TABLE IF NOT EXISTS dv_password_resets (
+CREATE TABLE IF NOT EXISTS password_resets (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   email       TEXT NOT NULL,
   token_hash  TEXT NOT NULL,
@@ -199,7 +199,7 @@ CREATE TABLE IF NOT EXISTS dv_password_resets (
 );
 
 -- Agent webhooks
-CREATE TABLE IF NOT EXISTS dv_webhooks (
+CREATE TABLE IF NOT EXISTS webhooks (
   id         INTEGER PRIMARY KEY AUTOINCREMENT,
   agent_id   TEXT NOT NULL,
   url        TEXT NOT NULL,
@@ -210,7 +210,7 @@ CREATE TABLE IF NOT EXISTS dv_webhooks (
 );
 
 -- Drone compute job queue
-CREATE TABLE IF NOT EXISTS dv_drone_jobs (
+CREATE TABLE IF NOT EXISTS drone_jobs (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   title           TEXT NOT NULL,
   command         TEXT NOT NULL DEFAULT '',
@@ -232,7 +232,7 @@ CREATE TABLE IF NOT EXISTS dv_drone_jobs (
 );
 
 -- Shared concepts (characters, styles, rulesets, etc. that flow between projects)
-CREATE TABLE IF NOT EXISTS dv_concepts (
+CREATE TABLE IF NOT EXISTS concepts (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   name            TEXT NOT NULL,
   type            TEXT NOT NULL DEFAULT 'custom',
@@ -245,26 +245,26 @@ CREATE TABLE IF NOT EXISTS dv_concepts (
 );
 
 -- Project-concept links (many-to-many)
-CREATE TABLE IF NOT EXISTS dv_project_concepts (
+CREATE TABLE IF NOT EXISTS project_concepts (
   project_id      TEXT NOT NULL,
-  concept_id      INTEGER NOT NULL REFERENCES dv_concepts(id) ON DELETE CASCADE,
+  concept_id      INTEGER NOT NULL REFERENCES concepts(id) ON DELETE CASCADE,
   linked_at       TEXT NOT NULL DEFAULT (datetime('now')),
   linked_by       TEXT NOT NULL DEFAULT '',
   PRIMARY KEY (project_id, concept_id)
 );
 
 -- Task comments
-CREATE TABLE IF NOT EXISTS dv_task_comments (
+CREATE TABLE IF NOT EXISTS task_comments (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  task_id INTEGER NOT NULL REFERENCES dv_tasks(id) ON DELETE CASCADE,
+  task_id INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   author TEXT NOT NULL,
   content TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_task_comments_task ON dv_task_comments(task_id);
+CREATE INDEX IF NOT EXISTS idx_task_comments_task ON task_comments(task_id);
 
 -- Support tickets (customer support)
-CREATE TABLE IF NOT EXISTS dv_support_tickets (
+CREATE TABLE IF NOT EXISTS support_tickets (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   instance_id     TEXT NOT NULL DEFAULT '',
   subject         TEXT NOT NULL,
@@ -286,53 +286,53 @@ CREATE TABLE IF NOT EXISTS dv_support_tickets (
 );
 
 -- Indexes
-CREATE INDEX IF NOT EXISTS idx_dv_tasks_status ON dv_tasks(status);
-CREATE INDEX IF NOT EXISTS idx_dv_tasks_project ON dv_tasks(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_tasks_assignee ON dv_tasks(assignee);
-CREATE INDEX IF NOT EXISTS idx_dv_tasks_updated ON dv_tasks(updated_at DESC);
-CREATE INDEX IF NOT EXISTS idx_dv_assets_project ON dv_assets(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_assets_status ON dv_assets(status);
-CREATE INDEX IF NOT EXISTS idx_dv_events_created ON dv_events(created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_dv_events_type ON dv_events(type);
-CREATE INDEX IF NOT EXISTS idx_dv_events_agent ON dv_events(agent);
-CREATE INDEX IF NOT EXISTS idx_dv_messages_from ON dv_messages(from_agent);
-CREATE INDEX IF NOT EXISTS idx_dv_messages_to ON dv_messages(to_agent);
-CREATE INDEX IF NOT EXISTS idx_dv_messages_thread ON dv_messages(thread_id);
-CREATE INDEX IF NOT EXISTS idx_dv_messages_created ON dv_messages(created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_dv_context_keys_ns ON dv_context_keys(namespace);
-CREATE INDEX IF NOT EXISTS idx_dv_bugs_status ON dv_bugs(status);
-CREATE INDEX IF NOT EXISTS idx_dv_bugs_project ON dv_bugs(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_plans_status ON dv_plans(status);
-CREATE INDEX IF NOT EXISTS idx_dv_plans_project ON dv_plans(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_plans_owner ON dv_plans(owner);
-CREATE INDEX IF NOT EXISTS idx_dv_plan_steps_plan ON dv_plan_steps(plan_id);
-CREATE INDEX IF NOT EXISTS idx_dv_plan_steps_task ON dv_plan_steps(linked_task_id);
-CREATE INDEX IF NOT EXISTS idx_dv_plan_step_comments_step ON dv_plan_step_comments(step_id);
-CREATE INDEX IF NOT EXISTS idx_dv_studio_users_username ON dv_studio_users(username);
-CREATE INDEX IF NOT EXISTS idx_dv_webhooks_agent ON dv_webhooks(agent_id);
-CREATE INDEX IF NOT EXISTS idx_dv_webhooks_active ON dv_webhooks(active);
-CREATE INDEX IF NOT EXISTS idx_dv_drone_jobs_status ON dv_drone_jobs(status);
-CREATE INDEX IF NOT EXISTS idx_dv_drone_jobs_drone ON dv_drone_jobs(drone_id);
-CREATE INDEX IF NOT EXISTS idx_dv_drone_jobs_requester ON dv_drone_jobs(requester);
-CREATE INDEX IF NOT EXISTS idx_dv_drone_jobs_priority ON dv_drone_jobs(priority DESC, created_at ASC);
-CREATE INDEX IF NOT EXISTS idx_dv_concepts_type ON dv_concepts(type);
-CREATE INDEX IF NOT EXISTS idx_dv_concepts_name ON dv_concepts(name);
-CREATE INDEX IF NOT EXISTS idx_dv_project_concepts_project ON dv_project_concepts(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_project_concepts_concept ON dv_project_concepts(concept_id);
-CREATE INDEX IF NOT EXISTS idx_dv_organizations_status ON dv_organizations(status);
-CREATE INDEX IF NOT EXISTS idx_dv_projects_org ON dv_projects(org_id);
-CREATE INDEX IF NOT EXISTS idx_dv_projects_status ON dv_projects(status);
-CREATE INDEX IF NOT EXISTS idx_dv_projects_type ON dv_projects(type);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_project ON tasks(project_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_assignee ON tasks(assignee);
+CREATE INDEX IF NOT EXISTS idx_tasks_updated ON tasks(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_assets_project ON assets(project_id);
+CREATE INDEX IF NOT EXISTS idx_assets_status ON assets(status);
+CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events(type);
+CREATE INDEX IF NOT EXISTS idx_events_agent ON events(agent);
+CREATE INDEX IF NOT EXISTS idx_messages_from ON messages(from_agent);
+CREATE INDEX IF NOT EXISTS idx_messages_to ON messages(to_agent);
+CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id);
+CREATE INDEX IF NOT EXISTS idx_messages_created ON messages(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_context_keys_ns ON context_keys(namespace);
+CREATE INDEX IF NOT EXISTS idx_bugs_status ON bugs(status);
+CREATE INDEX IF NOT EXISTS idx_bugs_project ON bugs(project_id);
+CREATE INDEX IF NOT EXISTS idx_plans_status ON plans(status);
+CREATE INDEX IF NOT EXISTS idx_plans_project ON plans(project_id);
+CREATE INDEX IF NOT EXISTS idx_plans_owner ON plans(owner);
+CREATE INDEX IF NOT EXISTS idx_plan_steps_plan ON plan_steps(plan_id);
+CREATE INDEX IF NOT EXISTS idx_plan_steps_task ON plan_steps(linked_task_id);
+CREATE INDEX IF NOT EXISTS idx_plan_step_comments_step ON plan_step_comments(step_id);
+CREATE INDEX IF NOT EXISTS idx_studio_users_username ON studio_users(username);
+CREATE INDEX IF NOT EXISTS idx_webhooks_agent ON webhooks(agent_id);
+CREATE INDEX IF NOT EXISTS idx_webhooks_active ON webhooks(active);
+CREATE INDEX IF NOT EXISTS idx_drone_jobs_status ON drone_jobs(status);
+CREATE INDEX IF NOT EXISTS idx_drone_jobs_drone ON drone_jobs(drone_id);
+CREATE INDEX IF NOT EXISTS idx_drone_jobs_requester ON drone_jobs(requester);
+CREATE INDEX IF NOT EXISTS idx_drone_jobs_priority ON drone_jobs(priority DESC, created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_concepts_type ON concepts(type);
+CREATE INDEX IF NOT EXISTS idx_concepts_name ON concepts(name);
+CREATE INDEX IF NOT EXISTS idx_project_concepts_project ON project_concepts(project_id);
+CREATE INDEX IF NOT EXISTS idx_project_concepts_concept ON project_concepts(concept_id);
+CREATE INDEX IF NOT EXISTS idx_organizations_status ON organizations(status);
+CREATE INDEX IF NOT EXISTS idx_projects_org ON projects(org_id);
+CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);
+CREATE INDEX IF NOT EXISTS idx_projects_type ON projects(type);
 
 -- Additional performance indexes
-CREATE INDEX IF NOT EXISTS idx_dv_agents_project ON dv_agents(project_id);
-CREATE INDEX IF NOT EXISTS idx_dv_tasks_requester ON dv_tasks(requester);
-CREATE INDEX IF NOT EXISTS idx_dv_tasks_project_status ON dv_tasks(project_id, status);
-CREATE INDEX IF NOT EXISTS idx_dv_bugs_severity ON dv_bugs(severity);
-CREATE INDEX IF NOT EXISTS idx_dv_bugs_assignee ON dv_bugs(assignee);
-CREATE INDEX IF NOT EXISTS idx_dv_messages_project ON dv_messages(project_id);
+CREATE INDEX IF NOT EXISTS idx_agents_project ON agents(project_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_requester ON tasks(requester);
+CREATE INDEX IF NOT EXISTS idx_tasks_project_status ON tasks(project_id, status);
+CREATE INDEX IF NOT EXISTS idx_bugs_severity ON bugs(severity);
+CREATE INDEX IF NOT EXISTS idx_bugs_assignee ON bugs(assignee);
+CREATE INDEX IF NOT EXISTS idx_messages_project ON messages(project_id);
 -- Plugins (installable capability modules with routes, DB, MCP tools)
-CREATE TABLE IF NOT EXISTS dv_plugins (
+CREATE TABLE IF NOT EXISTS plugins (
   name            TEXT PRIMARY KEY,
   display_name    TEXT NOT NULL DEFAULT '',
   description     TEXT NOT NULL DEFAULT '',
@@ -345,7 +345,7 @@ CREATE TABLE IF NOT EXISTS dv_plugins (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE TABLE IF NOT EXISTS dv_plugin_migrations (
+CREATE TABLE IF NOT EXISTS plugin_migrations (
   plugin_name     TEXT NOT NULL,
   version         INTEGER NOT NULL,
   description     TEXT NOT NULL DEFAULT '',
@@ -354,7 +354,7 @@ CREATE TABLE IF NOT EXISTS dv_plugin_migrations (
 );
 
 -- Approval gates (human-in-the-loop for agent actions)
-CREATE TABLE IF NOT EXISTS dv_approvals (
+CREATE TABLE IF NOT EXISTS approvals (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   action_type     TEXT NOT NULL,
   requested_by    TEXT NOT NULL,
@@ -371,19 +371,19 @@ CREATE TABLE IF NOT EXISTS dv_approvals (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_approvals_status ON dv_approvals(status);
-CREATE INDEX IF NOT EXISTS idx_dv_approvals_action ON dv_approvals(action_type);
-CREATE INDEX IF NOT EXISTS idx_dv_approvals_agent ON dv_approvals(requested_by);
-CREATE INDEX IF NOT EXISTS idx_dv_approvals_project ON dv_approvals(project_id);
+CREATE INDEX IF NOT EXISTS idx_approvals_status ON approvals(status);
+CREATE INDEX IF NOT EXISTS idx_approvals_action ON approvals(action_type);
+CREATE INDEX IF NOT EXISTS idx_approvals_agent ON approvals(requested_by);
+CREATE INDEX IF NOT EXISTS idx_approvals_project ON approvals(project_id);
 
 -- Operators (human team members)
-CREATE TABLE IF NOT EXISTS dv_operators (
+CREATE TABLE IF NOT EXISTS operators (
   id              TEXT PRIMARY KEY,
   display_name    TEXT NOT NULL,
   role            TEXT NOT NULL DEFAULT 'member',
   responsibilities TEXT NOT NULL DEFAULT '',
   email           TEXT NOT NULL DEFAULT '',
-  studio_user_id  INTEGER REFERENCES dv_studio_users(id),
+  studio_user_id  INTEGER REFERENCES studio_users(id),
   status          TEXT NOT NULL DEFAULT 'active',
   availability    TEXT NOT NULL DEFAULT 'available',
   last_seen_at    TEXT,
@@ -391,11 +391,11 @@ CREATE TABLE IF NOT EXISTS dv_operators (
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_dv_operators_role ON dv_operators(role);
-CREATE INDEX IF NOT EXISTS idx_dv_operators_status ON dv_operators(status);
+CREATE INDEX IF NOT EXISTS idx_operators_role ON operators(role);
+CREATE INDEX IF NOT EXISTS idx_operators_status ON operators(status);
 
 -- Instance configuration (per-deployment settings)
-CREATE TABLE IF NOT EXISTS dv_instance_config (
+CREATE TABLE IF NOT EXISTS instance_config (
   key         TEXT PRIMARY KEY,
   value       TEXT NOT NULL DEFAULT '',
   updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
@@ -403,20 +403,20 @@ CREATE TABLE IF NOT EXISTS dv_instance_config (
 );
 
 -- Multi-human approval voting
-CREATE TABLE IF NOT EXISTS dv_approval_votes (
+CREATE TABLE IF NOT EXISTS approval_votes (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
-  approval_id INTEGER NOT NULL REFERENCES dv_approvals(id),
+  approval_id INTEGER NOT NULL REFERENCES approvals(id),
   voter       TEXT NOT NULL,
   vote        TEXT NOT NULL DEFAULT 'approve',
   notes       TEXT NOT NULL DEFAULT '',
   created_at  TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(approval_id, voter)
 );
-CREATE INDEX IF NOT EXISTS idx_dv_approval_votes_approval ON dv_approval_votes(approval_id);
-CREATE INDEX IF NOT EXISTS idx_dv_approval_votes_voter ON dv_approval_votes(voter);
+CREATE INDEX IF NOT EXISTS idx_approval_votes_approval ON approval_votes(approval_id);
+CREATE INDEX IF NOT EXISTS idx_approval_votes_voter ON approval_votes(voter);
 
 -- Webhook delivery log
-CREATE TABLE IF NOT EXISTS dv_webhook_deliveries (
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   webhook_id      INTEGER NOT NULL,
   event           TEXT NOT NULL,
@@ -428,13 +428,13 @@ CREATE TABLE IF NOT EXISTS dv_webhook_deliveries (
   duration_ms     INTEGER,
   created_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_dv_webhook_deliveries_agent ON dv_webhook_deliveries(agent_id);
-CREATE INDEX IF NOT EXISTS idx_dv_webhook_deliveries_event ON dv_webhook_deliveries(event);
-CREATE INDEX IF NOT EXISTS idx_dv_webhook_deliveries_webhook ON dv_webhook_deliveries(webhook_id);
-CREATE INDEX IF NOT EXISTS idx_dv_webhook_deliveries_created ON dv_webhook_deliveries(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_agent ON webhook_deliveries(agent_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_event ON webhook_deliveries(event);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_webhook ON webhook_deliveries(webhook_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_created ON webhook_deliveries(created_at DESC);
 
 -- Chat channels
-CREATE TABLE IF NOT EXISTS dv_channels (
+CREATE TABLE IF NOT EXISTS channels (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   name        TEXT NOT NULL,
   slug        TEXT UNIQUE NOT NULL,
@@ -447,15 +447,15 @@ CREATE TABLE IF NOT EXISTS dv_channels (
   created_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_channels_slug ON dv_channels(slug);
-CREATE INDEX IF NOT EXISTS idx_dv_channels_type ON dv_channels(type);
-CREATE INDEX IF NOT EXISTS idx_dv_channels_linked ON dv_channels(linked_type, linked_id);
-CREATE INDEX IF NOT EXISTS idx_dv_channels_status ON dv_channels(status);
+CREATE INDEX IF NOT EXISTS idx_channels_slug ON channels(slug);
+CREATE INDEX IF NOT EXISTS idx_channels_type ON channels(type);
+CREATE INDEX IF NOT EXISTS idx_channels_linked ON channels(linked_type, linked_id);
+CREATE INDEX IF NOT EXISTS idx_channels_status ON channels(status);
 
 -- Channel membership
-CREATE TABLE IF NOT EXISTS dv_channel_members (
+CREATE TABLE IF NOT EXISTS channel_members (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
-  channel_id  INTEGER NOT NULL REFERENCES dv_channels(id) ON DELETE CASCADE,
+  channel_id  INTEGER NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
   user_id     TEXT NOT NULL,
   user_type   TEXT NOT NULL DEFAULT 'agent',
   role        TEXT NOT NULL DEFAULT 'member',
@@ -463,11 +463,11 @@ CREATE TABLE IF NOT EXISTS dv_channel_members (
   UNIQUE(channel_id, user_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_dv_channel_members_channel ON dv_channel_members(channel_id);
-CREATE INDEX IF NOT EXISTS idx_dv_channel_members_user ON dv_channel_members(user_id);
+CREATE INDEX IF NOT EXISTS idx_channel_members_channel ON channel_members(channel_id);
+CREATE INDEX IF NOT EXISTS idx_channel_members_user ON channel_members(user_id);
 
 -- Agent savepoints (persistent session state)
-CREATE TABLE IF NOT EXISTS dv_agent_savepoints (
+CREATE TABLE IF NOT EXISTS agent_savepoints (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   agent_id        TEXT NOT NULL,
   session_id      TEXT,
@@ -479,12 +479,12 @@ CREATE TABLE IF NOT EXISTS dv_agent_savepoints (
   notes           TEXT,
   created_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_savepoints_agent ON dv_agent_savepoints(agent_id, heartbeat_at DESC);
-CREATE INDEX IF NOT EXISTS idx_savepoints_session ON dv_agent_savepoints(session_id);
+CREATE INDEX IF NOT EXISTS idx_savepoints_agent ON agent_savepoints(agent_id, heartbeat_at DESC);
+CREATE INDEX IF NOT EXISTS idx_savepoints_session ON agent_savepoints(session_id);
 
 -- Channel read tracking
-CREATE TABLE IF NOT EXISTS dv_channel_reads (
-  channel_id          INTEGER NOT NULL REFERENCES dv_channels(id) ON DELETE CASCADE,
+CREATE TABLE IF NOT EXISTS channel_reads (
+  channel_id          INTEGER NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
   user_id             TEXT NOT NULL,
   last_read_at        TEXT,
   last_read_message_id INTEGER NOT NULL DEFAULT 0,
@@ -492,7 +492,7 @@ CREATE TABLE IF NOT EXISTS dv_channel_reads (
 );
 
 -- Operator inbox (human-facing messages, approvals, BIP drafts, @mentions)
-CREATE TABLE IF NOT EXISTS dv_operator_inbox (
+CREATE TABLE IF NOT EXISTS operator_inbox (
   id            INTEGER PRIMARY KEY AUTOINCREMENT,
   operator_id   TEXT NOT NULL,
   type          TEXT NOT NULL DEFAULT 'message',    -- 'message','approval','bip_draft','mention','feedback_request'
@@ -506,13 +506,13 @@ CREATE TABLE IF NOT EXISTS dv_operator_inbox (
   created_at    TEXT NOT NULL DEFAULT (datetime('now')),
   read_at       TEXT
 );
-CREATE INDEX IF NOT EXISTS idx_dv_operator_inbox_operator ON dv_operator_inbox(operator_id, status);
-CREATE INDEX IF NOT EXISTS idx_dv_operator_inbox_type ON dv_operator_inbox(type);
-CREATE INDEX IF NOT EXISTS idx_dv_operator_inbox_entity ON dv_operator_inbox(entity_type, entity_id);
-CREATE INDEX IF NOT EXISTS idx_dv_operator_inbox_created ON dv_operator_inbox(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_operator_inbox_operator ON operator_inbox(operator_id, status);
+CREATE INDEX IF NOT EXISTS idx_operator_inbox_type ON operator_inbox(type);
+CREATE INDEX IF NOT EXISTS idx_operator_inbox_entity ON operator_inbox(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_operator_inbox_created ON operator_inbox(created_at DESC);
 
 -- Operator feedback on agent work (ratings + comments)
-CREATE TABLE IF NOT EXISTS dv_feedback (
+CREATE TABLE IF NOT EXISTS feedback (
   id           INTEGER PRIMARY KEY AUTOINCREMENT,
   entity_type  TEXT NOT NULL DEFAULT 'general',  -- 'task', 'plan_step', 'bug', 'general'
   entity_id    TEXT NOT NULL DEFAULT '',          -- ID of the referenced entity
@@ -523,12 +523,12 @@ CREATE TABLE IF NOT EXISTS dv_feedback (
   agent_id     TEXT NOT NULL DEFAULT '',          -- which agent's work is rated
   created_at   TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_dv_feedback_agent ON dv_feedback(agent_id);
-CREATE INDEX IF NOT EXISTS idx_dv_feedback_entity ON dv_feedback(entity_type, entity_id);
-CREATE INDEX IF NOT EXISTS idx_dv_feedback_created ON dv_feedback(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_feedback_agent ON feedback(agent_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_entity ON feedback(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_created ON feedback(created_at DESC);
 
 -- Drone profiles (per-drone setup & dependency definitions)
-CREATE TABLE IF NOT EXISTS dv_drone_profiles (
+CREATE TABLE IF NOT EXISTS drone_profiles (
   id          TEXT PRIMARY KEY,
   name        TEXT NOT NULL,
   description TEXT NOT NULL DEFAULT '',
@@ -542,19 +542,19 @@ CREATE TABLE IF NOT EXISTS dv_drone_profiles (
 );
 
 -- Drone-to-profile assignments (tracks setup status per drone)
-CREATE TABLE IF NOT EXISTS dv_drone_profile_assignments (
+CREATE TABLE IF NOT EXISTS drone_profile_assignments (
   drone_id    TEXT NOT NULL,
-  profile_id  TEXT NOT NULL REFERENCES dv_drone_profiles(id) ON DELETE CASCADE,
+  profile_id  TEXT NOT NULL REFERENCES drone_profiles(id) ON DELETE CASCADE,
   setup_done  INTEGER NOT NULL DEFAULT 0,
   setup_at    TEXT,
   checksum    TEXT NOT NULL DEFAULT '',
   PRIMARY KEY (drone_id, profile_id)
 );
-CREATE INDEX IF NOT EXISTS idx_drone_profile_assignments_drone ON dv_drone_profile_assignments(drone_id);
-CREATE INDEX IF NOT EXISTS idx_drone_profile_assignments_profile ON dv_drone_profile_assignments(profile_id);
+CREATE INDEX IF NOT EXISTS idx_drone_profile_assignments_drone ON drone_profile_assignments(drone_id);
+CREATE INDEX IF NOT EXISTS idx_drone_profile_assignments_profile ON drone_profile_assignments(profile_id);
 
 -- Job templates: reusable job type definitions for smart routing
-CREATE TABLE IF NOT EXISTS dv_job_templates (
+CREATE TABLE IF NOT EXISTS job_templates (
   id                  TEXT PRIMARY KEY,
   name                TEXT NOT NULL,
   project_id          TEXT NOT NULL DEFAULT '',
@@ -571,7 +571,7 @@ CREATE TABLE IF NOT EXISTS dv_job_templates (
 );
 
 -- Plugin config: per-plugin key/value store (supports secrets)
-CREATE TABLE IF NOT EXISTS dv_plugin_config (
+CREATE TABLE IF NOT EXISTS plugin_config (
   plugin_name  TEXT NOT NULL,
   key          TEXT NOT NULL,
   value        TEXT NOT NULL DEFAULT '',
@@ -579,10 +579,10 @@ CREATE TABLE IF NOT EXISTS dv_plugin_config (
   updated_at   TEXT NOT NULL DEFAULT (datetime('now')),
   PRIMARY KEY (plugin_name, key)
 );
-CREATE INDEX IF NOT EXISTS idx_dv_plugin_config_plugin ON dv_plugin_config(plugin_name);
+CREATE INDEX IF NOT EXISTS idx_plugin_config_plugin ON plugin_config(plugin_name);
 
 -- Runner spawns (agent SDK session queue for mycelium-runner)
-CREATE TABLE IF NOT EXISTS dv_runner_spawns (
+CREATE TABLE IF NOT EXISTS runner_spawns (
   id             INTEGER PRIMARY KEY AUTOINCREMENT,
   tier           TEXT NOT NULL DEFAULT 'agent',
   model          TEXT NOT NULL DEFAULT '',
@@ -598,13 +598,13 @@ CREATE TABLE IF NOT EXISTS dv_runner_spawns (
   done_at        TEXT,
   created_at     TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_dv_runner_spawns_status ON dv_runner_spawns(status);
-CREATE INDEX IF NOT EXISTS idx_dv_support_tickets_status ON dv_support_tickets(status);
-CREATE INDEX IF NOT EXISTS idx_dv_support_tickets_instance ON dv_support_tickets(instance_id);
-CREATE INDEX IF NOT EXISTS idx_dv_support_tickets_priority ON dv_support_tickets(priority);
+CREATE INDEX IF NOT EXISTS idx_runner_spawns_status ON runner_spawns(status);
+CREATE INDEX IF NOT EXISTS idx_support_tickets_status ON support_tickets(status);
+CREATE INDEX IF NOT EXISTS idx_support_tickets_instance ON support_tickets(instance_id);
+CREATE INDEX IF NOT EXISTS idx_support_tickets_priority ON support_tickets(priority);
 
 -- Node profiles: Stand Up calibration system for agent/drone/admin behavior rules
-CREATE TABLE IF NOT EXISTS dv_node_profiles (
+CREATE TABLE IF NOT EXISTS node_profiles (
   id                 TEXT PRIMARY KEY,
   node_type          TEXT NOT NULL DEFAULT 'agent',
   layer              TEXT NOT NULL DEFAULT 'customer',
@@ -619,11 +619,11 @@ CREATE TABLE IF NOT EXISTS dv_node_profiles (
   created_at         TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_dv_node_profiles_layer ON dv_node_profiles(layer);
-CREATE INDEX IF NOT EXISTS idx_dv_node_profiles_node_type ON dv_node_profiles(node_type);
+CREATE INDEX IF NOT EXISTS idx_node_profiles_layer ON node_profiles(layer);
+CREATE INDEX IF NOT EXISTS idx_node_profiles_node_type ON node_profiles(node_type);
 
 -- Customer instances (links billing to provisioning to deploys to churn)
-CREATE TABLE IF NOT EXISTS dv_customer_instances (
+CREATE TABLE IF NOT EXISTS customer_instances (
   id                    INTEGER PRIMARY KEY AUTOINCREMENT,
   org_id                TEXT NOT NULL,
   railway_project_id    TEXT,
@@ -643,23 +643,23 @@ CREATE TABLE IF NOT EXISTS dv_customer_instances (
   created_at            TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at            TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_instances_org ON dv_customer_instances(org_id);
-CREATE INDEX IF NOT EXISTS idx_instances_status ON dv_customer_instances(status);
-CREATE INDEX IF NOT EXISTS idx_instances_domain ON dv_customer_instances(domain);
+CREATE INDEX IF NOT EXISTS idx_instances_org ON customer_instances(org_id);
+CREATE INDEX IF NOT EXISTS idx_instances_status ON customer_instances(status);
+CREATE INDEX IF NOT EXISTS idx_instances_domain ON customer_instances(domain);
 
 -- Message read tracking (agent ↔ message acknowledgment)
-CREATE TABLE IF NOT EXISTS dv_message_reads (
+CREATE TABLE IF NOT EXISTS message_reads (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   message_id  INTEGER NOT NULL,
   agent_id    TEXT NOT NULL,
   read_at     TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(message_id, agent_id)
 );
-CREATE INDEX IF NOT EXISTS idx_msg_reads_agent ON dv_message_reads(agent_id);
-CREATE INDEX IF NOT EXISTS idx_msg_reads_message ON dv_message_reads(message_id);
+CREATE INDEX IF NOT EXISTS idx_msg_reads_agent ON message_reads(agent_id);
+CREATE INDEX IF NOT EXISTS idx_msg_reads_message ON message_reads(message_id);
 
 -- Team settings (customer-facing configuration that syncs to node profiles)
-CREATE TABLE IF NOT EXISTS dv_team_settings (
+CREATE TABLE IF NOT EXISTS team_settings (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   section TEXT NOT NULL,
   key TEXT NOT NULL,
@@ -668,4 +668,4 @@ CREATE TABLE IF NOT EXISTS dv_team_settings (
   updated_by TEXT NOT NULL DEFAULT '',
   UNIQUE(section, key)
 );
-CREATE INDEX IF NOT EXISTS idx_team_settings_section ON dv_team_settings(section);
+CREATE INDEX IF NOT EXISTS idx_team_settings_section ON team_settings(section);

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -669,3 +669,30 @@ CREATE TABLE IF NOT EXISTS team_settings (
   UNIQUE(section, key)
 );
 CREATE INDEX IF NOT EXISTS idx_team_settings_section ON team_settings(section);
+
+-- Teams
+CREATE TABLE IF NOT EXISTS teams (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  created_by TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_teams_org ON teams(org_id);
+
+CREATE TABLE IF NOT EXISTS team_members (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  team_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  user_type TEXT NOT NULL DEFAULT 'operator',
+  role TEXT NOT NULL DEFAULT 'member',
+  is_primary INTEGER NOT NULL DEFAULT 0,
+  joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(team_id, user_id),
+  FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_team_members_team ON team_members(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_members_user ON team_members(user_id);
+CREATE INDEX IF NOT EXISTS idx_team_members_primary ON team_members(is_primary) WHERE is_primary = 1;

--- a/studio-react/src/App.tsx
+++ b/studio-react/src/App.tsx
@@ -30,6 +30,7 @@ const SpawnsPage = lazy(() => import('./pages/SpawnsPage'))
 const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'))
 const FeedbackPage = lazy(() => import('./pages/FeedbackPage'))
 const DeploymentsPage = lazy(() => import('./pages/DeploymentsPage'))
+const TeamsPage = lazy(() => import('./pages/TeamsPage'))
 const TeamSettingsPage = lazy(() => import('./pages/TeamSettingsPage'))
 const PluginPageView = lazy(() => import('./pages/PluginPageView'))
 
@@ -71,6 +72,7 @@ export default function App() {
             <Route path="bugs" element={<BugsPage />} />
             <Route path="assets" element={<AssetsPage />} />
             <Route path="operators" element={<OperatorsPage />} />
+            <Route path="teams" element={<TeamsPage />} />
             <Route path="approvals" element={<ApprovalsPage />} />
             <Route path="drones" element={<DronesPage />} />
             <Route path="concepts" element={<ConceptsPage />} />

--- a/studio-react/src/api/endpoints.ts
+++ b/studio-react/src/api/endpoints.ts
@@ -33,6 +33,8 @@ import type {
   InboxItem,
   InboxCountResponse,
   TeamSettingsGrouped,
+  Team,
+  TeamMember,
 } from './types';
 
 // Auth
@@ -688,4 +690,39 @@ export function deleteTeamSetting(section: string, key: string): Promise<{ ok: b
 
 export function syncTeamSettings(): Promise<{ ok: boolean }> {
   return apiPost<{ ok: boolean }>('/team-settings/sync', {});
+}
+
+// Teams
+
+export function fetchTeams(orgId?: string): Promise<Team[]> {
+  const params = orgId ? `?org_id=${orgId}` : '';
+  return apiGet<{ teams: Team[] }>(`/teams${params}`).then(r => r.teams);
+}
+
+export function fetchTeam(id: string): Promise<Team> {
+  return apiGet<Team>(`/teams/${id}`);
+}
+
+export function createTeam(data: { id: string; name: string; org_id: string; description?: string }): Promise<Team> {
+  return apiPost<Team>('/teams', data);
+}
+
+export function updateTeam(id: string, data: Partial<Team>): Promise<Team> {
+  return apiPut<Team>(`/teams/${id}`, data);
+}
+
+export function deleteTeam(id: string): Promise<void> {
+  return apiDelete<void>(`/teams/${id}`);
+}
+
+export function addTeamMember(teamId: string, data: { user_id: string; user_type: string; role?: string; is_primary?: boolean }): Promise<TeamMember> {
+  return apiPost<TeamMember>(`/teams/${teamId}/members`, data);
+}
+
+export function updateTeamMember(teamId: string, userId: string, data: { role?: string; is_primary?: boolean }): Promise<TeamMember> {
+  return apiPut<TeamMember>(`/teams/${teamId}/members/${userId}`, data);
+}
+
+export function removeTeamMember(teamId: string, userId: string): Promise<void> {
+  return apiDelete<void>(`/teams/${teamId}/members/${userId}`);
 }

--- a/studio-react/src/api/types.ts
+++ b/studio-react/src/api/types.ts
@@ -543,6 +543,31 @@ export interface TeamSetting {
 
 export type TeamSettingsGrouped = Record<string, Record<string, unknown>>;
 
+// ── Teams ──
+
+export interface Team {
+  id: string;
+  org_id: string;
+  name: string;
+  description: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  members?: TeamMember[];
+  projects?: Project[];
+  member_count?: number;
+}
+
+export interface TeamMember {
+  id: number;
+  team_id: string;
+  user_id: string;
+  user_type: 'operator' | 'agent';
+  role: 'lead' | 'member' | 'guest';
+  is_primary: number;
+  joined_at: string;
+}
+
 // Customer Instances
 
 export interface CustomerInstance {

--- a/studio-react/src/layouts/SideNav.tsx
+++ b/studio-react/src/layouts/SideNav.tsx
@@ -72,6 +72,7 @@ const staticNavSections: NavSection[] = [
     label: 'Manage',
     items: [
       { to: '/operators', label: 'Operators', icon: Users },
+      { to: '/teams', label: 'Teams', icon: Users, adminOnly: true },
       { to: '/team-settings', label: 'Team Settings', icon: Settings2, adminOnly: true },
       { to: '/deployments', label: 'Deployments', icon: Server, adminOnly: true },
       { to: '/approvals', label: 'Approvals', icon: ShieldCheck, adminOnly: true },

--- a/studio-react/src/pages/TeamsPage.tsx
+++ b/studio-react/src/pages/TeamsPage.tsx
@@ -1,0 +1,631 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useDashboardStore } from '../stores/dashboardStore'
+import {
+  fetchTeams,
+  fetchTeam,
+  createTeam,
+  updateTeam,
+  deleteTeam,
+  addTeamMember,
+  removeTeamMember,
+} from '../api/endpoints'
+import type { Team, TeamMember } from '../api/types'
+import ModalOverlay from '../components/modals/ModalOverlay'
+import { toast } from 'sonner'
+import { ChevronDown, ChevronRight, Plus, Trash2, UserPlus } from 'lucide-react'
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+const ROLE_COLORS: Record<string, string> = {
+  lead: 'bg-accent/15 text-accent',
+  member: 'bg-green/15 text-green',
+  guest: 'bg-text-muted/15 text-text-muted',
+}
+
+// ---- Create / Edit Team Modal -----------------------------------------------
+
+interface TeamFormProps {
+  isOpen: boolean
+  onClose: () => void
+  team?: Team | null
+  onSaved: () => void
+}
+
+function TeamFormModal({ isOpen, onClose, team, onSaved }: TeamFormProps) {
+  const organizations = useDashboardStore((s) => s.organizations)
+  const isEditing = !!team
+
+  const [id, setId] = useState(team?.id ?? '')
+  const [name, setName] = useState(team?.name ?? '')
+  const [orgId, setOrgId] = useState(team?.org_id ?? (organizations[0]?.id || ''))
+  const [description, setDescription] = useState(team?.description ?? '')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset form when team changes
+  useEffect(() => {
+    setId(team?.id ?? '')
+    setName(team?.name ?? '')
+    setOrgId(team?.org_id ?? (organizations[0]?.id || ''))
+    setDescription(team?.description ?? '')
+    setError(null)
+  }, [team, organizations])
+
+  function resetAndClose() {
+    setId('')
+    setName('')
+    setOrgId(organizations[0]?.id || '')
+    setDescription('')
+    setError(null)
+    onClose()
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim()) return
+    if (!isEditing && !id.trim()) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      if (isEditing) {
+        await updateTeam(team!.id, {
+          name: name.trim(),
+          description: description.trim(),
+        })
+        toast.success('Team updated')
+      } else {
+        await createTeam({
+          id: id.trim(),
+          name: name.trim(),
+          org_id: orgId,
+          description: description.trim() || undefined,
+        })
+        toast.success('Team created')
+      }
+      onSaved()
+      resetAndClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save team')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <ModalOverlay isOpen={isOpen} onClose={resetAndClose} title={isEditing ? 'Edit Team' : 'Create Team'}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {!isEditing && (
+          <div>
+            <label className="block text-xs font-medium text-text-dim mb-1">
+              ID <span className="text-text-muted">(URL-friendly slug)</span>
+            </label>
+            <input
+              type="text"
+              value={id}
+              onChange={(e) => setId(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-'))}
+              placeholder="engineering-team"
+              autoFocus
+              disabled={submitting}
+              className="w-full bg-surface-raised border border-border rounded px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40 disabled:opacity-50"
+            />
+          </div>
+        )}
+
+        <div>
+          <label className="block text-xs font-medium text-text-dim mb-1">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Engineering"
+            autoFocus={isEditing}
+            disabled={submitting}
+            className="w-full bg-surface-raised border border-border rounded px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40 disabled:opacity-50"
+          />
+        </div>
+
+        {!isEditing && (
+          <div>
+            <label className="block text-xs font-medium text-text-dim mb-1">Organization</label>
+            <select
+              value={orgId}
+              onChange={(e) => setOrgId(e.target.value)}
+              disabled={submitting}
+              className="w-full bg-surface-raised border border-border rounded px-3 py-2 text-sm text-text-dim focus:outline-none focus:ring-1 focus:ring-accent/40 appearance-none cursor-pointer disabled:opacity-50"
+            >
+              {organizations.map((org) => (
+                <option key={org.id} value={org.id}>{org.name} ({org.id})</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div>
+          <label className="block text-xs font-medium text-text-dim mb-1">
+            Description <span className="text-text-muted">(optional)</span>
+          </label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What does this team work on?"
+            rows={3}
+            disabled={submitting}
+            className="w-full bg-surface-raised border border-border rounded px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40 resize-none disabled:opacity-50"
+          />
+        </div>
+
+        {error && <p className="text-red text-xs">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={resetAndClose}
+            className="px-4 py-2 rounded text-sm text-text-dim hover:text-text transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !name.trim() || (!isEditing && !id.trim())}
+            className="px-5 py-2 rounded text-sm font-semibold bg-accent text-bg hover:bg-accent-light transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? 'Saving...' : isEditing ? 'Save Changes' : 'Create Team'}
+          </button>
+        </div>
+      </form>
+    </ModalOverlay>
+  )
+}
+
+// ---- Add Member Modal -------------------------------------------------------
+
+interface AddMemberModalProps {
+  isOpen: boolean
+  onClose: () => void
+  teamId: string
+  onSaved: () => void
+}
+
+function AddMemberModal({ isOpen, onClose, teamId, onSaved }: AddMemberModalProps) {
+  const agents = useDashboardStore((s) => s.agents)
+  const operators = useDashboardStore((s) => s.operators)
+
+  const [userId, setUserId] = useState('')
+  const [userType, setUserType] = useState<'operator' | 'agent'>('operator')
+  const [role, setRole] = useState<string>('member')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function resetAndClose() {
+    setUserId('')
+    setUserType('operator')
+    setRole('member')
+    setError(null)
+    onClose()
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!userId.trim()) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await addTeamMember(teamId, {
+        user_id: userId.trim(),
+        user_type: userType,
+        role,
+      })
+      toast.success('Member added')
+      onSaved()
+      resetAndClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add member')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const suggestions = userType === 'operator'
+    ? operators.map((o) => ({ id: o.id, label: o.display_name }))
+    : agents.map((a) => ({ id: a.id, label: a.name }))
+
+  return (
+    <ModalOverlay isOpen={isOpen} onClose={resetAndClose} title="Add Team Member">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-xs font-medium text-text-dim mb-1">Type</label>
+          <div className="flex gap-2">
+            {(['operator', 'agent'] as const).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => { setUserType(t); setUserId('') }}
+                className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+                  userType === t
+                    ? 'bg-accent/20 text-accent border border-accent/40'
+                    : 'bg-surface-raised text-text-muted border border-border hover:text-text-dim'
+                }`}
+              >
+                {t === 'operator' ? 'Operator (Person)' : 'Agent (AI)'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-text-dim mb-1">User ID</label>
+          <input
+            type="text"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            placeholder={userType === 'operator' ? 'greatness' : 'greatness-claude'}
+            autoFocus
+            disabled={submitting}
+            className="w-full bg-surface-raised border border-border rounded px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-accent/40 disabled:opacity-50"
+          />
+          {suggestions.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {suggestions.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  onClick={() => setUserId(s.id)}
+                  className={`px-2 py-0.5 rounded-full text-xs font-mono transition-colors ${
+                    userId === s.id
+                      ? 'bg-accent/20 text-accent border border-accent/40'
+                      : 'bg-surface-raised text-text-muted border border-border hover:text-text-dim'
+                  }`}
+                >
+                  {s.id}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-text-dim mb-1">Role</label>
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            disabled={submitting}
+            className="w-full bg-surface-raised border border-border rounded px-3 py-2 text-sm text-text-dim focus:outline-none focus:ring-1 focus:ring-accent/40 appearance-none cursor-pointer disabled:opacity-50"
+          >
+            <option value="lead">Lead</option>
+            <option value="member">Member</option>
+            <option value="guest">Guest</option>
+          </select>
+        </div>
+
+        {error && <p className="text-red text-xs">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={resetAndClose}
+            className="px-4 py-2 rounded text-sm text-text-dim hover:text-text transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !userId.trim()}
+            className="px-5 py-2 rounded text-sm font-semibold bg-accent text-bg hover:bg-accent-light transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? 'Adding...' : 'Add Member'}
+          </button>
+        </div>
+      </form>
+    </ModalOverlay>
+  )
+}
+
+// ---- Team Card (expandable) ------------------------------------------------
+
+interface TeamCardProps {
+  team: Team
+  onEdit: () => void
+  onDelete: () => void
+  onRefresh: () => void
+}
+
+function TeamCard({ team, onEdit, onDelete, onRefresh }: TeamCardProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [members, setMembers] = useState<TeamMember[]>(team.members ?? [])
+  const [loadingMembers, setLoadingMembers] = useState(false)
+  const [showAddMember, setShowAddMember] = useState(false)
+
+  async function loadMembers(force = false) {
+    if (!force && (members.length > 0 || loadingMembers)) return
+    setLoadingMembers(true)
+    try {
+      const detail = await fetchTeam(team.id)
+      setMembers(detail.members ?? [])
+    } catch {
+      toast.error('Failed to load team members')
+    } finally {
+      setLoadingMembers(false)
+    }
+  }
+
+  function handleToggle() {
+    const next = !expanded
+    setExpanded(next)
+    if (next) loadMembers()
+  }
+
+  async function handleRemoveMember(userId: string) {
+    if (!confirm(`Remove "${userId}" from team "${team.name}"?`)) return
+    try {
+      await removeTeamMember(team.id, userId)
+      toast.success('Member removed')
+      setMembers((prev) => prev.filter((m) => m.user_id !== userId))
+      onRefresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove member')
+    }
+  }
+
+  function handleMemberAdded() {
+    setMembers([])
+    loadMembers(true)
+    onRefresh()
+  }
+
+  const memberCount = team.member_count ?? members.length
+
+  return (
+    <div className="bg-surface-raised rounded-lg border border-border/50 hover:border-border transition-colors group">
+      {/* Main card content */}
+      <div className="p-4 flex flex-col gap-3">
+        {/* Header: name + actions */}
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="font-semibold text-text truncate">{team.name}</h3>
+          <div className="flex items-center gap-2">
+            <span className="shrink-0 text-xs bg-accent/10 text-accent px-2 py-0.5 rounded-full font-medium font-mono">
+              {team.org_id}
+            </span>
+            <div className="hidden group-hover:flex items-center gap-1">
+              <button
+                onClick={onEdit}
+                className="text-text-muted hover:text-accent transition-colors p-0.5"
+                title="Edit"
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M8.5 2.5l3 3M2 9l6-6 3 3-6 6H2V9z" strokeLinejoin="round" />
+                </svg>
+              </button>
+              <button
+                onClick={onDelete}
+                className="text-text-muted hover:text-red transition-colors p-0.5"
+                title="Delete"
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M3 4h8M5.5 4V3a1 1 0 0 1 1-1h1a1 1 0 0 1 1 1v1M4.5 4v7.5a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1V4" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* ID */}
+        <p className="text-text-muted font-mono text-sm leading-none">{team.id}</p>
+
+        {/* Description */}
+        {team.description && (
+          <p className="text-text-dim text-sm leading-relaxed">{team.description}</p>
+        )}
+
+        {/* Footer: member count + date + expand toggle */}
+        <div className="flex items-center justify-between mt-auto pt-1">
+          <div className="flex items-center gap-3 text-xs text-text-muted">
+            <span>{memberCount} member{memberCount !== 1 ? 's' : ''}</span>
+            <span>Created {formatDate(team.created_at)}</span>
+          </div>
+          <button
+            onClick={handleToggle}
+            className="flex items-center gap-1 text-xs text-text-muted hover:text-accent transition-colors"
+          >
+            {expanded ? (
+              <>
+                <ChevronDown size={14} />
+                <span>Hide</span>
+              </>
+            ) : (
+              <>
+                <ChevronRight size={14} />
+                <span>Members</span>
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Expanded: members list */}
+      {expanded && (
+        <div className="border-t border-border/50 px-4 py-3">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-text-dim uppercase tracking-wider">Members</span>
+            <button
+              onClick={() => setShowAddMember(true)}
+              className="flex items-center gap-1 text-xs text-accent hover:text-accent-light transition-colors"
+            >
+              <UserPlus size={12} />
+              <span>Add</span>
+            </button>
+          </div>
+
+          {loadingMembers ? (
+            <div className="flex items-center justify-center py-4">
+              <div className="inline-block w-4 h-4 border-2 border-accent/30 border-t-accent rounded-full animate-spin" />
+            </div>
+          ) : members.length === 0 ? (
+            <p className="text-text-muted text-xs py-2">No members yet.</p>
+          ) : (
+            <div className="space-y-1.5">
+              {members.map((m) => (
+                <div
+                  key={`${m.user_id}-${m.user_type}`}
+                  className="flex items-center justify-between gap-2 px-2 py-1.5 rounded bg-surface hover:bg-surface/80 transition-colors"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-sm font-mono text-text truncate">{m.user_id}</span>
+                    <span className={`shrink-0 text-[10px] px-1.5 py-0.5 rounded-full font-medium ${ROLE_COLORS[m.role] || ROLE_COLORS.member}`}>
+                      {m.role}
+                    </span>
+                    <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded-full bg-surface-raised text-text-muted">
+                      {m.user_type}
+                    </span>
+                    {m.is_primary === 1 && (
+                      <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded-full bg-accent/10 text-accent">
+                        primary
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => handleRemoveMember(m.user_id)}
+                    className="shrink-0 text-text-muted hover:text-red transition-colors p-0.5"
+                    title="Remove member"
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {showAddMember && (
+            <AddMemberModal
+              isOpen={showAddMember}
+              onClose={() => setShowAddMember(false)}
+              teamId={team.id}
+              onSaved={handleMemberAdded}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---- Main Page --------------------------------------------------------------
+
+export default function TeamsPage() {
+  const [teams, setTeams] = useState<Team[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [editingTeam, setEditingTeam] = useState<Team | null>(null)
+
+  const loadTeams = useCallback(async () => {
+    try {
+      const data = await fetchTeams()
+      setTeams(data)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load teams')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadTeams()
+  }, [loadTeams])
+
+  async function handleDelete(team: Team) {
+    if (!confirm(`Delete team "${team.name}"? This will remove all member associations.`)) return
+    try {
+      await deleteTeam(team.id)
+      toast.success('Team deleted')
+      loadTeams()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete team')
+    }
+  }
+
+  // Loading state
+  if (loading && teams.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-center">
+          <div className="inline-block w-6 h-6 border-2 border-accent/30 border-t-accent rounded-full animate-spin mb-3" />
+          <p className="text-text-dim text-sm">Loading teams...</p>
+        </div>
+      </div>
+    )
+  }
+
+  // Error state
+  if (error && teams.length === 0) {
+    return (
+      <div className="bg-surface rounded-lg p-8 text-center">
+        <p className="text-red text-sm mb-3">Failed to load teams</p>
+        <p className="text-text-muted text-xs mb-4">{error}</p>
+        <button
+          onClick={loadTeams}
+          className="px-4 py-2 rounded text-sm bg-surface-raised text-text-dim hover:text-text transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-lg font-semibold text-text">Teams</h2>
+            <p className="text-text-muted text-sm mt-0.5">
+              {teams.length} team{teams.length !== 1 ? 's' : ''} registered
+            </p>
+          </div>
+          <button
+            onClick={() => { setEditingTeam(null); setShowForm(true) }}
+            className="flex items-center gap-1.5 px-4 py-2 rounded text-sm font-medium bg-accent text-bg hover:bg-accent-light transition-colors"
+          >
+            <Plus size={14} />
+            Create Team
+          </button>
+        </div>
+
+        {teams.length === 0 ? (
+          <div className="bg-surface rounded-lg p-8 text-center">
+            <p className="text-text-muted text-sm">No teams created yet.</p>
+            <p className="text-text-muted text-xs mt-1">Create a team to organize operators and agents into working groups.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {teams.map((team) => (
+              <TeamCard
+                key={team.id}
+                team={team}
+                onEdit={() => { setEditingTeam(team); setShowForm(true) }}
+                onDelete={() => handleDelete(team)}
+                onRefresh={loadTeams}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Create / Edit Modal */}
+      {showForm && (
+        <TeamFormModal
+          isOpen={showForm}
+          onClose={() => { setShowForm(false); setEditingTeam(null) }}
+          team={editingTeam}
+          onSaved={loadTeams}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- **Table rename**: Removed `dv_` prefix from all 43+ database tables and 800+ code references across schema, db.js, routes, index.js, and 14 plugins. Live DB migration runs on startup (idempotent ALTER TABLE RENAME).
- **Teams system**: Added first-class Teams layer (teams inside orgs) with membership, work scoping, auto-channel creation, boot payload integration, and auto-dispatch scoping.
- **Dashboard**: New TeamsPage with team management UI, API integration, and nav item.
- **MCP tools**: 5 new team tools in mycelium-mcp (list, get, create, add/remove member).

## Changes
1. `server/schema.sql` — All table/index names cleaned, teams + team_members tables added
2. `server/db.js` — 414 refs renamed, 10 team DB functions, boot payload + auto-dispatch scoping
3. `server/routes/mycelium.js` — 54 refs renamed, 9 team API endpoints added
4. `server/index.js` — 9 refs renamed
5. `server/migrate-table-names.js` — New startup migration (67 tables)
6. `server/plugins/` — 324 refs renamed across 57 files
7. `studio-react/` — Team types, API functions, TeamsPage, nav item, route

## Test plan
- [x] Local server starts with migration (48 tables renamed successfully)
- [x] API endpoints return valid data (`/agents`, `/admin/overview`)
- [x] Teams CRUD API tested (create team, add member, list, get detail)
- [x] Auto-channel creation verified (team creates #team-{slug} channel)
- [x] Dashboard builds clean (no TS errors)
- [ ] Production deploy via Railway
- [ ] Verify production migration runs correctly
- [ ] Seed Dioverse teams on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)