### PR TITLE
Platform: squad-loop reliability — failed-step terminal state + repo/project routing

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -96,6 +96,10 @@ export function initDB() {
     // Smart Memory — access tracking for context keys
     ["context_keys", "access_count", "INTEGER NOT NULL DEFAULT 0"],
     ["context_keys", "last_accessed_at", "TEXT"],
+    // Squad-loop repo resolution — a project's local checkout root so agents
+    // working its tasks resolve relative paths in the right repo (not the
+    // agent's CWD). Any squad sets this per project.
+    ["projects", "repo_path", "TEXT NOT NULL DEFAULT ''"],
   ];
 
   for (var [table, col, def] of migrations) {
@@ -430,7 +434,7 @@ export function updateProject(id, fields) {
   if (fields.bug_categories !== undefined && typeof fields.bug_categories !== 'string') {
     fields = Object.assign({}, fields, { bug_categories: JSON.stringify(fields.bug_categories) });
   }
-  buildUpdate('projects', id, fields, ['name', 'description', 'repo_url', 'org_id', 'type', 'status', 'bug_categories', 'team_id']);
+  buildUpdate('projects', id, fields, ['name', 'description', 'repo_url', 'repo_path', 'org_id', 'type', 'status', 'bug_categories', 'team_id']);
 }
 
 export function deleteProject(id) {
@@ -1730,12 +1734,12 @@ export function buildWorkQueue(agentId, projectId, directives, requests, tasks, 
     if (!plan.steps) continue;
     for (var step of plan.steps) {
       if (step.assignee === agentId && step.status === 'in_progress') {
-        queue.push({ priority: 2, type: 'plan_step', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status });
+        queue.push({ priority: 2, type: 'plan_step', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status, project_id: plan.project_id });
       }
     }
     for (var step of plan.steps) {
       if (step.assignee === agentId && step.status === 'pending' && _planPriorsComplete(plan, step)) {
-        queue.push({ priority: 3, type: 'plan_step', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status });
+        queue.push({ priority: 3, type: 'plan_step', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status, project_id: plan.project_id });
       }
     }
   }
@@ -1765,7 +1769,7 @@ export function buildWorkQueue(agentId, projectId, directives, requests, tasks, 
     if (!plan.steps) continue;
     for (var step of plan.steps) {
       if (!step.assignee && step.status === 'pending' && _planPriorsComplete(plan, step)) {
-        queue.push({ priority: 7, type: 'plan_step_unassigned', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status });
+        queue.push({ priority: 7, type: 'plan_step_unassigned', id: step.id, plan_id: plan.id, plan_title: plan.title, title: step.title, status: step.status, project_id: plan.project_id });
       }
     }
   }

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -310,7 +310,7 @@ var STATUS_ENUMS = {
   task:      ['open', 'in_progress', 'review', 'done', 'cancelled'],
   asset:     ['requested', 'in_progress', 'ready', 'delivered', 'cancelled'],
   plan:      ['draft', 'active', 'completed', 'cancelled'],
-  plan_step: ['pending', 'in_progress', 'completed', 'blocked'],
+  plan_step: ['pending', 'in_progress', 'completed', 'blocked', 'failed'], // 'failed' = terminal: a worker couldn't complete it (max-iter / gate fail). Leaves the work queue (never re-dispatched) + surfaces; later steps gate on prior 'completed' so it can't false-advance. Added 2026-06-07 to stop fail-loops.
   bug:       ['open', 'in_progress', 'fixed', 'closed'],
   channel:   ['active', 'archived'],
   drone_job: ['pending', 'claimed', 'done', 'completed', 'failed', 'cancelled', 'dismissed']
@@ -3130,6 +3130,14 @@ router.put('/plans/:id/steps/:stepId', asyncHandler(function (req, res) {
   }
   emitEvent('plan_step_updated', agentId, plan ? plan.project_id : null, agentId + ' updated step #' + stepStepId + ' on plan #' + stepPlanId, { plan_id: stepPlanId, step_id: stepStepId, fields: fields });
   dispatchWebhook('plan_step_updated', agentId, { plan_id: stepPlanId, step_id: stepStepId, fields: fields });
+  // A FAILED step is terminal — surface it loudly. It stalls its plan by design
+  // (later steps gate on prior 'completed'), so it never false-advances; it needs
+  // a retry/re-plan rather than silently re-dispatching.
+  if (fields.status === 'failed') {
+    emitEvent('plan_step_failed', agentId, plan ? plan.project_id : null,
+      agentId + ' FAILED step #' + stepStepId + ' on plan #' + stepPlanId + (planStep ? (': ' + planStep.title) : ''),
+      { plan_id: stepPlanId, step_id: stepStepId });
+  }
   // Route operator_input assignments to all operators' inboxes
   if (fields.assignee === 'operator_input') {
     var stepTitle = planStep ? planStep.title : ('Step #' + stepStepId);

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS projects (
   description     TEXT NOT NULL DEFAULT '',
   org_id          TEXT NOT NULL DEFAULT '',
   repo_url        TEXT NOT NULL DEFAULT '',
+  repo_path       TEXT NOT NULL DEFAULT '',  -- local checkout root; agents working this project's tasks resolve relative paths here (squad-loop repo resolution)
   type            TEXT NOT NULL DEFAULT 'software',
   status          TEXT NOT NULL DEFAULT 'active',
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),


### PR DESCRIPTION
Three small, coupled platform changes that make **any** squad's plan-step loop fail *honestly* and resolve work in the *right place*. General-purpose (not our-squad-shaped). This is the platform half — the changes that belong in the public, multi-tenant platform. (The squad-side bridge changes that *consume* these live in our private squad repo.)

## What & why

**1. Terminal `failed` plan_step status** (+ a `plan_step_failed` event)
A worker that can't finish a step (hit max iterations, or its efficacy gate failed) now marks the step `failed` instead of leaving it `in_progress`. Previously an unfinishable step stuck `in_progress` and got **re-dispatched forever**, starving sibling plans (a fail-loop that could block all other work). `failed` is terminal: the step leaves the work queue and surfaces via the new event. Later steps already gate on prior `completed` (phase ordering), so a failed step **stalls its plan for retry/re-plan** — it can never false-advance past the gap.

**2. `projects.repo_path`** (schema column + idempotent migration + `updateProject` allowlist)
A project's local checkout root. Agents working that project's tasks resolve **relative paths against this repo**, not the agent's CWD. It's a per-project **config knob** set as data/UI — never hardcoded, works for any squad's repos. (This is the "lift knobs to config, not Python constants" template.)

**3. `project_id` on `buildWorkQueue` plan_step items**
So the bridge can look up the project's `repo_path` (and file under the right project) for each step it claims.

## Safety
- Migration is additive + idempotent (`TEXT NOT NULL DEFAULT ''`); existing rows get the default, no backfill.
- `failed` is purely additive to the enum; nothing emits it unless a worker explicitly sets it. Existing `pending/in_progress/completed/blocked` flows are unchanged.

## Stacking
Based on `planner-triage-routing` (#120) because these build on its `buildWorkQueue` phase-gating + plan-step infra. GitHub will retarget the base to `master` automatically when #120 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
