### PR TITLE
Fix drone bugs: stale jobs, project dispatch, worker resilience, template merging

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -2232,6 +2232,32 @@ export function listDroneJobs(filters) {
   return db.prepare('SELECT * FROM drone_jobs WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
 }
 
+// Bug #137: Release stale claimed jobs for a drone (claimed >1 hour ago, not completed)
+export function releaseStaleClaimedJobs(droneId) {
+  var staleJobs = db.prepare(
+    "SELECT * FROM drone_jobs WHERE status = 'claimed' AND drone_id = ? AND started_at < datetime('now', '-1 hour')"
+  ).all(droneId);
+  for (var job of staleJobs) {
+    db.prepare(
+      "UPDATE drone_jobs SET status = 'failed', error = ?, completed_at = datetime('now') WHERE id = ?"
+    ).run('[stale_timeout] Job was claimed for >1 hour with no completion. Auto-failed on drone restart.', job.id);
+  }
+  return staleJobs;
+}
+
+// Also auto-fail ALL stale claimed jobs across all drones (called periodically or on server boot)
+export function releaseAllStaleClaimedJobs() {
+  var staleJobs = db.prepare(
+    "SELECT * FROM drone_jobs WHERE status = 'claimed' AND started_at < datetime('now', '-1 hour')"
+  ).all();
+  for (var job of staleJobs) {
+    db.prepare(
+      "UPDATE drone_jobs SET status = 'failed', error = ?, completed_at = datetime('now') WHERE id = ?"
+    ).run('[stale_timeout] Job was claimed for >1 hour with no progress. Auto-failed by server.', job.id);
+  }
+  return staleJobs;
+}
+
 export function listDrones() {
   return db.prepare("SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, created_at FROM agents WHERE project_id = 'drone' ORDER BY created_at").all();
 }

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -132,7 +132,7 @@ import {
   listWebhookDeliveries, pruneWebhookDeliveries,
   getAdminOps, resolveStaleRequests,
   createTeamChat, listTeamChat,
-  createDroneJob, getDroneJob, claimDroneJob, updateDroneJob, listDroneJobs, listDrones, listAssetsByDroneJob, bulkCancelDroneJobs,
+  createDroneJob, getDroneJob, claimDroneJob, updateDroneJob, listDroneJobs, listDrones, listAssetsByDroneJob, bulkCancelDroneJobs, releaseStaleClaimedJobs, releaseAllStaleClaimedJobs,
   createJobTemplate, getJobTemplate, listJobTemplates, updateJobTemplate, deleteJobTemplate,
   updateDroneDiagnostics, getDroneDiagnostics, renderJobForDrone, checkDroneCompatibility,
   createDroneProfile, getDroneProfile, listDroneProfiles, updateDroneProfile, deleteDroneProfile,
@@ -172,7 +172,7 @@ import {
   getAllTeamSettingsGrouped, syncTeamSettingsToProfile,
   createTeam, getTeam, listTeams, updateTeam, deleteTeam,
   addTeamMember, updateTeamMember, removeTeamMember,
-  getTeamsForUser, getTeamProjects
+  getTeamsForUser, getTeamProjects, getTeamProjectIdsForAgent
 } from '../db.js';
 import { loadPlugins, getLoadedPlugins, getPluginMcpTools, callEventHooks, registerEventHook, getWorkerStatus } from '../plugins.js';
 
@@ -765,7 +765,13 @@ function dispatchWorkToIdleAgents(triggerContext) {
     if (agentTasks.length > 0) continue; // has queued work
 
     // Try to find work: plan steps first, then unassigned tasks
-    var step = getNextUnassignedPlanStep();
+    // Bug #131: Scope to agent's project(s) to prevent cross-project dispatch
+    var agentProjectIds = getTeamProjectIdsForAgent(agent.id);
+    // Also include the agent's own project_id field as fallback
+    if (agent.project_id && agent.project_id !== 'drone' && agentProjectIds.indexOf(agent.project_id) === -1) {
+      agentProjectIds.push(agent.project_id);
+    }
+    var step = getNextUnassignedPlanStep(agentProjectIds.length > 0 ? agentProjectIds : null);
     // Capability check — skip if agent can't handle this step
     if (step && !agentCanHandle(agent, step)) step = null;
     if (step) {
@@ -778,7 +784,7 @@ function dispatchWorkToIdleAgents(triggerContext) {
       continue;
     }
 
-    var task = getNextUnassignedTask(claimedTaskIds);
+    var task = getNextUnassignedTask(claimedTaskIds, agentProjectIds.length > 0 ? agentProjectIds : null);
     // Capability check — skip if agent can't handle this task
     if (task && !agentCanHandle(agent, task)) task = null;
     if (task) {
@@ -3933,6 +3939,29 @@ setInterval(function () {
   } catch (e) { /* cleanup is best-effort */ }
 }, 10 * 60 * 1000);
 
+// Bug #137: Periodically auto-fail stale claimed drone jobs (every 15 minutes)
+// Bug #134/#132: Also flag drones offline if no heartbeat in 30 minutes
+setInterval(function () {
+  try {
+    var stale = releaseAllStaleClaimedJobs();
+    if (stale.length > 0) {
+      emitEvent('drone_stale_cleanup', '__system__', 'drone', 'Auto-failed ' + stale.length + ' stale claimed drone job(s): ' + stale.map(function (j) { return '#' + j.id; }).join(', '), { job_ids: stale.map(function (j) { return j.id; }) });
+    }
+    // Flag drones offline if no heartbeat in 30 minutes
+    var drones = listDrones();
+    for (var drone of drones) {
+      if (drone.status === 'online' && drone.last_heartbeat) {
+        var lastSeen = new Date(drone.last_heartbeat).getTime();
+        var minutesAgo = (Date.now() - lastSeen) / 60000;
+        if (minutesAgo > 30) {
+          updateAgentHeartbeat(drone.id, 'offline', '');
+          emitEvent('drone_offline_detected', '__system__', 'drone', 'Drone ' + drone.id + ' flagged offline — no heartbeat for ' + Math.round(minutesAgo) + ' minutes', { drone_id: drone.id, minutes_since_heartbeat: Math.round(minutesAgo) });
+        }
+      }
+    }
+  } catch (e) { /* cleanup is best-effort */ }
+}, 15 * 60 * 1000);
+
 // POST /files — upload a temp file (multipart form, field name: "file")
 // curl -X POST -H "X-Agent-Key: <key>" -F "file=@myimage.png" https://mycelium.fyi/api/mycelium/files
 // Files auto-delete after 24 hours. Download with wget/curl before then.
@@ -4356,8 +4385,14 @@ router.post('/drones/claim', function (req, res) {
   var agentId = checkAgent(req, res);
   if (!agentId) return;
   var capabilities = req.body.capabilities || [];
+
+  // Bug #137: Release stale claimed jobs before claiming new work
+  // Auto-fail jobs claimed by this drone for >1 hour with no completion
+  var staleJobs = releaseStaleClaimedJobs(agentId);
+  var staleReleased = staleJobs.length;
+
   var job = claimDroneJob(agentId, capabilities);
-  if (!job) return res.json({ job: null });
+  if (!job) return res.json({ job: null, stale_released: staleReleased });
 
   // If job has a job_type, render commands from template
   if (job.job_type) {
@@ -4371,15 +4406,26 @@ router.post('/drones/claim', function (req, res) {
       try { var db2 = getDB(); db2.prepare("UPDATE drone_jobs SET status = 'pending', drone_id = NULL, started_at = NULL WHERE id = ?").run(job.id); } catch (e) { /* fallback already set status */ }
       return res.json({ job: null, skipped: { job_id: job.id, reason: rendered.error } });
     }
-    // Write rendered command back to the job
-    updateDroneJob(job.id, { command: rendered.command });
-    // Inject setup_steps and artifacts into the job's input_data
-    inputData.setup_steps = rendered.setup_steps;
-    inputData.artifacts = rendered.artifacts;
+    // Write rendered command back to the job (only if job doesn't already have one)
+    if (!job.command) {
+      updateDroneJob(job.id, { command: rendered.command });
+    }
+    // Bug #136: Merge template setup_steps/artifacts with job's own, instead of replacing
+    // Job-specified artifacts take priority (appended after template artifacts, deduped)
+    var jobArtifacts = inputData.artifacts || [];
+    var templateArtifacts = rendered.artifacts || [];
+    var mergedArtifacts = templateArtifacts.slice();
+    for (var a of jobArtifacts) {
+      if (mergedArtifacts.indexOf(a) === -1) mergedArtifacts.push(a);
+    }
+    inputData.artifacts = mergedArtifacts;
+    // Job-specified setup_steps come after template steps
+    var jobSetupSteps = inputData.setup_steps || [];
+    inputData.setup_steps = (rendered.setup_steps || []).concat(jobSetupSteps);
     inputData.workspace_dir = rendered.workspace_name;
     updateDroneJob(job.id, { input_data: JSON.stringify(inputData) });
     // Return enriched job
-    job.command = rendered.command;
+    if (!job.command) job.command = rendered.command;
     job.input_data = JSON.stringify(inputData);
   }
 

--- a/tools/drone_worker_v4.py
+++ b/tools/drone_worker_v4.py
@@ -854,7 +854,7 @@ def execute_job(api, job, system_info, runner, allowed_commands,
     print(f"  Executing: {command[:150]}")
     try:
         r = runner.run_streaming(
-            command, shell=True, cwd=exec_dir, env=env, timeout=3600
+            command, shell=True, cwd=exec_dir, env=env, timeout=7200
         )
         stdout = r.stdout[:MAX_OUTPUT_SIZE] if r.stdout else ""
         stderr = r.stderr[:MAX_OUTPUT_SIZE] if r.stderr else ""
@@ -882,7 +882,7 @@ def execute_job(api, job, system_info, runner, allowed_commands,
     except __import__("subprocess").TimeoutExpired:
         return False, {
             "error_type": "timeout",
-            "message": "Job timed out after 3600 seconds (1 hour).",
+            "message": "Job timed out after 7200 seconds (2 hours).",
         }
     except Exception as e:
         return False, {
@@ -1163,4 +1163,29 @@ Examples:
 
 
 if __name__ == "__main__":
-    main()
+    # Bug #134/#132: Auto-restart on crash with backoff
+    max_restarts = 10
+    restart_count = 0
+    base_delay = 10  # seconds
+
+    while restart_count < max_restarts:
+        try:
+            main()
+            break  # Clean exit (e.g. KeyboardInterrupt handled inside)
+        except KeyboardInterrupt:
+            print("\nShutting down.")
+            break
+        except SystemExit:
+            break
+        except Exception as e:
+            restart_count += 1
+            delay = min(base_delay * restart_count, 300)
+            print(f"\n{'!' * 60}")
+            print(f"CRASH #{restart_count}/{max_restarts}: {e}")
+            traceback.print_exc()
+            print(f"Restarting in {delay}s...")
+            print(f"{'!' * 60}\n")
+            time.sleep(delay)
+
+    if restart_count >= max_restarts:
+        print(f"Max restarts ({max_restarts}) reached. Exiting. Run again manually.")


### PR DESCRIPTION
## Summary
- **Bug #137** (HIGH): Auto-fail drone jobs claimed >1hr with no completion — prevents stale jobs from blocking the pipeline
- **Bug #131**: Auto-dispatch now filters by agent's project scope — no more cross-project step assignments
- **Bug #134/#132**: Drone worker wraps main() in restart loop (10 retries, backoff). Server flags drones offline after 30min without heartbeat
- **Bug #136**: Template-based jobs merge artifacts/setup_steps instead of replacing job-specified ones. Pre-set commands preserved

## Test plan
- [ ] Queue a drone job, kill worker mid-job, restart — stale job auto-fails after 1hr
- [ ] Heartbeat with hijack-claude (king-city agent) — verify no WS plan steps dispatched
- [ ] Kill drone worker process — verify it auto-restarts
- [ ] Queue job with job_type + custom command/artifacts — verify merge not replace
- [ ] Check events dashboard for `drone_stale_cleanup` and `drone_offline_detected` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)