### PR TITLE
Platform: bounded self-heal retry policy for failed plan steps

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -100,6 +100,8 @@ export function initDB() {
     // working its tasks resolve relative paths in the right repo (not the
     // agent's CWD). Any squad sets this per project.
     ["projects", "repo_path", "TEXT NOT NULL DEFAULT ''"],
+    // Bounded self-heal: how many auto-retries a plan step has spent (retry policy).
+    ["plan_steps", "attempt_count", "INTEGER NOT NULL DEFAULT 0"],
   ];
 
   for (var [table, col, def] of migrations) {
@@ -1993,6 +1995,42 @@ export function updatePlanStep(stepId, fields) {
   // Update parent plan's updated_at
   var step = db.prepare("SELECT plan_id FROM plan_steps WHERE id = ?").get(stepId);
   if (step) db.prepare("UPDATE plans SET updated_at = datetime('now') WHERE id = ?").run(step.plan_id);
+}
+
+// Bounded self-heal for a FAILED plan step. If the step still has retry budget,
+// reopen it + the phase it guards (the immediately-prior step_order) to 'pending'
+// and attach the failure `critique` to those reopened steps, so the work re-cycles
+// with the verifier's reasons fed forward. Returns {action:'retried'|'exhausted'|'none'}.
+// Runtime-agnostic: it only moves platform rows; the reopened steps flow through the
+// normal work queue to whatever agent/runner is assigned. The caller decides what to
+// do on 'exhausted' (block + escalate). maxAttempts is the caller's policy knob.
+export function autoRetryOrEscalatePlanStep(planId, stepId, maxAttempts, critique) {
+  var failed = db.prepare("SELECT id, step_order, attempt_count FROM plan_steps WHERE id = ? AND plan_id = ?").get(stepId, planId);
+  if (!failed) return { action: 'none' };
+  var attempts = failed.attempt_count || 0;
+  if (attempts >= maxAttempts) return { action: 'exhausted', attempts: attempts };
+  var nextAttempt = attempts + 1;
+  var steps = db.prepare("SELECT id, step_order, status FROM plan_steps WHERE plan_id = ?").all(planId);
+  // The phase this step guards = the greatest step_order below it (re-run the impl
+  // a verify step checks). Reopen those completed steps + the failed step itself.
+  var priorOrders = steps.map(function (s) { return s.step_order; }).filter(function (o) { return o < failed.step_order; });
+  var priorOrder = priorOrders.length ? Math.max.apply(null, priorOrders) : null;
+  var toReopen = steps.filter(function (s) {
+    return s.id === stepId || (priorOrder !== null && s.step_order === priorOrder && s.status === 'completed');
+  });
+  var tx = db.transaction(function () {
+    for (var s of toReopen) {
+      db.prepare("UPDATE plan_steps SET status = 'pending', completed_at = NULL, updated_at = datetime('now') WHERE id = ?").run(s.id);
+      if (critique && s.id !== stepId) {
+        addPlanStepComment(s.id, planId, '__system__',
+          '[auto-retry ' + nextAttempt + '/' + maxAttempts + '] Prior verification FAILED — fix before re-submitting:\n' + critique);
+      }
+    }
+    db.prepare("UPDATE plan_steps SET attempt_count = ?, updated_at = datetime('now') WHERE id = ?").run(nextAttempt, stepId);
+    db.prepare("UPDATE plans SET updated_at = datetime('now') WHERE id = ?").run(planId);
+  });
+  tx();
+  return { action: 'retried', attempt: nextAttempt, max: maxAttempts, reopened: toReopen.length };
 }
 
 export function deletePlanStep(stepId) {

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -139,7 +139,7 @@ import {
   assignDroneProfile, unassignDroneProfile, getDroneProfileAssignments, markProfileSetupDone, getDronesWithProfile,
   addTaskComment, getTaskComments, getTaskComment, deleteTaskComment, deleteTask,
   addTaskDeliverable, getTaskDeliverables,
-  addPlanStepComment, getPlanStepComments,
+  addPlanStepComment, getPlanStepComments, autoRetryOrEscalatePlanStep,
   GATED_ACTIONS, createApproval, getApproval, listApprovals, decideApproval,
   markApprovalExecuted, countPendingApprovals, listPendingApprovalsByAgent,
   castApprovalVote, getApprovalVotes, countApprovalVotes,
@@ -3130,13 +3130,36 @@ router.put('/plans/:id/steps/:stepId', asyncHandler(function (req, res) {
   }
   emitEvent('plan_step_updated', agentId, plan ? plan.project_id : null, agentId + ' updated step #' + stepStepId + ' on plan #' + stepPlanId, { plan_id: stepPlanId, step_id: stepStepId, fields: fields });
   dispatchWebhook('plan_step_updated', agentId, { plan_id: stepPlanId, step_id: stepStepId, fields: fields });
-  // A FAILED step is terminal — surface it loudly. It stalls its plan by design
-  // (later steps gate on prior 'completed'), so it never false-advances; it needs
-  // a retry/re-plan rather than silently re-dispatching.
+  // A FAILED step triggers the platform's bounded SELF-HEAL: reopen the step + the
+  // phase it guards (with the failure critique) for another attempt; after RETRY_MAX
+  // attempts, finalize as terminal-failed → block the plan → escalate to operators.
+  // Runtime-agnostic: reopened steps flow through the normal work queue to whoever's
+  // assigned — no orchestrator/runtime/agent assumptions live here. (Worker may pass
+  // an optional `critique` in the PUT body; the failed step's own comment otherwise.)
   if (fields.status === 'failed') {
-    emitEvent('plan_step_failed', agentId, plan ? plan.project_id : null,
-      agentId + ' FAILED step #' + stepStepId + ' on plan #' + stepPlanId + (planStep ? (': ' + planStep.title) : ''),
-      { plan_id: stepPlanId, step_id: stepStepId });
+    var RETRY_MAX = 2; // resilient default; first knob to lift to per-scope config
+    var critique = req.body.critique || null;
+    var rr = autoRetryOrEscalatePlanStep(stepPlanId, stepStepId, RETRY_MAX, critique);
+    if (rr.action === 'retried') {
+      emitEvent('plan_step_retry', agentId, plan ? plan.project_id : null,
+        agentId + ' — step #' + stepStepId + ' failed; auto-retry ' + rr.attempt + '/' + rr.max +
+        ' (reopened ' + rr.reopened + ' step(s) with the critique)',
+        { plan_id: stepPlanId, step_id: stepStepId, attempt: rr.attempt });
+    } else {
+      emitEvent('plan_step_failed', agentId, plan ? plan.project_id : null,
+        agentId + ' FAILED step #' + stepStepId + ' on plan #' + stepPlanId +
+        (planStep ? (': ' + planStep.title) : '') + ' (auto-retries exhausted)',
+        { plan_id: stepPlanId, step_id: stepStepId });
+      updatePlan(stepPlanId, { status: 'blocked' });
+      createInboxItemForAllOperators('approval', 'plan_step', stepStepId,
+        'Plan step failed after retries: ' + (planStep ? planStep.title : ('#' + stepStepId)),
+        'Plan #' + stepPlanId + ' — ' + (plan ? (plan.title || '') : '') + '. Step #' + stepStepId +
+        ' exhausted ' + RETRY_MAX + ' auto-retries and was blocked for review.',
+        { plan_id: stepPlanId, step_id: stepStepId }, 'high');
+      emitEvent('plan_blocked', agentId, plan ? plan.project_id : null,
+        'Plan #' + stepPlanId + ' blocked — step #' + stepStepId + ' failed after ' + RETRY_MAX + ' auto-retries',
+        { plan_id: stepPlanId });
+    }
   }
   // Route operator_input assignments to all operators' inboxes
   if (fields.assignee === 'operator_input') {

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -236,6 +236,7 @@ CREATE TABLE IF NOT EXISTS plan_steps (
   linked_branch  TEXT,
   linked_pr_url  TEXT,
   completed_at   TEXT,
+  attempt_count  INTEGER NOT NULL DEFAULT 0,  -- bounded self-heal: auto-retries spent on this step
   created_at     TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
 );


### PR DESCRIPTION
Bounded self-heal for failed plan steps — **the platform half** (the squad-bridge half is a sibling jarvis PR).

A step marked `failed` no longer dead-stops: the platform reopens it + the phase it guards (with the failure critique) for another attempt, bounded by `plan_steps.attempt_count` (`RETRY_MAX`=2, resilient default). After the cap → terminal `failed` + plan `blocked` + operator-inbox escalation. Reopened steps flow through the normal work queue — **runtime-agnostic, no orchestrator/agent assumptions in it.**

- `plan_steps.attempt_count` (schema + idempotent migration)
- `autoRetryOrEscalatePlanStep()` (db.js)
- PUT `/plans/:id/steps` `failed` branch → `plan_step_retry`, or exhaust → `plan_step_failed` + plan `blocked` + inbox; accepts an optional `critique` in the PUT body, attached to the reopened steps.

Builds on the merged failed-step state (#121). `RETRY_MAX` is the first knob to lift to per-scope config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
