### PR TITLE
chore(sdk): align license field with repo relicense (MIT -> Apache-2.0)

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -37,7 +37,7 @@
     "mcp"
   ],
   "author": "SoftBacon Software <hello@mycelium.fyi> (https://mycelium.fyi)",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/SoftBacon-Software/mycelium.git",


### PR DESCRIPTION
86f726d relicensed the repo AGPL-3.0 -> Apache-2.0 but sdk/package.json still declared MIT. One license, everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)