### PR TITLE
fix: smart memory follow-up — 6 review fixes

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1413,7 +1413,7 @@ export function getSlimBootPayload(agentId) {
 }
 
 // Smart boot: slim boot + scored context injection
-export function getSmartBootPayload(agentId, contextScorer, memoryDb) {
+export function getSmartBootPayload(agentId, contextScorer, memoryDb, queryEmbedding) {
   var slim = getSlimBootPayload(agentId);
   if (!slim) return null;
 
@@ -1473,23 +1473,27 @@ export function getSmartBootPayload(agentId, contextScorer, memoryDb) {
     try {
       var config = memoryDb.getAllConfig();
       if (config.embedding_provider && config.embedding_provider !== 'none') {
-        // Look up embeddings for context keys already indexed
+        // Batch-load embeddings for context keys (single query instead of N+1)
         var keyEmbeddings = {};
-        for (var ck of allKeys) {
-          var sourceId = ck.namespace + ':' + ck.key;
-          var row = db.prepare(
-            'SELECT embedding FROM sm_embeddings WHERE source_type = ? AND source_id = ? AND embedding IS NOT NULL LIMIT 1'
-          ).get('context_key', sourceId);
-          if (row && row.embedding) {
-            try {
-              keyEmbeddings[sourceId] = JSON.parse(typeof row.embedding === 'string' ? row.embedding : row.embedding.toString());
-            } catch (e) { /* */ }
+        var sourceIds = allKeys.map(function (ck) { return ck.namespace + ':' + ck.key; });
+        if (sourceIds.length > 0) {
+          var placeholders = sourceIds.map(function () { return '?'; }).join(',');
+          var embRows = db.prepare(
+            'SELECT source_id, embedding FROM sm_embeddings WHERE source_type = ? AND source_id IN (' + placeholders + ') AND embedding IS NOT NULL'
+          ).all('context_key', ...sourceIds);
+          for (var embRow of embRows) {
+            if (embRow.embedding) {
+              try {
+                keyEmbeddings[embRow.source_id] = JSON.parse(typeof embRow.embedding === 'string' ? embRow.embedding : embRow.embedding.toString());
+              } catch (e) { /* */ }
+            }
           }
         }
         if (Object.keys(keyEmbeddings).length > 0) {
           scorerOpts.keyEmbeddings = keyEmbeddings;
-          // Build query embedding from work context synchronously isn't possible,
-          // so vector scoring uses pre-existing embeddings only (query embedding added at route level)
+        }
+        if (queryEmbedding) {
+          scorerOpts.queryEmbedding = queryEmbedding;
         }
       }
     } catch (e) { /* semantic-memory not available */ }

--- a/server/plugins/auto-memory/db.js
+++ b/server/plugins/auto-memory/db.js
@@ -134,8 +134,9 @@ export default function createAutoMemoryDB(db) {
 
     pruneLowConfidence(threshold) {
       // Mark facts below threshold as superseded (superseded_by = -1 signals decay-pruned)
+      // Age guard: don't prune facts less than 7 days old (may have low initial confidence)
       var result = db.prepare(
-        'UPDATE am_facts SET superseded_by = -1 WHERE superseded_by IS NULL AND confidence < ?'
+        "UPDATE am_facts SET superseded_by = -1 WHERE superseded_by IS NULL AND confidence < ? AND updated_at < datetime('now', '-7 days')"
       ).run(threshold);
       return result.changes;
     },

--- a/server/plugins/auto-memory/decay.js
+++ b/server/plugins/auto-memory/decay.js
@@ -1,5 +1,7 @@
 // Confidence decay for auto-memory facts
-// Model: effective_confidence = base_confidence * max(0.1, 1.0 - days_since_access * rate)
+// Model: each cycle applies confidence *= max(0.1, 1.0 - days_since_last_access * rate)
+// This compounds across cycles — effectively exponential decay.
+// Accessing a fact resets the reference point (last_accessed_at), keeping active facts high.
 
 var DECAY_RATES = {
   convention: 0.002,   // ~450 days to floor

--- a/server/plugins/semantic-memory/db.js
+++ b/server/plugins/semantic-memory/db.js
@@ -161,8 +161,11 @@ export default function createMemoryDB(db) {
         params.push(opts.namespace);
       }
 
+      // Cap rows loaded for JS-side cosine sim to prevent DoS on large tables
+      var vectorCap = 5000;
+      params.push(vectorCap);
       var rows = db.prepare(
-        'SELECT id, source_type, source_id, chunk_index, embedding FROM sm_embeddings WHERE ' + where.join(' AND ')
+        'SELECT id, source_type, source_id, chunk_index, embedding FROM sm_embeddings WHERE ' + where.join(' AND ') + ' ORDER BY updated_at DESC LIMIT ?'
       ).all(...params);
 
       // Compute cosine similarity in JS

--- a/server/plugins/semantic-memory/routes.js
+++ b/server/plugins/semantic-memory/routes.js
@@ -105,13 +105,12 @@ export default function (core) {
     res.json(db.stats());
   });
 
-  // GET /memory/config — current provider config
+  // GET /memory/config — current provider config (admin only, key stripped)
   router.get('/config', function (req, res) {
     var who = checkAdmin(req, res);
     if (!who) return;
     var config = db.getAllConfig();
-    // Mask API key
-    if (config.embedding_api_key) config.embedding_api_key = '***';
+    delete config.embedding_api_key;
     res.json(config);
   });
 

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -1136,6 +1136,7 @@ router.put('/waitlist/:id', function (req, res) {
 // Lazy-load smart boot dependencies (plugin may not be available)
 var _contextScorer = null;
 var _createMemoryDB = null;
+var _generateEmbedding = null;
 
 // Pre-load smart boot deps at startup (fire-and-forget)
 (async function () {
@@ -1144,13 +1145,15 @@ var _createMemoryDB = null;
     _contextScorer = scorerMod.scoreContextKeys;
     var dbMod = await import('../plugins/semantic-memory/db.js');
     _createMemoryDB = dbMod.default;
+    var embedMod = await import('../plugins/semantic-memory/embeddings.js');
+    _generateEmbedding = embedMod.generateEmbedding;
     console.log('[mycelium] Smart boot dependencies loaded');
   } catch (e) {
     console.log('[mycelium] Smart boot deps not available (semantic-memory plugin not loaded):', e.message);
   }
 })();
 
-router.get('/boot/:agentId', asyncHandler(function (req, res) {
+router.get('/boot/:agentId', asyncHandler(async function (req, res) {
   var agentId = checkAgent(req, res);
   if (!agentId) return;
   if (agentId !== req.params.agentId) {
@@ -1177,7 +1180,29 @@ router.get('/boot/:agentId', asyncHandler(function (req, res) {
   if (req.query.smart === 'true' && _contextScorer) {
     try {
       var memoryDb = _createMemoryDB ? _createMemoryDB(getDB()) : null;
-      var payload = getSmartBootPayload(agentId, _contextScorer, memoryDb);
+      // Generate query embedding from work context for vector scoring
+      var queryEmbedding = null;
+      if (_generateEmbedding && memoryDb) {
+        try {
+          var embConfig = memoryDb.getAllConfig();
+          if (embConfig.embedding_provider && embConfig.embedding_provider !== 'none') {
+            // Build query text from agent's current work
+            var agent = getAgent(agentId);
+            var workTexts = [];
+            if (agent && agent.working_on) workTexts.push(agent.working_on);
+            var recentWork = db.prepare(
+              "SELECT title FROM tasks WHERE assignee = ? AND status IN ('open', 'in_progress') LIMIT 5"
+            ).all(agentId);
+            for (var rw of recentWork) { if (rw.title) workTexts.push(rw.title); }
+            if (workTexts.length > 0) {
+              queryEmbedding = await _generateEmbedding(embConfig, workTexts.join(' '));
+            }
+          }
+        } catch (e) {
+          // Non-critical — falls back to keyword+access scoring
+        }
+      }
+      var payload = getSmartBootPayload(agentId, _contextScorer, memoryDb, queryEmbedding);
       if (!payload) return res.status(404).json({ error: 'Agent not found' });
       var diff = computeSavepointDiff(agentId);
       payload.savepoint = diff;


### PR DESCRIPTION
## Summary

Addresses all 6 issues flagged by dev-claude on PR #100:

- **#1 CRITICAL**: `searchVector` now caps at LIMIT 5000 rows (was unbounded — DoS risk)
- **#2 CRITICAL**: Smart boot embedding lookups batched into single `IN (...)` query (was N+1)
- **#3 CRITICAL**: `GET /memory/config` deletes API key from response entirely (was masking with `***`)
- **#4 IMPORTANT**: Smart boot now generates query embedding from agent's work context, enabling the vector scoring branch that was previously dead code
- **#5 IMPORTANT**: Compound decay behavior documented in code comments
- **#6 IMPORTANT**: `pruneLowConfidence` adds 7-day age guard — won't prune facts younger than 7 days

## Test plan
- [ ] Verify searchVector respects 5000 row cap
- [ ] Verify smart boot with embeddings configured — should show `method: hybrid` in context_meta
- [ ] Verify `GET /memory/config` response has no `embedding_api_key` field
- [ ] Verify new facts with low confidence aren't pruned within 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)