### PR TITLE
Platform: agent-coordination hardening + semantic-memory vector search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.1.0",
         "resend": "^6.9.3",
+        "sqlite-vec": "^0.1.9",
         "stripe": "^20.4.1",
         "ws": "^8.19.0"
       },
@@ -4830,6 +4831,84 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+      "license": "MIT OR Apache",
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/stackback": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.1.0",
     "resend": "^6.9.3",
+    "sqlite-vec": "^0.1.9",
     "stripe": "^20.4.1",
     "ws": "^8.19.0"
   },

--- a/server/db.js
+++ b/server/db.js
@@ -96,6 +96,10 @@ export function initDB() {
     // Smart Memory — access tracking for context keys
     ["context_keys", "access_count", "INTEGER NOT NULL DEFAULT 0"],
     ["context_keys", "last_accessed_at", "TEXT"],
+    // Squad-loop repo resolution — a project's local checkout root so agents
+    // working its tasks resolve relative paths in the right repo (not the
+    // agent's CWD). Any squad sets this per project.
+    ["projects", "repo_path", "TEXT NOT NULL DEFAULT ''"],
   ];
 
   for (var [table, col, def] of migrations) {
@@ -430,7 +434,7 @@ export function updateProject(id, fields) {
   if (fields.bug_categories !== undefined && typeof fields.bug_categories !== 'string') {
     fields = Object.assign({}, fields, { bug_categories: JSON.stringify(fields.bug_categories) });
   }
-  buildUpdate('projects', id, fields, ['name', 'description', 'repo_url', 'org_id', 'type', 'status', 'bug_categories', 'team_id']);
+  buildUpdate('projects', id, fields, ['name', 'description', 'repo_url', 'repo_path', 'org_id', 'type', 'status', 'bug_categories', 'team_id']);
 }
 
 export function deleteProject(id) {
@@ -1730,12 +1734,12 @@ export function buildWorkQueue(agentId, projectId, directives, requests, tasks, 
     if (!plan.steps) continue;
     for (var step of plan.steps) {
       if (step.assignee === agentId && step.status === 'in_progress') {
-        queue.push({ priority: 2, type: 'plan_step', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status });
+        queue.push({ priority: 2, type: 'plan_step', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status, project_id: plan.project_id });
       }
     }
     for (var step of plan.steps) {
       if (step.assignee === agentId && step.status === 'pending' && _planPriorsComplete(plan, step)) {
-        queue.push({ priority: 3, type: 'plan_step', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status });
+        queue.push({ priority: 3, type: 'plan_step', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status, project_id: plan.project_id });
       }
     }
   }
@@ -1765,7 +1769,7 @@ export function buildWorkQueue(agentId, projectId, directives, requests, tasks, 
     if (!plan.steps) continue;
     for (var step of plan.steps) {
       if (!step.assignee && step.status === 'pending' && _planPriorsComplete(plan, step)) {
-        queue.push({ priority: 7, type: 'plan_step_unassigned', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status });
+        queue.push({ priority: 7, type: 'plan_step_unassigned', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status, project_id: plan.project_id });
       }
     }
   }

--- a/server/db.js
+++ b/server/db.js
@@ -548,6 +548,23 @@ export function deleteTaskComment(commentId) {
   return result.changes > 0;
 }
 
+// -- Task Deliverables --
+// The agent's final output, distinct from the task_comments status thread.
+// Append-only; getTaskDeliverables returns all attempts oldest-first.
+
+export function addTaskDeliverable(taskId, author, kind, format, content, flags) {
+  var result = db.prepare(
+    "INSERT INTO task_deliverables (task_id, author, kind, format, content, flags) VALUES (?, ?, ?, ?, ?, ?) RETURNING *"
+  ).get(taskId, author, kind || 'report', format || 'markdown', content, flags || '');
+  return result;
+}
+
+export function getTaskDeliverables(taskId) {
+  return db.prepare(
+    "SELECT * FROM task_deliverables WHERE task_id = ? ORDER BY created_at ASC, id ASC"
+  ).all(taskId);
+}
+
 export function deleteTask(id) {
   db.prepare("DELETE FROM task_comments WHERE task_id = ?").run(id);
   var result = db.prepare("DELETE FROM tasks WHERE id = ?").run(id);

--- a/server/db.js
+++ b/server/db.js
@@ -1692,6 +1692,20 @@ function scopeHasOnlinePlanner(agentId, projectId, teamProjIds) {
   } catch (e) { return false; }
 }
 
+// Step ordering (durable rule): a plan step is "ready" to claim only when every
+// EARLIER step in its plan (lower step_order) is completed. Plan steps are
+// sequential by design — verify follows code, deploy follows build — so a later
+// step is never offered for claim before its predecessors finish. Enforced
+// wherever a step is offered (here + getNextUnassignedPlanStep's SQL). Today
+// step_order IS the dependency order; an explicit parallel/dependency model
+// would generalize this later.
+function _planPriorsComplete(plan, step) {
+  var order = step.step_order;
+  return (plan.steps || []).every(function (s) {
+    return s.step_order >= order || s.status === 'completed';
+  });
+}
+
 export function buildWorkQueue(agentId, projectId, directives, requests, tasks, bugs, plans) {
   var queue = [];
 
@@ -1720,7 +1734,7 @@ export function buildWorkQueue(agentId, projectId, directives, requests, tasks, 
       }
     }
     for (var step of plan.steps) {
-      if (step.assignee === agentId && step.status === 'pending') {
+      if (step.assignee === agentId && step.status === 'pending' && _planPriorsComplete(plan, step)) {
         queue.push({ priority: 3, type: 'plan_step', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status });
       }
     }
@@ -1750,7 +1764,7 @@ export function buildWorkQueue(agentId, projectId, directives, requests, tasks, 
   for (var plan of plans) {
     if (!plan.steps) continue;
     for (var step of plan.steps) {
-      if (!step.assignee && step.status === 'pending') {
+      if (!step.assignee && step.status === 'pending' && _planPriorsComplete(plan, step)) {
         queue.push({ priority: 7, type: 'plan_step_unassigned', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status });
       }
     }
@@ -1833,6 +1847,18 @@ export function getNextUnassignedPlanStep(teamProjectIds) {
      WHERE p.status = 'active'
        AND s.status = 'pending'
        AND (s.assignee IS NULL OR s.assignee = '')
+       -- Step ordering (durable): a plan step is not claimable until ALL earlier
+       -- steps in its plan (lower step_order) are completed. Plan steps are
+       -- sequential by design — a verify step must not run before the code step
+       -- it checks; a deploy not before its build. Enforced here AND in
+       -- buildWorkQueue (the assigned-claim path) so out-of-order execution
+       -- cannot happen regardless of how the steps were assigned.
+       AND NOT EXISTS (
+         SELECT 1 FROM plan_steps prior
+         WHERE prior.plan_id = s.plan_id
+           AND prior.step_order < s.step_order
+           AND prior.status != 'completed'
+       )
        ${teamScope}
      ORDER BY s.step_order ASC
      LIMIT 1`
@@ -1915,7 +1941,7 @@ export function listPlans(filters) {
   if (plans.length > 0) {
     var planIds = plans.map(function (p) { return p.id; });
     var placeholders = planIds.map(function () { return '?'; }).join(',');
-    var allSteps = db.prepare("SELECT plan_id, id, status, title, assignee FROM plan_steps WHERE plan_id IN (" + placeholders + ") ORDER BY step_order ASC").all(...planIds);
+    var allSteps = db.prepare("SELECT plan_id, id, status, title, assignee, step_order FROM plan_steps WHERE plan_id IN (" + placeholders + ") ORDER BY step_order ASC").all(...planIds);
     var stepsByPlan = {};
     for (var s of allSteps) {
       if (!stepsByPlan[s.plan_id]) stepsByPlan[s.plan_id] = [];

--- a/server/plugins/auto-memory/routes.js
+++ b/server/plugins/auto-memory/routes.js
@@ -129,13 +129,15 @@ export default function (core) {
 // ---- Extraction ----
 
 var EXTRACTION_PROMPT = `Given this agent activity, extract durable knowledge facts.
-Only extract facts that would be useful across sessions — preferences, decisions, patterns, architecture choices, conventions.
+Only extract facts useful across sessions — preferences, decisions, patterns, architecture choices, conventions.
 Do NOT extract: temporary status, in-progress work, timestamps, routine heartbeats.
+
+Each fact's "category" MUST be exactly ONE word from this set: preference, decision, pattern, architecture, convention, insight. Output a single word, never the whole list.
 
 Activity:
 {content}
 
-Return a JSON array only (no markdown, no explanation): [{ "category": "preference|decision|pattern|architecture|convention|insight", "fact_text": "...", "confidence": 0.0-1.0 }]`;
+Return ONLY a JSON array (no markdown, no prose). Each item: {"category":"<one word>","fact_text":"...","confidence":0.0-1.0}`;
 
 export async function extractFacts(db, config, text, agentId, projectId) {
   if (!text || text.length < 20) return [];

--- a/server/plugins/semantic-memory/db.js
+++ b/server/plugins/semantic-memory/db.js
@@ -1,6 +1,7 @@
 // Semantic Memory DB helpers
 
 import { cosineSimilarity } from './embeddings.js';
+import * as sqliteVec from 'sqlite-vec';
 
 var _vecAvailable = null;
 
@@ -8,7 +9,7 @@ export default function createMemoryDB(db) {
   // Try to load sqlite-vec extension on first use
   if (_vecAvailable === null) {
     try {
-      db.loadExtension('vec0');
+      sqliteVec.load(db);
       _vecAvailable = true;
       console.log('[semantic-memory] sqlite-vec loaded — vector search enabled');
     } catch (e) {

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -310,7 +310,7 @@ var STATUS_ENUMS = {
   task:      ['open', 'in_progress', 'review', 'done', 'cancelled'],
   asset:     ['requested', 'in_progress', 'ready', 'delivered', 'cancelled'],
   plan:      ['draft', 'active', 'completed', 'cancelled'],
-  plan_step: ['pending', 'in_progress', 'completed', 'blocked'],
+  plan_step: ['pending', 'in_progress', 'completed', 'blocked', 'failed'], // 'failed' = terminal: a worker couldn't complete it (max-iter / gate fail). Leaves the work queue (never re-dispatched) + surfaces; later steps gate on prior 'completed' so it can't false-advance. Added 2026-06-07 to stop fail-loops.
   bug:       ['open', 'in_progress', 'fixed', 'closed'],
   channel:   ['active', 'archived'],
   drone_job: ['pending', 'claimed', 'done', 'completed', 'failed', 'cancelled', 'dismissed']
@@ -3130,6 +3130,14 @@ router.put('/plans/:id/steps/:stepId', asyncHandler(function (req, res) {
   }
   emitEvent('plan_step_updated', agentId, plan ? plan.project_id : null, agentId + ' updated step #' + stepStepId + ' on plan #' + stepPlanId, { plan_id: stepPlanId, step_id: stepStepId, fields: fields });
   dispatchWebhook('plan_step_updated', agentId, { plan_id: stepPlanId, step_id: stepStepId, fields: fields });
+  // A FAILED step is terminal — surface it loudly. It stalls its plan by design
+  // (later steps gate on prior 'completed'), so it never false-advances; it needs
+  // a retry/re-plan rather than silently re-dispatching.
+  if (fields.status === 'failed') {
+    emitEvent('plan_step_failed', agentId, plan ? plan.project_id : null,
+      agentId + ' FAILED step #' + stepStepId + ' on plan #' + stepPlanId + (planStep ? (': ' + planStep.title) : ''),
+      { plan_id: stepPlanId, step_id: stepStepId });
+  }
   // Route operator_input assignments to all operators' inboxes
   if (fields.assignee === 'operator_input') {
     var stepTitle = planStep ? planStep.title : ('Step #' + stepStepId);

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -459,6 +459,14 @@ function checkProjectScope(req, res, resourceProjectId, assignee) {
   if (req.method === 'GET') return true; // agents can read across projects (shared swarm context)
   if (req._authProjectId === resourceProjectId) return true;
   if (assignee && assignee === req._authAgentId) return true; // assigned agent can update their own work across projects
+  // Team-scope (durable): an agent may write to any project owned by a team it
+  // belongs to. This makes write-scope match DISPATCH-scope — auto-dispatch
+  // already routes team-project work to the agent via getTeamProjectIdsForAgent —
+  // so an agent can't be handed a team-project step yet 403 when recording its
+  // result or creating a plan there.
+  try {
+    if (getTeamProjectIdsForAgent(req._authAgentId).indexOf(resourceProjectId) !== -1) return true;
+  } catch (e) { /* fall through to 403 */ }
   res.status(403).json({ error: 'Agent ' + req._authAgentId + ' cannot access resources in project ' + resourceProjectId });
   return false;
 }

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -1294,6 +1294,36 @@ router.get('/work/:agentId', asyncHandler(function (req, res) {
   res.json({ ok: true, queue: queue });
 }));
 
+// ======== REASONING STREAM ========
+
+// An agent (squad_loop) posts its reasoning chain as it works a task: thinking
+// (<think>), tool_call, result, done, error. ONE stream → the operator app's
+// sidecar back-half + training corpus + cockpit shimmer colour. Persisted (it's
+// training data, unlike heartbeats) and SSE-broadcast to the operator app.
+// Contract: mycelium-app/docs/specs/2026-06-06-reasoning-stream.md
+router.post('/reasoning', agentWriteLimiter, asyncHandler(function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  var b = req.body || {};
+  var agent = b.agent || who;
+  var step = String(b.step || 'thinking');
+  if (['thinking', 'tool_call', 'result', 'done', 'error'].indexOf(step) === -1) {
+    return apiError(res, 400, 'invalid step');
+  }
+  var data = {
+    task_id: (b.task_id != null) ? b.task_id : null,
+    turn:    (b.turn != null) ? b.turn : null,
+    step:    step,
+    text:    (typeof b.text === 'string') ? b.text : '',
+    tool:    b.tool || null
+  };
+  var summary = agent + ' · ' + step
+    + (b.tool && b.tool.name ? ' · ' + b.tool.name : '')
+    + (b.task_id != null ? ' (task #' + b.task_id + ')' : '');
+  var id = emitEvent('agent_reasoning', agent, req._authProjectId || null, summary, data);
+  res.json({ ok: true, id: id });
+}));
+
 // ======== AGENTS ========
 
 router.post('/agents/heartbeat', asyncHandler(function (req, res) {

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -138,6 +138,7 @@ import {
   createDroneProfile, getDroneProfile, listDroneProfiles, updateDroneProfile, deleteDroneProfile,
   assignDroneProfile, unassignDroneProfile, getDroneProfileAssignments, markProfileSetupDone, getDronesWithProfile,
   addTaskComment, getTaskComments, getTaskComment, deleteTaskComment, deleteTask,
+  addTaskDeliverable, getTaskDeliverables,
   addPlanStepComment, getPlanStepComments,
   GATED_ACTIONS, createApproval, getApproval, listApprovals, decideApproval,
   markApprovalExecuted, countPendingApprovals, listPendingApprovalsByAgent,
@@ -1780,6 +1781,38 @@ router.post('/tasks/:id/comments', asyncHandler(function (req, res) {
   var comment = addTaskComment(task.id, author, content);
   emitEvent('task_comment', who, task.project_id, who + ' commented on task #' + task.id, { task_id: task.id, comment_id: comment.id });
   res.json(comment);
+}));
+
+// ======== TASK DELIVERABLES ========
+// An agent's final output (typed, raw markdown). Distinct from the comment
+// thread; a deliverable row existing == the task produced real output.
+
+router.get('/tasks/:id/deliverables', asyncHandler(function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  var task = getTask(parseIntParam(req.params.id));
+  if (!task) return res.status(404).json({ error: 'Task not found' });
+  res.json(getTaskDeliverables(task.id));
+}));
+
+router.post('/tasks/:id/deliverable', asyncHandler(function (req, res) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return;
+  var task = getTask(parseIntParam(req.params.id));
+  if (!task) return res.status(404).json({ error: 'Task not found' });
+  var author = escapeHtml(req.body.author || who);
+  var kind = escapeHtml(req.body.kind || 'report');
+  var format = escapeHtml(req.body.format || 'markdown');
+  var flags = escapeHtml(req.body.flags || '');
+  // content is stored RAW markdown — NOT escapeHtml'd (comments escape because
+  // they render as HTML; deliverables render through a markdown view in Phase 2,
+  // where escaping would corrupt code blocks). The Phase-2 renderer must treat
+  // this as markdown, never raw-inject it as HTML.
+  var content = req.body.content;
+  if (!content) return res.status(400).json({ error: 'content is required' });
+  var deliverable = addTaskDeliverable(task.id, author, kind, format, content, flags);
+  emitEvent('task_deliverable', who, task.project_id, who + ' delivered task #' + task.id + ' (' + kind + ')', { task_id: task.id, deliverable_id: deliverable.id, kind: kind });
+  res.json(deliverable);
 }));
 
 router.delete('/tasks/:id', asyncHandler(function (req, res) {

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS projects (
   description     TEXT NOT NULL DEFAULT '',
   org_id          TEXT NOT NULL DEFAULT '',
   repo_url        TEXT NOT NULL DEFAULT '',
+  repo_path       TEXT NOT NULL DEFAULT '',  -- local checkout root; agents working this project's tasks resolve relative paths here (squad-loop repo resolution)
   type            TEXT NOT NULL DEFAULT 'software',
   status          TEXT NOT NULL DEFAULT 'active',
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -335,6 +335,22 @@ CREATE TABLE IF NOT EXISTS task_comments (
 );
 CREATE INDEX IF NOT EXISTS idx_task_comments_task ON task_comments(task_id);
 
+-- Task deliverables: an agent's final OUTPUT (typed, raw markdown), distinct
+-- from the task_comments status/discussion thread. Append-only, so re-runs and
+-- review->revise cycles preserve every attempt (clean spec->deliverable pairs
+-- for the training loop). Invariant: a row here == the task produced real output.
+CREATE TABLE IF NOT EXISTS task_deliverables (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  task_id    INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  author     TEXT NOT NULL,
+  kind       TEXT NOT NULL DEFAULT 'report',
+  format     TEXT NOT NULL DEFAULT 'markdown',
+  content    TEXT NOT NULL,
+  flags      TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_task_deliverables_task ON task_deliverables(task_id);
+
 -- Support tickets (customer support)
 CREATE TABLE IF NOT EXISTS support_tickets (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
Platform hardening for multi-agent coordination, surfaced by dogfooding the squad against a real app build. Four independently-reviewable commits:

- **task deliverables** — typed deliverable store + routes
- **reasoning stream** — `POST /reasoning`, persisted + SSE
- **plan-step phase ordering + team project-scope** — a plan step isn't claimable until all earlier phases complete (fixes out-of-order execution, e.g. a verify step running before the code step it checks); steps sharing a `step_order` stay concurrent-eligible. `checkProjectScope` now honors team-scope so write-access matches dispatch-access (`getTeamProjectIdsForAgent`).
- **semantic-memory** — load `sqlite-vec` for vector search (the loader existed; only the package was missing); harden the auto-memory extraction prompt for small local extractor models.

Validated end-to-end: a full planner→coder→verifier squad cycle completes a real app edit with correct phase ordering (no 507 from concurrent big-model loads, no project-scope 403) and a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)