### PR TITLE
docs: update all docs + add PUT /waitlist/:id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,15 @@ No tests or linting configured.
 ```
 server/
   index.js          # Express app entry point + voice chat WebSocket
-  db.js             # SQLite (better-sqlite3, WAL) + all DB functions (~900 lines)
-  schema.sql        # Full platform schema (50 tables)
+  db.js             # SQLite (better-sqlite3, WAL) + all DB functions (~4000 lines)
+  schema.sql        # Full platform schema (52 tables)
+  plugins.js        # Plugin loader — auto-discovers, schema init, event hooks, worker processes
+  provisioning.js   # Customer instance provisioning (Railway + Cloudflare + health check)
+  email.js          # Email via Resend — waitlist, welcome, payment, suspension templates
   routes/
-    mycelium.js     # All API routes (211+ endpoints, served at /api/mycelium/)
+    mycelium.js     # All API routes (277 endpoints, served at /api/mycelium/)
   data/             # SQLite DB + uploaded files (gitignored)
-  plugins/          # Plugin system (5 built-in plugins)
+  plugins/          # Plugin system (17 plugins — billing, github-sync, cost-tracker, etc.)
 sdk/
   src/
     agent.js        # MyceliumAgent class — multi-runtime SDK
@@ -53,7 +56,7 @@ sdk/
     ollama-coder.js # Local Ollama coding agent
   package.json      # @mycelium/sdk package config
 studio-react/       # Dashboard (React 19 + TypeScript + Vite + Tailwind v4 + Zustand)
-  src/pages/        # 22 dashboard pages
+  src/pages/        # 28 dashboard pages
 public/
   studio/           # Built dashboard assets (served at /studio)
 tools/              # Utility scripts
@@ -70,9 +73,9 @@ package.json        # Root workspace config
 
 ## Architecture
 
-- **Database**: SQLite via better-sqlite3, WAL mode. 50 tables. Schema in `server/schema.sql`.
+- **Database**: SQLite via better-sqlite3, WAL mode. 52 tables. Schema in `server/schema.sql`.
 - **Auth**: JWT tokens (7-day expiry). Dashboard users in `dv_studio_users`. Agents use API keys (`X-Agent-Key`). Admin uses `X-Admin-Key` or JWT Bearer token.
-- **API routes**: Served at `/api/mycelium/`. 211+ endpoints.
+- **API routes**: Served at `/api/mycelium/`. 277 endpoints.
 - **Dashboard**: Served at `/` and `/studio/` (backward compat). React 19 SPA built with Vite.
 - **Voice chat**: WebRTC signaling via WebSocket at `/voice`. REST endpoints for peers and TURN credentials.
 - **Plans system**: `dv_plans` + `dv_plan_steps`. Auto-completion cascade.
@@ -83,15 +86,21 @@ package.json        # Root workspace config
 - **Widgets**: `widgets` table. Agents push live dashboard components.
 - **Skills**: `skills` + `agent_skills` tables. Discoverable, installable agent capabilities.
 - **Teams**: Team organization with roles (lead, member, guest).
+- **Agent profiles**: `agent_profiles` table. Persistent stats (tasks, bugs, PRs, sessions). Auto-created on boot. Leaderboard endpoint.
+- **Health patrol**: Stale detection for agents, tasks, requests, drones, plan steps. Config-gated 5-minute interval.
+- **Billing**: Plugin-based Stripe integration. Webhooks for checkout, subscription changes, payment failures.
+- **Customer provisioning**: `customer_instances` + `subscriptions` tables. Auto-provisions Railway instances with Cloudflare DNS on Stripe payment. Lifecycle: provisioning → active → suspended → archived.
+- **Waitlist**: Public signup at `POST /waitlist`. Operator inbox alerts + confirmation email.
+- **Plugins**: 17 plugins auto-discovered from `server/plugins/`. Schema init, event hooks, route mounting, MCP tool registration. Worker plugins run as separate processes.
 - **SDK**: Multi-runtime agent SDK in `sdk/`. HTTP polling, handler modules, CLI tools, adapters.
 
 ## Command Structure v2
 
-Mycelium uses a command structure where Claude Admin (greatness-claude) coordinates work.
+Mycelium uses a command structure where operators coordinate work via the dashboard and agents self-organize via work queues.
 
 ### Terminology
 - **Operators** (people): greatness (owner), hijack (ui_lead), unakron (member). Table: `dv_operators`.
-- **Agents** (Claude instances): greatness-claude (admin), hijack-claude (agent), unakron-gpu (drone). Linked to operators via `operator_id`.
+- **Agents** (Claude instances): dev-claude, macbook-claude, hijack-claude, macbook-ollama, etc. Linked to operators via `operator_id`.
 - **Directives**: Blocking messages (`msg_type='directive'`). Agent MUST respond before getting new work.
 - **Instance Config**: `dv_instance_config` -- mode (developer/customer), admin status, risk tiers.
 
@@ -116,6 +125,9 @@ Multi-human voting: `dv_approval_votes` table. Any single deny = instant denial.
 | `ADMIN_KEY` | Yes | Admin API key |
 | `PORT` | No | Server port (default 3002) |
 | `DATA_DIR` | No | SQLite data directory (default `server/data/`) |
+| `RESEND_KEY` | No | Resend API key for email (graceful degradation if missing) |
+| `GITHUB_TOKEN` | No | GitHub API token for PR proxy endpoints |
+| `STRIPE_WEBHOOK_SECRET` | No | Stripe webhook signature verification |
 
 ## Key API Endpoints (under `/api/mycelium/`)
 
@@ -240,6 +252,26 @@ Agents report on heartbeat: `runtime`, `llm_backend`, `llm_model`, `capabilities
 - `GET /github/prs/:owner/:repo` -- List pull requests
 - `POST /github/prs/:owner/:repo` -- Create pull request
 - `POST /github/prs/:owner/:repo/:number/merge` -- Merge pull request
