### PR TITLE
fix: allow claimed/pending status in drone job PUT endpoint

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -2315,7 +2315,7 @@ export function updateDroneJob(id, fields) {
   var f = Object.assign({}, fields);
   if (f.input_data !== undefined && typeof f.input_data !== 'string') f.input_data = JSON.stringify(f.input_data);
   if (f.result_data !== undefined && typeof f.result_data !== 'string') f.result_data = JSON.stringify(f.result_data);
-  buildUpdate('drone_jobs', id, f, ['status', 'command', 'input_data', 'result_url', 'result_data', 'error', 'completed_at']);
+  buildUpdate('drone_jobs', id, f, ['status', 'command', 'input_data', 'result_url', 'result_data', 'error', 'completed_at', 'drone_id', 'started_at']);
 }
 
 export function listDroneJobs(filters) {

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -304,7 +304,7 @@ function getBugCategories(projectId) {
   return DEFAULT_BUG_CATEGORIES;
 }
 var CHANNEL_STATUSES = ['active', 'archived'];
-var DRONE_JOB_STATUSES = ['done', 'completed', 'failed', 'cancelled', 'dismissed'];
+var DRONE_JOB_STATUSES = ['pending', 'claimed', 'done', 'completed', 'failed', 'cancelled', 'dismissed'];
 
 // Sanitize input: ensure string type, trim, handle null/undefined.
 // HTML entity escaping — defense in depth. Dashboard uses textContent (XSS-safe),
@@ -5067,6 +5067,11 @@ router.put('/drones/jobs/:id', asyncHandler(function (req, res) {
   if (req.body.result_url !== undefined) fields.result_url = req.body.result_url;
   if (req.body.result_data !== undefined) fields.result_data = req.body.result_data;
   if (req.body.error !== undefined) fields.error = req.body.error;
+  if (req.body.drone_id !== undefined) fields.drone_id = req.body.drone_id;
+  if (fields.status === 'claimed' && !job.started_at) {
+    fields.started_at = new Date().toISOString();
+    if (!fields.drone_id) fields.drone_id = who;
+  }
   if (fields.status === 'done' || fields.status === 'failed') {
     fields.completed_at = new Date().toISOString();
   }


### PR DESCRIPTION
## Summary
- The `PUT /drones/jobs/:id` endpoint only accepted `done/completed/failed/cancelled/dismissed` statuses
- SDK agents can't use `POST /drones/claim` (requires drone heartbeat registration via `renderJobForDrone`)
- This blocked macbook-ollama's embed handler from claiming jobs — the PUT returned 400 silently

## Changes
- Add `pending` and `claimed` to `DRONE_JOB_STATUSES` enum
- Auto-set `started_at` and `drone_id` (defaults to caller) when claiming via PUT
- Add `drone_id` and `started_at` to `updateDroneJob` allowed fields in db.js

## Test plan
- [ ] Verify `PUT /drones/jobs/:id { status: "claimed" }` works for agent auth
- [ ] Verify `drone_id` is auto-set to calling agent when claiming
- [ ] Verify `started_at` is auto-set on first claim
- [ ] Verify existing done/failed/cancelled flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)