### PR TITLE
Security hardening: JWT, SSRF, prototype pollution

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -815,6 +815,12 @@ export function upsertContextKey(namespace, key, data, agentId, opts) {
     try {
       var existingData = JSON.parse(existing.data);
       var newData = typeof data === 'string' ? JSON.parse(data) : data;
+      // Sanitize against prototype pollution
+      if (newData && typeof newData === 'object') {
+        delete newData.__proto__;
+        delete newData.constructor;
+        delete newData.prototype;
+      }
       merged = JSON.stringify(Object.assign({}, existingData, newData));
     } catch (e) {
       merged = typeof data === 'string' ? data : JSON.stringify(data);

--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ function checkVoiceAuth(req, res) {
   if (adminKey === process.env.ADMIN_KEY) return true;
   var auth = req.headers['authorization'];
   if (auth && auth.startsWith('Bearer ')) {
-    try { jwt.verify(auth.slice(7), process.env.JWT_SECRET); return true; } catch (e) { /* invalid */ }
+    try { jwt.verify(auth.slice(7), process.env.JWT_SECRET, { algorithms: ['HS256'] }); return true; } catch (e) { /* invalid */ }
   }
   var agentKey = req.headers['x-agent-key'];
   if (agentKey) {
@@ -403,7 +403,7 @@ wss.on('connection', function (ws, req) {
   var url = new URL(req.url, 'http://localhost');
   var token = url.searchParams.get('token');
   if (!token) { ws.close(4401, 'Authentication required'); return; }
-  try { jwt.verify(token, process.env.JWT_SECRET); } catch (e) { ws.close(4403, 'Invalid token'); return; }
+  try { jwt.verify(token, process.env.JWT_SECRET, { algorithms: ['HS256'] }); } catch (e) { ws.close(4403, 'Invalid token'); return; }
 
   ws.isAlive = true;
   var peerId = 'peer_' + (++peerCounter);

--- a/server/plugins/a2a-gateway/routes.js
+++ b/server/plugins/a2a-gateway/routes.js
@@ -5,6 +5,22 @@ import { Router } from 'express';
 import crypto from 'crypto';
 import createA2ADB from './db.js';
 
+// SSRF protection: validate URLs before fetching
+function validateExternalUrl(urlStr) {
+  try {
+    var parsed = new URL(urlStr);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+    var host = parsed.hostname.toLowerCase();
+    // Block private/internal IPs
+    if (host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '0.0.0.0') return false;
+    if (host.startsWith('10.') || host.startsWith('192.168.') || host.startsWith('169.254.')) return false;
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false;
+    // Block metadata endpoints
+    if (host === 'metadata.google.internal' || host === '169.254.169.254') return false;
+    return true;
+  } catch (e) { return false; }
+}
+
 // A2A status mapping
 var A2A_TO_MYCELIUM = {
   submitted: 'open',
@@ -190,6 +206,7 @@ export default function (core) {
     if (!who) return;
     var url = req.body.url;
     if (!url) return apiError(res, 400, 'url is required');
+    if (!validateExternalUrl(url)) return apiError(res, 400, 'Invalid or blocked URL — must be public http(s)');
 
     // Normalize URL
     var agentCardUrl = url.replace(/\/$/, '') + '/.well-known/agent.json';
@@ -235,6 +252,7 @@ export default function (core) {
 
     var agent = db.getExternalAgent(parseInt(agent_id));
     if (!agent) return apiError(res, 404, 'External agent not found');
+    if (!validateExternalUrl(agent.agent_url)) return apiError(res, 400, 'Agent URL is blocked — private/internal addresses not allowed');
 
     var taskId = db.createOutboundTask(agent.id, who, 'tasks/send', message);
 

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -348,7 +348,7 @@ function getStudioUser(req) {
   var auth = req.headers['authorization'];
   if (!auth || !auth.startsWith('Bearer ')) return null;
   try {
-    var decoded = jwt.verify(auth.slice(7), JWT_SECRET);
+    var decoded = jwt.verify(auth.slice(7), JWT_SECRET, { algorithms: ['HS256'] });
     if (decoded && decoded.studioUser) {
       if (decoded.userId) touchStudioUserSeen(decoded.userId);
       return decoded;
@@ -2582,7 +2582,7 @@ router.get('/events/stream', asyncHandler(function (req, res) {
   var token = req.query.token;
   if (token) {
     try {
-      var decoded = jwt.verify(token, JWT_SECRET);
+      var decoded = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] });
       if (decoded && decoded.studioUser) { req._authIsAdmin = true; authOk = true; }
     } catch (e) { /* invalid token, fall through to header auth */ }
   }


### PR DESCRIPTION
## Summary
- **JWT algorithm pinning**: All 4 `jwt.verify()` calls now pin to `HS256`, preventing algorithm confusion attacks (e.g. `alg: "none"`)
- **SSRF protection**: a2a-gateway discover/send endpoints now validate URLs against private IPs (10.x, 172.16-31.x, 192.168.x), localhost, and cloud metadata endpoints (169.254.169.254)
- **Prototype pollution**: `upsertContextKey()` now strips `__proto__`, `constructor`, and `prototype` keys before `Object.assign` merge

## Files changed
- `server/db.js` — prototype pollution sanitization in context key merge
- `server/index.js` — JWT algorithm pinning (voice auth + WebSocket)
- `server/routes/mycelium.js` — JWT algorithm pinning (studio auth + SSE)
- `server/plugins/a2a-gateway/routes.js` — SSRF URL validation

## Test plan
- [ ] Verify studio login still works (JWT signing uses HS256 by default, so pinning is compatible)
- [ ] Verify voice chat WebSocket auth still works
- [ ] Verify a2a-gateway rejects `localhost` and private IP URLs
- [ ] Verify context key upsert still merges correctly with normal data

🤖 Generated with [Claude Code](https://claude.com/claude-code)