+
+### Agent Profiles
+- `GET /agents/:id/profile` -- Get agent profile (stats, specializations)
+- `PUT /agents/:id/profile` -- Update agent profile
+- `GET /agents/profiles` -- List all agent profiles
+- `GET /agents/leaderboard` -- Agent leaderboard by stats
+
+### Health Patrol (Admin)
+- `GET /admin/health` -- Run stale detection (agents, tasks, requests, drones, plan steps)
+- `GET /admin/health/history` -- Health patrol history
+
+### Customer Instances (Admin)
+- `GET /waitlist` -- List waitlist signups
+- `POST /waitlist` -- Public signup (no auth, rate-limited)
+- `GET /instances` -- List customer instances
+- `GET /instances/:id` -- Instance details
+- `PUT /instances/:id` -- Update instance
+- `POST /instances/:id/health-check` -- Trigger health check
+- `POST /admin/churn-check` -- Run churn lifecycle (suspend → archive → delete)
+- `POST /admin/deploy/health-check-all` -- Health check all active instances
 
 ### Other
 - `GET /health` -- Health check

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Mycelium is a self-hosted command center that turns any collection of AI agents 
 
 Runtime-agnostic. Production-tested. Human-in-the-loop where it matters.
 
-> 130/130 tests passing. 211+ API endpoints. 50 database tables. Used daily in production with multiple agents shipping real products.
+> 277 API endpoints. 52 database tables. 17 plugins. Used daily in production with multiple agents shipping real products.
 
 ## Why Mycelium
 
@@ -44,7 +44,7 @@ Your agents get identity, work queues, messaging, context, budget tracking, and 
 - **Concepts & Context** -- Shared knowledge store (characters, styles, rulesets, brands -- any structured data). Concepts link across projects. Namespaced key-value context persists agent state across sessions with full version history.
 - **Operator Inbox** -- Human-facing message layer. Pending approvals, agent requests, and mentions surface automatically with unread badges.
 - **Plugin System** -- Drop-in plugins with their own schemas, migrations, routes, event hooks, and MCP tools.
-- **Dashboard** -- 22-page React app: network overview, agent analytics, plans, tasks, bugs, channels, concepts, approvals, drones, assets, operators, webhooks, context explorer, feedback, and more.
+- **Dashboard** -- 28-page React app: network overview, agent analytics, plans, tasks, bugs, channels, concepts, approvals, drones, assets, operators, webhooks, context explorer, feedback, teams, plugins, deployments, and more.
 
 ## Quick Start
 
@@ -213,17 +213,17 @@ Say "Mycelium, what's the status?" and get a spoken summary of your agent networ
 mycelium/
 ├── server/
 │   ├── index.js              # Express app + WebSocket
-│   ├── db.js                 # SQLite (better-sqlite3, WAL mode, 50 tables)
+│   ├── db.js                 # SQLite (better-sqlite3, WAL mode, 52 tables)
 │   ├── schema.sql            # Full schema
-│   ├── routes/mycelium.js    # All API routes (211+ endpoints)
-│   └── plugins/              # Plugin system (5 built-in plugins)
+│   ├── routes/mycelium.js    # All API routes (277 endpoints)
+│   └── plugins/              # Plugin system (17 plugins)
 ├── sdk/                      # Multi-runtime Agent SDK
 │   ├── src/                  # Core: MyceliumAgent class + HTTP client
 │   ├── bin/                  # CLI: mycelium-init, mycelium-agent
 │   ├── adapters/             # Discord, Slack, Voice bridges
 │   └── examples/             # echo-agent, ollama-coder
 ├── studio-react/             # Dashboard (React 19 + TypeScript + Vite + Tailwind v4 + Zustand)
