### PR TITLE
Cleanup: sovereignty defaults complete + events-stream auth role fix

### DIFF
--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -35,7 +35,7 @@ package.json      # mycelium-mcp v1.2.0
 
 - **Transport**: stdio (standard MCP pattern)
 - **Two modes**: `admin` (full access, X-Admin-Key) and `agent` (scoped, X-Agent-Key, auto-heartbeat)
-- **API target**: Defaults to `https://mycelium.fyi/api/mycelium`. Configurable via `MYCELIUM_API_URL`.
+- **API target**: Defaults to `http://localhost:3002/api/mycelium` — sovereignty default: your own local instance, never a hosted third party (mycelium.fyi is deprecated). Configurable via `MYCELIUM_API_URL`.
 - **Tool naming**: All tools registered with `mycelium_*` prefix. Legacy `studio_*` aliases also registered.
 - **Auto-heartbeat**: In agent mode, sends heartbeat every 5 minutes. Clears `working_on` on shutdown.
 
@@ -46,7 +46,7 @@ package.json      # mycelium-mcp v1.2.0
 | `MYCELIUM_API_KEY` | Yes | Admin key or agent key |
 | `MYCELIUM_ROLE` | No | `admin` (default) or `agent` |
 | `MYCELIUM_AGENT_ID` | Agent mode | Agent identifier (e.g. `greatness-claude`) |
-| `MYCELIUM_API_URL` | No | API base URL (default: `https://mycelium.fyi/api/mycelium`) |
+| `MYCELIUM_API_URL` | No | API base URL (default: `http://localhost:3002/api/mycelium`) |
 
 ## Configuration
 
@@ -59,7 +59,7 @@ Add to `~/.claude/settings.json`:
       "command": "node",
       "args": ["/path/to/mycelium-mcp/index.js"],
       "env": {
-        "MYCELIUM_API_URL": "https://mycelium.fyi/api/mycelium",
+        "MYCELIUM_API_URL": "http://localhost:3002/api/mycelium",
         "MYCELIUM_ROLE": "admin",
         "MYCELIUM_API_KEY": "<admin-key>"
       }

--- a/sdk/bin/init.js
+++ b/sdk/bin/init.js
@@ -15,7 +15,8 @@ import { writeFileSync, existsSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
-var API_URL = process.env.MYCELIUM_API_URL || 'https://mycelium.fyi/api/mycelium'
+// Sovereignty default: your own local instance, never a hosted third party (mycelium.fyi is deprecated)
+var API_URL = process.env.MYCELIUM_API_URL || 'http://localhost:3002/api/mycelium'
 
 function prompt(rl, question, defaultVal) {
   return new Promise(function(resolve) {
@@ -222,7 +223,7 @@ async function main() {
 
     console.log('')
     console.log('Done! Your agent is registered on the Mycelium network.')
-    console.log('Dashboard: https://mycelium.fyi/studio/')
+    console.log('Health check: ' + API_URL + '/health')
   } catch (err) {
     console.error('Registration failed:', err.message)
     process.exit(1)

--- a/sdk/bin/run.js
+++ b/sdk/bin/run.js
@@ -4,7 +4,9 @@
 // Environment variables:
 //   MYCELIUM_AGENT_ID  — agent identifier (required)
 //   MYCELIUM_API_KEY   — agent API key (required)
-//   MYCELIUM_API_URL   — API base URL (default: https://mycelium.fyi/api/mycelium)
+//   MYCELIUM_API_URL   — API base URL (default: http://localhost:3002/api/mycelium)
+//                        Sovereignty default: your own local instance, never a
+//                        hosted third party (mycelium.fyi is deprecated)
 //   MYCELIUM_HANDLER   — path to JS module with work/message handlers (optional)
 //
 // The handler module should export:
@@ -27,7 +29,7 @@ if (!agentId || !apiKey) {
   console.error('  MYCELIUM_API_KEY   — Your agent API key')
   console.error('')
   console.error('Optional:')
-  console.error('  MYCELIUM_API_URL   — API base URL (default: https://mycelium.fyi/api/mycelium)')
+  console.error('  MYCELIUM_API_URL   — API base URL (default: http://localhost:3002/api/mycelium)')
   console.error('  MYCELIUM_HANDLER   — Path to JS module with handler functions')
   process.exit(1)
 }

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -2678,7 +2678,10 @@ router.get('/events/stream', asyncHandler(function (req, res) {
   if (token) {
     try {
       var decoded = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] });
-      if (decoded && decoded.studioUser) { req._authIsAdmin = true; authOk = true; }
+      // Any studio JWT may stream, but only admin-role users carry the admin
+      // flag (mirrors checkAgentOrAdmin — any-JWT-means-admin was a
+      // privilege-flattening hole)
+      if (decoded && decoded.studioUser) { req._authIsAdmin = decoded.role === 'admin'; authOk = true; }
     } catch (e) { /* invalid token, fall through to header auth */ }
   }
 


### PR DESCRIPTION
Last .fyi fallbacks flipped (sdk/bin CLIs, mcp docs), retired-dashboard print replaced, and the second instance of studio-JWT→admin flattening fixed on the events stream. All suites green (147 vitest + 21 plugin tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)