### PR TITLE
landing: fix RAM meter hidden on mobile (100svh + safe-area)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
   html{scroll-behavior:auto}
   body{background:#05060f;color:var(--ink);font-family:var(--body)}
   .scroller{height:560vh;position:relative}
-  .pin{position:sticky;top:0;height:100vh;overflow:hidden;background:radial-gradient(125% 95% at 50% 44%,#20204a 0%,#13132f 42%,#08081c 100%)}
+  .pin{position:sticky;top:0;height:100vh;height:100svh;overflow:hidden;background:radial-gradient(125% 95% at 50% 44%,#20204a 0%,#13132f 42%,#08081c 100%)}
   canvas{position:absolute;inset:0;width:100%;height:100%}
   .pin::after{content:"";position:absolute;inset:0;pointer-events:none;opacity:.045;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>")}
@@ -73,6 +73,9 @@
 
   /* mobile: beats are centered + shown one-at-a-time (JS crossfade) so they never overlap */
   @media (max-width:640px){
+    /* pin uses 100svh (above) so the RAM meter at bottom:80px stays above the URL bar;
+       lift it further + honor the home-indicator safe area as insurance */
+    .meter{bottom:calc(104px + env(safe-area-inset-bottom,0px))}
     .agent-card{width:min(82vw,230px)}
     .panel{width:min(84vw,300px)}
     .chat{width:min(84vw,260px)}


### PR DESCRIPTION
Mobile-only fix. The squad-memory meter in the intro sat at `bottom:80px` of a `100vh` pin; on phones `100vh` is the large viewport, so the bar rendered behind the browser URL/nav bar and was invisible.

- Pin now uses `100svh` (small viewport height — stable on scroll, unlike `dvh`) so bottom-anchored HUD stays on-screen.
- On ≤640px the meter is lifted to clear the home-indicator safe area.

Single file: `public/index.html` (low-risk path → should auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)