-│   └── src/pages/            # 22 pages
+│   └── src/pages/            # 28 pages
 ├── public/studio/            # Built dashboard assets (served at /studio)
 ├── docs/                     # Setup and plugin guides
 ├── docker-compose.yml        # Local-first deployment
@@ -234,7 +234,7 @@ mycelium/
 
 ### Database
 
-SQLite with 50 tables covering agents, tasks, plans, messages, channels, approvals, drones, concepts, context (with version history), bugs, assets, plugins, operators, webhooks, events, feedback, spend tracking, widgets, skills, and teams. WAL mode for concurrent reads. 30+ indexes for query performance.
+SQLite with 52 tables covering agents, tasks, plans, messages, channels, approvals, drones, concepts, context (with version history), bugs, assets, plugins, operators, webhooks, events, feedback, spend tracking, widgets, skills, teams, agent profiles, subscriptions, and customer instances. WAL mode for concurrent reads. 30+ indexes for query performance.
 
 ### Token-Efficient Protocol
 
@@ -356,7 +356,7 @@ GET /agents/my-agent/skills
 
 ## API Overview
 
-All endpoints under `/api/mycelium/`. Auth via `X-Agent-Key`, `X-Admin-Key`, or JWT Bearer token. 211+ endpoints across 17 categories.
+All endpoints under `/api/mycelium/`. Auth via `X-Agent-Key`, `X-Admin-Key`, or JWT Bearer token. 277 endpoints across 20+ categories.
 
 | Category | Key Endpoints | Description |
 |----------|--------------|-------------|
@@ -407,19 +407,36 @@ The React dashboard at `/studio` includes:
 - **Feedback** -- User feedback collection
 - **Spawns** -- Agent runner session tracking
 - **Onboarding** -- New instance setup wizard
+- **Agent Templates** -- Preconfigured agent templates for quick registration
+- **Deployments** -- Customer instance deployment status and management
+- **Agent Health** -- Per-agent health metrics and diagnostics
+- **Teams** -- Team management with roles and project assignments
+- **Team Settings** -- Team DNA configuration (conventions, preferences)
+- **Plugin Pages** -- Plugin-specific dashboard views
 - **Login** -- JWT-based authentication
 
 ## Plugins
 
-Built-in plugins with their own schemas, routes, and event hooks:
+17 built-in plugins with their own schemas, routes, event hooks, and MCP tools:
 
 | Plugin | Description |
 |--------|-------------|
+| `billing` | Stripe webhook integration, subscription management, auto-provisioning |
+| `build-in-public` | Public transparency dashboard and update sharing |
+| `cost-tracker` | Automated spend tracking and budget alerts |
+| `daily-digest` | Scheduled daily summary notifications |
+| `error-monitor` | Error tracking and alerting |
+| `github-sync` | GitHub PR/issue synchronization |
+| `guardrails` | Safety checks and policy enforcement |
+| `outreach` | Outreach pipeline automation |
+| `semantic-memory` | Hybrid FTS5 keyword + vector search across platform data |
+| `auto-memory` | Automated fact extraction from platform events |
+| `a2a-gateway` | Google A2A protocol for external agent interop |
 | `social-posting` | Schedule and publish to social media |
 | `steam-assets` | Steam game asset management |
 | `video-pipeline` | Video processing workflows |
-| `build-in-public` | Public transparency and update sharing |
-| `outreach` | Outreach pipeline automation |
+| `workflow-automations` | Event-driven workflow triggers |
+| `x-posting` | X/Twitter post drafting and publishing |
 
 Create your own with `server/plugins/_template/`. See `docs/plugin-guide.md`.
 
@@ -434,15 +451,16 @@ Create your own with `server/plugins/_template/`. See `docs/plugin-guide.md`.
 - `sdk/README.md` -- Agent SDK API reference and examples
 - `sdk/adapters/README.md` -- Discord, Slack, and Voice adapter setup
 
-## Related Repos
+## Monorepo Packages
 
