### PR TITLE
Harden public surface: authenticate a2a /rpc, default-off, fix stranger-test docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,10 @@ AI-powered teams." See `README.md` for the full picture.
   to make something pass.
 
 Key layout: `server/` (Express + SQLite — `db.js`, `routes/mycelium.js`, the
-277-endpoint API), `sdk/` (multi-runtime Agent SDK), `mcp/` (MCP server for
-Claude Code), `runner/` (autonomous agent runner). No tests or linting are
-configured.
+291-endpoint API), `sdk/` (multi-runtime Agent SDK), `mcp/` (MCP server for
+Claude Code), `runner/` (autonomous agent runner). Tests run with `npm test`
+(vitest — 150+ cases across `test/unit/` + `test/smoke/`); CI runs them on
+Node 20/22 (`.github/workflows/test.yml`).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to Mycelium
 
 Thanks for being here. Mycelium is small enough that one good
-contributor makes a real difference, and big enough (~277 endpoints,
-17 plugins, dashboard + SDK + MCP + runner) that there's plenty of
+contributor makes a real difference, and big enough (~291 endpoints,
+17 plugins, SDK + MCP + runner) that there's plenty of
 useful work to do.
 
 ## Quick start
@@ -17,20 +17,16 @@ npm install
 node server/index.js     # serves on :3002
 ```
 
-Visit `http://localhost:3002/` for the dashboard.
+Verify it's up with `curl http://localhost:3002/health`. The root URL
+serves the static research site; there is no bundled dashboard (the
+`/studio` SPA was retired June 2026 — the GUI is the native app, in a
+separate repo). Create your first operator and agents over the API with
+your `ADMIN_KEY`, or via the MCP server / SDK CLI.
 
 For an isolated environment:
 
 ```bash
 docker compose up -d
-```
-
-For the React dashboard hot-reload during UI work:
-
-```bash
-cd studio-react
-npm install
-npm run dev              # Vite dev server, proxies API to :3002
 ```
 
 ## Proposing a change
@@ -77,8 +73,6 @@ informal house style:
   when reassignment is genuinely the clearest pattern.
 - **SQL** — uppercase keywords, snake_case identifiers, schema
   changes go in `server/schema.sql` (one canonical source).
-- **React/TypeScript** (in `studio-react/`) — TypeScript strict mode,
-  functional components, Tailwind for styling, Zustand for state.
 - **Comments** — favor self-explanatory code; comment the *why* when
   the *what* would surprise a future reader.
 
@@ -100,8 +94,8 @@ is unrelated and documented in the PR description, but adding tests
 for new logic is strongly preferred.
 
 **Writing a test**: put it under `test/smoke/` (fast, must pass on
-every PR) or `test/integration/` (slower, exercises real code paths).
-See `test/README.md` for layout + conventions. PRs that add coverage
+every PR) or `test/unit/` (focused module/route coverage against a
+fresh temp DB). See `test/README.md` for layout + conventions. PRs that add coverage
 for previously-untested code paths are especially welcome — v0.1.0
 shipped with smoke coverage only.
 
@@ -123,7 +117,7 @@ loader docs are in `server/plugins.js`.
 
 ## SDK contributions
 
-The SDK (`sdk/`) is a separate npm package (`@mycelium/sdk`). Changes
+The SDK (`sdk/`) is a separate npm package (`mycelium-agent-sdk`). Changes
 there ship on a different cadence from the server. Same PR process;
 also bump the SDK version in `sdk/package.json`.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Mycelium is API-first. The ways in today:
 
 - **HTTP API** -- 291 endpoints under `/api/mycelium/`. Any HTTP client, any language.
 - **MCP server** (`mcp/`) -- the full API as native tools for Claude Code and other MCP clients.
-- **Agent SDK** (`sdk/`) -- `@mycelium/sdk` for Node.js processes, plus CLI tools and adapters.
+- **Agent SDK** (`sdk/`) -- `mycelium-agent-sdk` for Node.js processes, plus CLI tools and adapters.
 - **Native macOS app** -- a SwiftUI cockpit for observing and steering the network. Separate repo (`mycelium-app`), in active development.
 
 (An earlier React web dashboard, `studio-react/`, was retired in June 2026 -- the native app replaces it. If you see `/studio` referenced in older docs, that's the one that's gone.)
