### PR TITLE
refactor: DRY server code — deduplicate helpers

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1152,6 +1152,23 @@ export function countBugs() {
 
 // -- Boot payload --
 
+function buildCrashRecovery(agent, agentId) {
+  if (!agent.last_heartbeat || !agent.working_on) return null;
+  var lastHb = new Date(agent.last_heartbeat + (agent.last_heartbeat.endsWith('Z') ? '' : 'Z')).getTime();
+  var staleness = Date.now() - lastHb;
+  var CRASH_THRESHOLD = 15 * 60 * 1000;
+  if (staleness <= CRASH_THRESHOLD) return null;
+  var lastSavepoint = getLatestSavepoint(agentId);
+  return {
+    detected: true,
+    last_heartbeat: agent.last_heartbeat,
+    stale_minutes: Math.round(staleness / 60000),
+    was_working_on: agent.working_on,
+    recovery_state: lastSavepoint && lastSavepoint.state_snapshot ? lastSavepoint.state_snapshot : null,
+    recovery_notes: lastSavepoint && lastSavepoint.notes ? lastSavepoint.notes : null
+  };
+}
+
 export function getBootPayload(agentId) {
   var agent = getAgent(agentId);
   if (!agent) return null;
@@ -1231,24 +1248,7 @@ export function getBootPayload(agentId) {
     }
   }
 
-  // ---- Crash detection ----
-  var crashRecovery = null;
-  if (agent.last_heartbeat && agent.working_on) {
-    var lastHb = new Date(agent.last_heartbeat + (agent.last_heartbeat.endsWith('Z') ? '' : 'Z')).getTime();
-    var staleness = Date.now() - lastHb;
-    var CRASH_THRESHOLD = 15 * 60 * 1000; // 15 minutes
-    if (staleness > CRASH_THRESHOLD) {
-      var lastSavepoint = getLatestSavepoint(agentId);
-      crashRecovery = {
-        detected: true,
-        last_heartbeat: agent.last_heartbeat,
-        stale_minutes: Math.round(staleness / 60000),
-        was_working_on: agent.working_on,
-        recovery_state: lastSavepoint && lastSavepoint.state_snapshot ? lastSavepoint.state_snapshot : null,
-        recovery_notes: lastSavepoint && lastSavepoint.notes ? lastSavepoint.notes : null
-      };
-    }
-  }
+  var crashRecovery = buildCrashRecovery(agent, agentId);
 
   // ---- Stand Up: calibration block ----
   var calibration = null;
@@ -1393,26 +1393,7 @@ export function getSlimBootPayload(agentId) {
   var capabilities = [];
   try { capabilities = JSON.parse(agent.capabilities || '[]'); } catch (e) { /* */ }
 
-  // --- Crash detection ---
-  // If the agent was working on something and heartbeat went stale (>15 min), flag as crashed
-  var crashRecovery = null;
-  if (agent.last_heartbeat && agent.working_on) {
-    var lastHb = new Date(agent.last_heartbeat + (agent.last_heartbeat.endsWith('Z') ? '' : 'Z')).getTime();
-    var staleness = Date.now() - lastHb;
-    var CRASH_THRESHOLD = 15 * 60 * 1000; // 15 minutes
-    if (staleness > CRASH_THRESHOLD) {
-      // Previous session likely crashed — include recovery info
-      var lastSavepoint = getLatestSavepoint(agentId);
-      crashRecovery = {
-        detected: true,
-        last_heartbeat: agent.last_heartbeat,
-        stale_minutes: Math.round(staleness / 60000),
-        was_working_on: agent.working_on,
-        recovery_state: lastSavepoint && lastSavepoint.state_snapshot ? lastSavepoint.state_snapshot : null,
-        recovery_notes: lastSavepoint && lastSavepoint.notes ? lastSavepoint.notes : null
-      };
-    }
-  }
+  var crashRecovery = buildCrashRecovery(agent, agentId);
 
   // --- Auto drift detection on boot ---
   var calibration = null;
@@ -2270,28 +2251,26 @@ export function listDroneJobs(filters) {
   return db.prepare('SELECT * FROM drone_jobs WHERE ' + where.join(' AND ') + ' ORDER BY created_at DESC LIMIT ? OFFSET ?').all(...params);
 }
 
-// Bug #137: Release stale claimed jobs for a drone (claimed >1 hour ago, not completed)
+// Bug #137: Release stale claimed jobs (claimed >1 hour ago, not completed)
+// If droneId provided, scoped to that drone. Otherwise releases ALL stale jobs.
 export function releaseStaleClaimedJobs(droneId) {
-  var staleJobs = db.prepare(
-    "SELECT * FROM drone_jobs WHERE status = 'claimed' AND drone_id = ? AND started_at < datetime('now', '-1 hour')"
-  ).all(droneId);
-  for (var job of staleJobs) {
-    db.prepare(
-      "UPDATE drone_jobs SET status = 'failed', error = ?, completed_at = datetime('now') WHERE id = ?"
-    ).run('[stale_timeout] Job was claimed for >1 hour with no completion. Auto-failed on drone restart.', job.id);
+  var staleJobs;
+  if (droneId) {
+    staleJobs = db.prepare(
+      "SELECT * FROM drone_jobs WHERE status = 'claimed' AND drone_id = ? AND started_at < datetime('now', '-1 hour')"
+    ).all(droneId);
+  } else {
+    staleJobs = db.prepare(
+      "SELECT * FROM drone_jobs WHERE status = 'claimed' AND started_at < datetime('now', '-1 hour')"
+    ).all();
   }
-  return staleJobs;
-}
-
-// Also auto-fail ALL stale claimed jobs across all drones (called periodically or on server boot)
-export function releaseAllStaleClaimedJobs() {
-  var staleJobs = db.prepare(
-    "SELECT * FROM drone_jobs WHERE status = 'claimed' AND started_at < datetime('now', '-1 hour')"
-  ).all();
+  var msg = droneId
+    ? '[stale_timeout] Job was claimed for >1 hour with no completion. Auto-failed on drone restart.'
+    : '[stale_timeout] Job was claimed for >1 hour with no progress. Auto-failed by server.';
   for (var job of staleJobs) {
     db.prepare(
       "UPDATE drone_jobs SET status = 'failed', error = ?, completed_at = datetime('now') WHERE id = ?"
-    ).run('[stale_timeout] Job was claimed for >1 hour with no progress. Auto-failed by server.', job.id);
+    ).run(msg, job.id);
   }
   return staleJobs;
 }

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -132,7 +132,7 @@ import {
   listWebhookDeliveries, pruneWebhookDeliveries,
   getAdminOps, resolveStaleRequests,
   createTeamChat, listTeamChat,
-  createDroneJob, getDroneJob, claimDroneJob, updateDroneJob, listDroneJobs, listDrones, listAssetsByDroneJob, bulkCancelDroneJobs, releaseStaleClaimedJobs, releaseAllStaleClaimedJobs,
+  createDroneJob, getDroneJob, claimDroneJob, updateDroneJob, listDroneJobs, listDrones, listAssetsByDroneJob, bulkCancelDroneJobs, releaseStaleClaimedJobs,
   createJobTemplate, getJobTemplate, listJobTemplates, updateJobTemplate, deleteJobTemplate,
   updateDroneDiagnostics, getDroneDiagnostics, renderJobForDrone, checkDroneCompatibility,
   createDroneProfile, getDroneProfile, listDroneProfiles, updateDroneProfile, deleteDroneProfile,
@@ -183,6 +183,9 @@ import { loadPlugins, getLoadedPlugins, getPluginMcpTools, callEventHooks, regis
 import { broadcast, addClient, clientCount } from '../eventBus.js';
 
 var ADMIN_KEY = process.env.ADMIN_KEY;
+function isAdminKey(key) {
+  return key && key.length === ADMIN_KEY.length && crypto.timingSafeEqual(Buffer.from(key), Buffer.from(ADMIN_KEY));
+}
 var JWT_SECRET = process.env.JWT_SECRET;
 var STUDIO_JWT_EXPIRY = '7d';
 
@@ -431,7 +434,7 @@ function checkAdmin(req, res) {
     res.status(401).json({ error: 'Authentication required' });
     return false;
   }
-  if (key && key.length === ADMIN_KEY.length && crypto.timingSafeEqual(Buffer.from(key), Buffer.from(ADMIN_KEY))) { req._authIsAdmin = true; return true; }
+  if (isAdminKey(key)) { req._authIsAdmin = true; return true; }
   res.status(403).json({ error: 'Invalid admin key' });
   return false;
 }
@@ -441,7 +444,7 @@ function checkAdminOrOperator(req, res) {
   var user = getStudioUser(req);
   if (user) { req._authIsAdmin = user.role === 'admin'; return user.displayName || user.username; }
   var key = req.headers['x-admin-key'];
-  if (key && key.length === ADMIN_KEY.length && crypto.timingSafeEqual(Buffer.from(key), Buffer.from(ADMIN_KEY))) {
+  if (isAdminKey(key)) {
     req._authIsAdmin = true;
     return req.headers['x-acting-as'] || '__system__';
   }
@@ -474,7 +477,7 @@ function checkAgentOrAdmin(req, res) {
   if (user) { req._authIsAdmin = true; return user.displayName || user.username; }
   // Try admin key
   var adminKey = req.headers['x-admin-key'];
-  if (adminKey && adminKey.length === ADMIN_KEY.length && crypto.timingSafeEqual(Buffer.from(adminKey), Buffer.from(ADMIN_KEY))) {
+  if (isAdminKey(adminKey)) {
     req._authIsAdmin = true;
     var actingAs = req.headers['x-acting-as'];
     return actingAs || '__system__';
@@ -1086,8 +1089,9 @@ router.get('/boot/:agentId', function (req, res) {
   // Default: slim boot
   var payload = getSlimBootPayload(agentId);
   if (!payload) return res.status(404).json({ error: 'Agent not found' });
-  payload.savepoint = computeSavepointDiff(agentId);
-  payload.changes_since_last = formatSavepointSummary(computeSavepointDiff(agentId));
+  var diff = computeSavepointDiff(agentId);
+  payload.savepoint = diff;
+  payload.changes_since_last = formatSavepointSummary(diff);
   try { payload.profile = ensureAgentProfile(agentId); } catch (e) { /* non-critical */ }
   emitEvent('agent_boot', agentId, null, agentId + ' booted');
   res.json(payload);
@@ -1165,7 +1169,7 @@ router.post('/agents/heartbeat', function (req, res) {
   var agentId;
   // Admin can heartbeat on behalf of any agent via agent_id body field
   var adminKey = req.headers['x-admin-key'];
-  if (adminKey && adminKey.length === ADMIN_KEY.length && crypto.timingSafeEqual(Buffer.from(adminKey), Buffer.from(ADMIN_KEY)) && req.body.agent_id) {
+  if (isAdminKey(adminKey) && req.body.agent_id) {
     agentId = req.body.agent_id;
   } else {
     agentId = checkAgent(req, res);
@@ -4264,7 +4268,7 @@ setInterval(function () {
 // Bug #134/#132: Also flag drones offline if no heartbeat in 30 minutes
 setInterval(function () {
   try {
-    var stale = releaseAllStaleClaimedJobs();
+    var stale = releaseStaleClaimedJobs();
     if (stale.length > 0) {
       emitEvent('drone_stale_cleanup', '__system__', 'drone', 'Auto-failed ' + stale.length + ' stale claimed drone job(s): ' + stale.map(function (j) { return '#' + j.id; }).join(', '), { job_ids: stale.map(function (j) { return j.id; }) });
     }


### PR DESCRIPTION
## Summary
- **Fix double `computeSavepointDiff`**: Was called twice per slim boot — now computed once and reused
- **Extract `isAdminKey()` helper**: Replaces 4 inline timing-safe compare blocks with one function
- **Extract `buildCrashRecovery()` helper**: Identical 15-line crash detection block in both boot functions → one shared helper
- **Merge `releaseStaleClaimedJobs`**: Two near-identical functions (one filtered by drone, one not) → one with optional param

**Net: -17 lines** (46 insertions, 63 deletions). Pure refactoring, no behavior changes.

## Test plan
- [ ] Server starts clean
- [ ] Boot payload unchanged (slim + verbose)
- [ ] Heartbeat admin-on-behalf still works
- [ ] Stale job cleanup runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)