### PR TITLE
fix: route requests/directives to correct SDK handler

### DIFF
--- a/sdk/src/agent.js
+++ b/sdk/src/agent.js
@@ -398,9 +398,20 @@ export class MyceliumAgent {
         if (!this.workingOn) {
           var work = await this.getWork(true)  // auto_claim
           if (work.claimed) {
-            this.workingOn = work.claimed.title || ('work #' + work.claimed.id)
+            var item = work.claimed
+            this.workingOn = item.title || ('work #' + item.id)
             try {
-              await this._workHandler(work.claimed)
+              // Route to correct handler based on work item type
+              var type = item.type || item.msg_type
+              if ((type === 'request' || type === 'directive') && this._requestHandler) {
+                // Ensure content/from_agent are present (work queue may use summary/title)
+                if (!item.content && item.summary) item.content = item.summary
+                await this._requestHandler(item, type)
+              } else if (type === 'message' && this._messageHandler) {
+                await this._messageHandler(item)
+              } else {
+                await this._workHandler(item)
+              }
             } catch (err) {
               console.error('[mycelium] work handler error:', err.message)
             }

--- a/server/db.js
+++ b/server/db.js
@@ -1517,12 +1517,12 @@ export function buildWorkQueue(agentId, projectId, directives, requests, tasks, 
 
   // Priority 1: Blocking directives (MUST respond first)
   for (var d of directives) {
-    queue.push({ priority: 0, type: 'directive', id: d.id, title: 'DIRECTIVE from ' + d.from_agent, summary: (d.content || '').substring(0, 200), status: d.status });
+    queue.push({ priority: 0, type: 'directive', id: d.id, title: 'DIRECTIVE from ' + d.from_agent, summary: (d.content || '').substring(0, 200), status: d.status, from_agent: d.from_agent, content: d.content });
   }
 
   // Priority 2: Pending requests (respond before new work)
   for (var r of requests) {
-    queue.push({ priority: 1, type: 'request', id: r.id, title: 'Request from ' + r.from_agent, summary: (r.content || '').substring(0, 200), status: r.status });
+    queue.push({ priority: 1, type: 'request', id: r.id, title: 'Request from ' + r.from_agent, summary: (r.content || '').substring(0, 200), status: r.status, from_agent: r.from_agent, content: r.content });
   }
 
   // Priority 3: In-progress plan steps assigned to this agent


### PR DESCRIPTION
## Summary
- **SDK work loop routing bug**: Requests and directives claimed from the work queue were all routed to `onWork` handler, which called `completeTask()` on message IDs and failed with "Task not found". Now checks `item.type` and routes to `onRequest`/`onMessage` handlers correctly.
- **Work queue missing fields**: `buildWorkQueue()` for request/directive items didn't include `from_agent` or `content`, only `title`/`summary`. SDK handlers need these for proper responses.
- **Fallback**: SDK falls back to `item.summary` as `content` for pre-deploy compatibility.

## Test plan
- [x] Sent request to macbook-ollama, verified it routes through `onRequest` handler
- [x] Response correctly resolves the request and sends reply to the right agent
- [x] Content field properly populated via summary fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)