-| Repo | Description |
-|------|-------------|
-| [mycelium-mcp](https://github.com/SoftBacon-Software/mycelium-mcp) | MCP server wrapping the Mycelium API for Claude Code |
-| [mycelium-runner](https://github.com/SoftBacon-Software/mycelium-runner) | Autonomous agent runner -- polls Mycelium, spawns Claude sessions |
+| Package | Path | Description |
+|---------|------|-------------|
+| `@mycelium/sdk` | `sdk/` | Multi-runtime Agent SDK (npm) |
+| `@mycelium/mcp` | `mcp/` | MCP server for Claude Code agents |
+| `@mycelium/runner` | `runner/` | Autonomous agent runner -- spawns Claude sessions |
 
 ## License
 
-Proprietary. Copyright 2026 SoftBacon Software.
+AGPL-3.0-only. See [LICENSE](LICENSE) for full terms.
 
-Source visible for evaluation. Redistribution, modification, or commercial use requires a license. Contact grbarajas@gmail.com.
+The SDK (`@mycelium/sdk`) is licensed under MIT for maximum compatibility.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -176,11 +176,34 @@ agent.start()
 | `queueDroneJob(job)` | Queue a GPU/CPU compute job. |
 | `listDroneJobs(filters?)` | List drone jobs with optional status filter. |
 
-### Agents
+### Agents & Profiles
 
 | Method | Description |
 |--------|-------------|
 | `listAgents()` | List all agents on the network. |
+| `getProfile(agentId?)` | Get agent profile (stats, specializations). Defaults to self. |
+| `updateProfile(fields)` | Update own agent profile (specializations, max_concurrent, preferred_projects, profile_data). |
+
+### Semantic Memory
+
+| Method | Description |
+|--------|-------------|
+| `memorySearch(query, opts?)` | Search indexed content. Options: `sourceTypes`, `namespace`, `projectId`, `limit`, `mode`. |
+| `memoryIndex(sourceType, sourceId, contentText, opts?)` | Index content for search. Options: `namespace`, `metadata`. |
+
+### A2A Gateway
+
+| Method | Description |
+|--------|-------------|
+| `a2aDiscover(url)` | Discover an external A2A agent by URL. |
+| `a2aSend(agentId, message)` | Send a message to an A2A agent. |
+| `a2aList()` | List discovered A2A agents. |
+
+### Auto-Memory
+
+| Method | Description |
+|--------|-------------|
+| `getAutoMemoryFacts(opts?)` | Get auto-extracted facts. Options: `agent_id`, `project_id`, `limit`, etc. |
 
 ### Low-Level API Client
 

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -1058,6 +1058,31 @@ router.get('/waitlist', function (req, res) {
   }
 });
 
+// PUT /waitlist/:id — admin only, update waitlist entry status/notes
+router.put('/waitlist/:id', function (req, res) {
+  if (!checkAdmin(req, res)) return;
+  var db = getDB();
+  // Ensure notes column exists (added after initial schema)
+  try { db.prepare('ALTER TABLE waitlist ADD COLUMN notes TEXT DEFAULT ""').run(); } catch (e) { /* already exists */ }
+  var row = db.prepare('SELECT * FROM waitlist WHERE id = ?').get(req.params.id);
+  if (!row) return apiError(res, 404, 'Waitlist entry not found');
+  var allowed = ['status', 'notes'];
+  var sets = [];
+  var vals = [];
+  for (var key of allowed) {
+    if (req.body[key] !== undefined) {
+      sets.push(key + ' = ?');
+      vals.push(req.body[key]);
+    }
+  }
+  if (sets.length === 0) return apiError(res, 400, 'No valid fields to update');
+  vals.push(req.params.id);
+  db.prepare('UPDATE waitlist SET ' + sets.join(', ') + ' WHERE id = ?').run(...vals);
+  var updated = db.prepare('SELECT * FROM waitlist WHERE id = ?').get(req.params.id);
+  emitEvent('waitlist_updated', req.headers['x-admin-key'] ? '__admin__' : '__system__', null, 'Waitlist #' + req.params.id + ' updated', { waitlist_id: req.params.id, status: updated.status });
+  res.json(updated);
+});
+
 // ======== BOOT ========
 
 router.get('/boot/:agentId', function (req, res) {


### PR DESCRIPTION
## Summary
- **CLAUDE.md, README.md, SDK README**: All counts updated (52 tables, 277 endpoints, 17 plugins, 28 pages). Added missing architecture sections (billing, provisioning, agent profiles, health patrol, waitlist, plugin system). Fixed license, updated monorepo packages, added 8 undocumented SDK methods.
- **PUT /waitlist/:id**: Admin-only endpoint to update waitlist entry status/notes. Supports the customer onboarding workflow.
- Command structure updated: admin-claude decommissioned from docs.

## Test plan
- [ ] Verify PUT /waitlist/:id works with admin key
- [ ] Spot-check doc counts against actual codebase
- [ ] Confirm no broken links in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)