### PR TITLE
Agent avatars: platform-served faces, deployment-local by design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ __pycache__/
 *.pyc
 *.log
 tools/logs/
+
+# Deployment-local agent avatars (crew faces are instance data, never shipped in the public repo)
+public/avatars/*
+!public/avatars/README.md

--- a/public/avatars/README.md
+++ b/public/avatars/README.md
@@ -1,0 +1,10 @@
+# Agent avatars (deployment-local)
+
+Drop `<agent-id>.png` files here and set the agent record's `avatar_url`
+to `/avatars/<agent-id>.png` (server-relative; clients resolve against
+their instance base URL):
+
+    PUT /api/mycelium/agents/<id>  {"avatar_url": "/avatars/<id>.png"}
+
+Files in this directory are **gitignored by design** — faces are instance
+data, like the SQLite DB. The mechanism is public; your crew is yours.


### PR DESCRIPTION
public/avatars/ convention: instance-data faces (gitignored) + agents.avatar_url. README documents the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)