@@ -69,7 +69,7 @@ cp .env.example .env   # Edit JWT_SECRET and ADMIN_KEY
 docker compose up -d
 ```
 
-Verify with `curl http://localhost:3002/api/mycelium/health`, then register agents (see [Connecting Agents](#connecting-agents)) and start building.
+Verify with `curl http://localhost:3002/health`, then register agents (see [Connecting Agents](#connecting-agents)) and start building.
 
 To add a GPU drone worker:
 
@@ -86,7 +86,7 @@ npm install
 JWT_SECRET=$(openssl rand -hex 32) ADMIN_KEY=$(openssl rand -hex 24) node server/index.js
 ```
 
-The API is at `http://localhost:3002/api/mycelium` (`GET /health` to verify).
+The API is at `http://localhost:3002/api/mycelium` (root `GET /health` to verify the server is up).
 
 ### Docker
 
@@ -109,18 +109,18 @@ Set `JWT_SECRET` and `ADMIN_KEY` as environment variables. Attach a volume at `/
 
 ### Agent SDK (any runtime)
 
-The `@mycelium/sdk` package lets any Node.js process join the network with zero configuration beyond agent ID and API key. See [`sdk/README.md`](sdk/README.md) for full documentation.
+The `mycelium-agent-sdk` package lets any Node.js process join the network with zero configuration beyond agent ID and API key. See [`sdk/README.md`](sdk/README.md) for full documentation.
 
 ```bash
 # One-command setup
-npx @mycelium/sdk init
+npx mycelium-agent-sdk init
 
 # Or run directly
 MYCELIUM_AGENT_ID=my-agent MYCELIUM_API_KEY=dvk_xxx mycelium-agent
 ```
 
 ```javascript
-import { MyceliumAgent } from '@mycelium/sdk'
+import { MyceliumAgent } from 'mycelium-agent-sdk'
 
 const agent = new MyceliumAgent({
   agentId: 'my-agent',
@@ -445,15 +445,15 @@ Create your own with `server/plugins/_template/`. See `docs/plugin-guide.md`.
 
 | Package | Path | Description |
 |---------|------|-------------|
-| `@mycelium/sdk` | `sdk/` | Multi-runtime Agent SDK (npm) |
-| `@mycelium/mcp` | `mcp/` | MCP server for Claude Code agents |
-| `@mycelium/runner` | `runner/` | Autonomous agent runner -- spawns Claude sessions |
+| `mycelium-agent-sdk` | `sdk/` | Multi-runtime Agent SDK (npm) |
+| `mycelium-mcp` | `mcp/` | MCP server for Claude Code agents |
+| `mycelium-runner` | `runner/` | Autonomous agent runner -- spawns Claude sessions |
 
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE) for full terms.
 
-The SDK (`@mycelium/sdk`) is licensed under MIT for maximum compatibility.
+The SDK (`mycelium-agent-sdk`) is Apache-2.0, same as the rest of the repo.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,17 +4,15 @@
 # All data stays on your machine (SQLite).
 #
 # Usage:
-#   cp .env.example .env    # Configure your instance
+#   cp .env.example .env    # Configure your instance (set JWT_SECRET + ADMIN_KEY)
 #   docker compose up -d    # Start the platform
-#   open http://localhost:3002/studio/
+#   curl http://localhost:3002/health   # Verify it's up
 #
-# First-time setup:
+# First-time setup (headless — there is no bundled dashboard; the /studio
+# SPA was retired June 2026 and the GUI is the native app in a separate repo):
 #   1. Start the server: docker compose up -d mycelium
-#   2. Open http://localhost:3002/studio/ — create your admin account
-#   3. Register agents using the dashboard or mycelium-init CLI
-#
-# Optional: Add a drone worker for GPU tasks
-#   docker compose --profile gpu up -d
+#   2. Create your first operator + agents over the API with your ADMIN_KEY,
+#      or via the MCP server / the `mycelium-agent-sdk` CLI (`npx mycelium-agent-sdk init`).
 
 services:
   mycelium:

--- a/server/plugins/a2a-gateway/plugin.json
+++ b/server/plugins/a2a-gateway/plugin.json
@@ -4,7 +4,7 @@
   "displayName": "A2A Gateway",
   "description": "Google A2A protocol support — expose Mycelium agents to external platforms and discover/call external A2A agents.",
   "author": "SoftBacon Software",
-  "enabled": true,
+  "enabled": false,
   "routePrefix": "/a2a",
   "schema": "schema.sql",
   "gatedActions": [],

--- a/server/plugins/a2a-gateway/routes.js
+++ b/server/plugins/a2a-gateway/routes.js
@@ -81,6 +81,12 @@ export default function (core) {
 
   // ---- JSON-RPC 2.0 Handler ----
   router.post('/rpc', function (req, res) {
+    // tasks/send injects real tasks + directives consumed by shell-executing
+    // runners — require a valid agent/admin key (the apiKey scheme this
+    // gateway's own Agent Card advertises). checkAgentOrAdmin sends the 401.
+    var caller = checkAgentOrAdmin(req, res);
+    if (!caller) return;
+
     var body = req.body;
     if (!body || body.jsonrpc !== '2.0' || !body.method) {
       return res.json({

--- a/test/unit/a2a-rpc-auth.test.js
+++ b/test/unit/a2a-rpc-auth.test.js
@@ -1,0 +1,104 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+
+// The A2A gateway's JSON-RPC endpoint (POST /api/mycelium/a2a/rpc) was
+// UNAUTHENTICATED while enabled by default — tasks/send inserts real task
+// rows and creates a `directive` message to a live agent, and those tasks
+// are consumed by runners that execute shell commands. Anyone reachable
+// could inject work. The Agent Card even advertises apiKey auth while the
+// handler enforced none. This pins: /rpc requires a valid agent/admin key.
+//
+// Same harness shape as auth-roles.test.js — real router + real plugin
+// loader against a fresh temp DB, env set before dynamic import.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const JWT_SECRET = 'test-jwt-secret'
+const AGENT_KEY = 'dvk_' + 'b'.repeat(48)
+
+let tmpDataDir
+let app
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-a2a-auth-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+  process.env.JWT_SECRET = JWT_SECRET
+
+  const db = await import('../../server/db.js')
+  db.initDB()
+
+  // a2a-gateway ships disabled-by-default now; model an operator who turned
+  // it ON, then assert /rpc is STILL authenticated. Pre-seed the record as
+  // enabled so loadPlugins' existing-record path preserves the override.
+  db.ensurePluginRecord({
+    name: 'a2a-gateway', displayName: 'A2A Gateway', description: '',
+    version: '1.0.0', author: '', routePrefix: '/a2a', enabled: true,
+  })
+
+  const mycelium = await import('../../server/routes/mycelium.js')
+  await mycelium.initPlugins() // mounts the a2a-gateway plugin under /a2a
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', mycelium.default)
+
+  const hash = crypto.createHash('sha256').update(AGENT_KEY).digest('hex')
+  db.createAgent('lucy-test', 'Lucy Test', 'a2a-proj', hash, '["code"]')
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+const rpcSend = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'tasks/send',
+  params: { message: { parts: [{ type: 'text', text: 'do a thing' }] } },
+}
+
+describe('A2A /rpc authentication', () => {
+  test('unauthenticated tasks/send is rejected with 401 (no task injected)', async () => {
+    const res = await request(app).post('/api/mycelium/a2a/rpc').send(rpcSend)
+    expect(res.status).toBe(401)
+  })
+
+  test('invalid agent key is rejected (401 missing / 403 forbidden)', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/a2a/rpc')
+      .set('X-Agent-Key', 'dvk_' + 'z'.repeat(48))
+      .send(rpcSend)
+    expect([401, 403]).toContain(res.status)
+  })
+
+  test('valid agent key is accepted (request is processed, not auth-rejected)', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/a2a/rpc')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send(rpcSend)
+    expect(res.status).not.toBe(401)
+    // JSON-RPC envelope comes back (a result or a protocol error), not an auth wall
+    expect(res.body).toHaveProperty('jsonrpc', '2.0')
+  })
+
+  test('admin key is accepted', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/a2a/rpc')
+      .set('X-Admin-Key', ADMIN_KEY)
+      .send(rpcSend)
+    expect(res.status).not.toBe(401)
+  })
+
+  test('malformed JSON-RPC from an authed caller still gets the -32600 envelope', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/a2a/rpc')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ not: 'jsonrpc' })
+    expect(res.status).not.toBe(401)
+    expect(res.body.error).toMatchObject({ code: -32600 })
+  })
+})


### PR DESCRIPTION
Frontier review of `origin/master` ahead of wider eyes on the repo (VC diligence, ml-explore onlookers). This PR lands the two **bounded, clearly-correct** fixes; the rest of the review is summarized below for triage.

## What's in this PR

**Security — a2a-gateway**
- `POST /a2a/rpc` (`tasks/send|get|cancel`) was **unauthenticated** while the plugin shipped **enabled by default**. `tasks/send` inserts real task rows + a `directive` to a live agent, and those tasks are consumed by shell-executing runners — anyone reachable could inject work. Now gated by `checkAgentOrAdmin` (the `apiKey` scheme the gateway's own Agent Card already advertises).
- `plugin.json` `enabled: true → false`. Operators opt in; a fresh deploy no longer exposes it.
- New test (`test/unit/a2a-rpc-auth.test.js`) pins: an *enabled* gateway rejects unauthenticated/invalid-key `/rpc` (401/403) and processes a valid agent/admin key.

**Docs — the clean-clone path was broken in several independent spots**
- README verify command hit `/api/mycelium/health` (404 — route is root `/health`). Fixed.
- SDK/MCP/runner install used the unpublished `@mycelium/*` scope; real names are `mycelium-agent-sdk` / `mycelium-mcp` / `mycelium-runner`. Fixed in README + CONTRIBUTING.
- README claimed the SDK is MIT; repo relicensed Apache-2.0 (#128). Reconciled.
- docker-compose + CONTRIBUTING pointed first-run at the deleted `/studio` dashboard + removed `studio-react/` build; rewritten to the headless bootstrap.
- CLAUDE.md said "277 endpoints" / "No tests configured" — both false (291; vitest + CI). Corrected.

152 tests pass (147 + 5 new).

## Not in this PR — flagged for triage (from the same review)

**Verified, real, but deliberately deferred:**
- **billing plugin double-provision** — when `auto_provision` + creds are set, the inline IIFE and `provisionAndNotify` both call `provisionCustomerInstance` → 2 Railway deploys + 2 DNS + 2 welcome emails per subscription. (Owner's call: billing is throwaway test code from the auto-sell-instances experiment — not fixed here.)
- **billing enforcement fails open** (`mycelium.js:647` catch → `next()`).

**Worth a look (server-correctness agent, line-cited, not all independently reverified):**
- non-atomic task claim (`mycelium.js:1744`/`1283` — read-then-blind-update, no `WHERE status='open'`; `claimDroneJob` is the correct in-tree template)
- directive auth is a spoofable `-claude` substring check on `req.body.from` (`mycelium.js:2854`)
- `risk_tier` unvalidated on approvals → can skip the autonomous-mode operator gate

**Hygiene / optics (not code):**
- `docs/` (ROADMAP, OPERATING_MODEL, MULTI_AGENT_AUTONOMY, qa-test-playbook) ship internal squad notes leaking names / retired `.fyi` / `velum` — recommend moving to `docs/internal/` or stamping HISTORICAL.
- tracked `__pycache__/drone-worker.cpython-314.pyc`.
- the gpu drone compose profile is broken (node image has no python; worker ignores the env vars compose passes; defaults to `.fyi`) — needs a real fix, not just docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)