### PR TITLE
Scrub leaked admin key from test scripts (+ CRLF/python3 fixes)

### DIFF
--- a/tools/qa-test.sh
+++ b/tools/qa-test.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # Mycelium QA Test Suite
-AH="X-Admin-Key: KPeO7ZspKsAQotZsrvnZ2vYk"
-BASE="https://mycelium.fyi/api/mycelium"
+#
+# Usage: ADMIN_KEY=<your-admin-key> bash tools/qa-test.sh
+#   Optional: MYCELIUM_URL=https://your-instance  (default: http://localhost:3002)
+AH="X-Admin-Key: ${ADMIN_KEY:?set ADMIN_KEY to your instance admin key}"
+BASE="${MYCELIUM_URL:-http://localhost:3002}/api/mycelium"
 PASS=0
 FAIL=0
 
@@ -37,7 +40,7 @@ echo "$R" | grep -q "api_key_hash" && { echo "FAIL: T2.3b api_key_hash EXPOSED";
 echo ""
 echo "--- Phase 3: Tasks ---"
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/tasks" -d '{"title":"QA Test Task","description":"QA","project_id":"mycelium"}')
-TASK_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+TASK_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T3.1 Create task" "$R" '"id"'
 
 R=$(curl -s -H "$AH" "$BASE/tasks?limit=3")
@@ -53,7 +56,7 @@ check "T3.4 Complete task" "$R" '"ok":true'
 echo ""
 echo "--- Phase 4: Messages ---"
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/messages" -d '{"content":"QA test msg","to_agent":"greatness-claude","from_agent":"__admin__"}')
-MSG_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+MSG_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T4.1 Send message (content)" "$R" '"id"'
 
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/messages" -d '{"body":"wrong","to_agent":"greatness-claude","from_agent":"__admin__"}')
@@ -63,7 +66,7 @@ R=$(curl -s -H "$AH" "$BASE/messages?to=greatness-claude&limit=3")
 check "T4.3 Read messages" "$R" "QA test msg"
 
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/requests" -d '{"content":"QA request","to_agent":"greatness-claude"}')
-REQ_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+REQ_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T4.4 Send request" "$R" '"id"'
 
 R=$(curl -s -X PUT -H "$AH" -H "Content-Type: application/json" "$BASE/messages/$REQ_ID/resolve" -d '{"response":"QA resolved"}')
@@ -73,11 +76,11 @@ check "T4.5 Resolve request" "$R" '"ok":true'
 echo ""
 echo "--- Phase 5: Plans ---"
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/plans" -d '{"title":"QA Test Plan","description":"QA","project_id":"mycelium"}')
-PLAN_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+PLAN_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T5.1 Create plan" "$R" '"id"'
 
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/plans/$PLAN_ID/steps" -d '{"title":"QA Step 1","assignee":"greatness-claude"}')
-STEP_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+STEP_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T5.2 Add step" "$R" '"id"'
 
 R=$(curl -s -X PUT -H "$AH" -H "Content-Type: application/json" "$BASE/plans/$PLAN_ID/steps/$STEP_ID" -d '{"status":"completed"}')
@@ -90,7 +93,7 @@ check "T5.4 Get plan" "$R" '"steps"'
 echo ""
 echo "--- Phase 6: Bugs ---"
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/bugs" -d '{"title":"QA Bug","description":"QA","project_id":"mycelium","severity":"low"}')
-BUG_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+BUG_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T6.1 File bug" "$R" '"id"'
 
 R=$(curl -s -H "$AH" "$BASE/bugs?status=open")
@@ -118,7 +121,7 @@ check "T7.4 Delete context" "$R" '"ok":true'
 echo ""
 echo "--- Phase 8: Approvals ---"
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/approvals" -d '{"action_type":"deploy","title":"QA Deploy","risk_tier":"medium","required_approvals":1,"payload":"{}"}')
-APPR_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+APPR_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T8.1 Create approval" "$R" '"id"'
 
 R=$(curl -s -H "$AH" "$BASE/approvals?status=pending")
@@ -129,7 +132,7 @@ check "T8.3 Approve (quorum=1)" "$R" "approved"
 
 # Deny test
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/approvals" -d '{"action_type":"deploy","title":"QA Deny","required_approvals":3,"payload":"{}"}')
-APPR2_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+APPR2_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 R=$(curl -s -X PUT -H "$AH" -H "Content-Type: application/json" "$BASE/approvals/$APPR2_ID/vote" -d '{"vote":"deny","voter_id":"greatness","voter_type":"operator"}')
 check "T8.4 Deny (instant)" "$R" "denied"
 
@@ -137,7 +140,7 @@ check "T8.4 Deny (instant)" "$R" "denied"
 echo ""
 echo "--- Phase 9: Concepts ---"
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/concepts" -d '{"name":"QA Character","type":"character","description":"Test"}')
-CONCEPT_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+CONCEPT_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T9.1 Create concept" "$R" '"id"'
 
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/concepts/$CONCEPT_ID/link" -d '{"project_id":"mycelium"}')
@@ -213,7 +216,7 @@ R=$(curl -s -H "$AH" "$BASE/drones")
 check "T15.1 List drones" "$R" "["
 
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/drones/jobs" -d '{"title":"QA Job","command":"echo test","requires":["cpu"]}')
-JOB_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+JOB_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T15.2 Queue job" "$R" '"id"'
 
 R=$(curl -s -H "$AH" "$BASE/drones/jobs?status=pending")
@@ -293,7 +296,7 @@ R=$(curl -s -H "$AH" "$BASE/teams")
 check "T29.1 List teams" "$R" '"teams"'
 
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/teams" -d '{"id":"qa-team","name":"QA Team","org_id":"softbacon","description":"QA test team"}')
-QA_TEAM_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+QA_TEAM_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T29.2 Create team" "$R" '"id":"qa-team"'
 
 R=$(curl -s -H "$AH" "$BASE/teams/qa-team")
@@ -394,7 +397,7 @@ check "T31.5 History exists" "$R" "version-1"
 check "T31.6 History has v2" "$R" "version-2"
 
 # Get history ID for rollback — history is DESC, so last entry = oldest (v1)
-HIST_ID=$(echo "$R" | python -c "import sys,json; d=json.load(sys.stdin); entries=d if isinstance(d,list) else d.get('history',[]); print(entries[-1]['id'] if len(entries)>0 else '')" 2>/dev/null)
+HIST_ID=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); entries=d if isinstance(d,list) else d.get('history',[]); print(entries[-1]['id'] if len(entries)>0 else '')" 2>/dev/null)
 
 if [ -n "$HIST_ID" ] && [ "$HIST_ID" != "" ]; then
   R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/context/keys/rollback/$HIST_ID")
@@ -429,7 +432,7 @@ check "T32.3 Per-agent spend" "$R" "["
 echo ""
 echo "--- Phase 33: Widgets ---"
 R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/widgets" -d '{"title":"QA Widget","widget_type":"status","data":{"status":"healthy","message":"QA test"},"agent_id":"dev-claude","project_id":"mycelium"}')
-WIDGET_ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+WIDGET_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 check "T33.1 Create widget" "$R" '"id"'
 
 R=$(curl -s -H "$AH" "$BASE/widgets")
@@ -556,7 +559,7 @@ echo "PASS: T41.1b Cleaned QA skill"
 PASS=$((PASS+1))
 
 # Delete leftover QA widgets
-for WID in $(curl -s -H "$AH" "$BASE/widgets" | python -c "import sys,json; [print(w['id']) for w in json.load(sys.stdin) if 'QA' in w.get('title','')]" 2>/dev/null); do
+for WID in $(curl -s -H "$AH" "$BASE/widgets" | python3 -c "import sys,json; [print(w['id']) for w in json.load(sys.stdin) if 'QA' in w.get('title','')]" 2>/dev/null); do
   curl -s -X DELETE -H "$AH" "$BASE/widgets/$WID" > /dev/null 2>&1
 done
 echo "PASS: T41.1c Cleaned QA widgets"
@@ -583,7 +586,7 @@ else
 fi
 
 # Close QA support ticket bugs
-for BID in $(curl -s -H "$AH" "$BASE/bugs?status=open" | python -c "import sys,json; [print(b['id']) for b in json.load(sys.stdin).get('bugs',[]) if 'QA Ticket' in b.get('title','')]" 2>/dev/null); do
+for BID in $(curl -s -H "$AH" "$BASE/bugs?status=open" | python3 -c "import sys,json; [print(b['id']) for b in json.load(sys.stdin).get('bugs',[]) if 'QA Ticket' in b.get('title','')]" 2>/dev/null); do
   curl -s -X PUT -H "$AH" -H "Content-Type: application/json" "$BASE/bugs/$BID" -d '{"status":"fixed","notes":"QA test artifact cleanup"}' > /dev/null 2>&1
 done
 echo "PASS: T41.4 Cleaned QA support tickets"

--- a/tools/stress-test.sh
+++ b/tools/stress-test.sh
@@ -6,8 +6,8 @@
 # Hammers the platform's messaging, context storage, task lifecycle,
 # and channel systems to verify data persistence under load.
 #
-# Usage: bash tools/stress-test.sh [--local]
-#   --local  run against localhost:3002 instead of production
+# Usage: ADMIN_KEY=<your-admin-key> bash tools/stress-test.sh
+#   Optional: MYCELIUM_URL=https://your-instance  (default: http://localhost:3002)
 #
 # What it tests:
 #   1. Message flood — 50 rapid messages, verify all persisted
@@ -24,15 +24,10 @@
 
 set -euo pipefail
 
-AH="X-Admin-Key: KPeO7ZspKsAQotZsrvnZ2vYk"
+AH="X-Admin-Key: ${ADMIN_KEY:?set ADMIN_KEY to your instance admin key}"
 
-if [[ "${1:-}" == "--local" ]]; then
-  BASE="http://localhost:3002/api/mycelium"
-  echo "[stress] Running against LOCAL (localhost:3002)"
-else
-  BASE="https://mycelium.fyi/api/mycelium"
-  echo "[stress] Running against PRODUCTION (mycelium.fyi)"
-fi
+BASE="${MYCELIUM_URL:-http://localhost:3002}/api/mycelium"
+echo "[stress] Running against $BASE"
 
 PASS=0
 FAIL=0
@@ -57,7 +52,7 @@ MSG_IDS=()
 for i in $(seq 1 50); do
   R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/messages" \
     -d "{\"content\":\"STRESS-MSG-$i-$(date +%s%N)\",\"to_agent\":\"dev-claude\",\"from_agent\":\"greatness-claude\"}")
-  ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+  ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
   if [ -n "$ID" ] && [ "$ID" != "" ]; then
     MSG_IDS+=("$ID")
   fi
@@ -67,7 +62,7 @@ echo "  Sent 50 messages in $((T1_END-T1_START))s"
 
 # Verify all persisted — use high limit, filter STRESS-MSG pattern
 R=$(curl -s -H "$AH" "$BASE/messages?limit=200")
-FOUND=$(echo "$R" | python -c "import sys,json; msgs=json.load(sys.stdin); print(sum(1 for m in msgs if 'STRESS-MSG-' in m.get('content','')))" 2>/dev/null)
+FOUND=$(echo "$R" | python3 -c "import sys,json; msgs=json.load(sys.stdin); print(sum(1 for m in msgs if 'STRESS-MSG-' in m.get('content','')))" 2>/dev/null)
 if [ "${FOUND:-0}" -ge 50 ]; then
   pass "All 50 messages persisted (found $FOUND)"
 else
@@ -82,7 +77,7 @@ REQ_IDS=()
 for i in $(seq 1 20); do
   R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/requests" \
     -d "{\"content\":\"STRESS-REQ-$i\",\"to_agent\":\"dev-claude\"}")
-  ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+  ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
   if [ -n "$ID" ] && [ "$ID" != "" ]; then
     REQ_IDS+=("$ID")
   fi
@@ -108,7 +103,7 @@ fi
 
 # Verify resolved status persisted
 R=$(curl -s -H "$AH" "$BASE/messages?to=dev-claude&limit=30&type=request")
-RESOLVED_COUNT=$(echo "$R" | python -c "
+RESOLVED_COUNT=$(echo "$R" | python3 -c "
 import sys,json
 msgs=json.load(sys.stdin)
 print(sum(1 for m in msgs if 'STRESS-REQ-' in m.get('content','') and m.get('status')=='resolved'))
@@ -142,7 +137,7 @@ echo "  Wrote $WRITE_OK/100 keys in $((T3_MID-T3_START))s ($WRITE_FAIL failed)"
 
 # Read all back via namespace list — this is the real persistence check
 R=$(curl -s -H "$AH" "$BASE/context/keys/$NS")
-KEY_COUNT=$(echo "$R" | python -c "
+KEY_COUNT=$(echo "$R" | python3 -c "
 import sys,json
 data=json.load(sys.stdin)
 if isinstance(data, list):
@@ -196,7 +191,7 @@ done
 wait
 
 R=$(curl -s -H "$AH" "$BASE/context/keys/$RACE_NS/contested")
-FINAL=$(echo "$R" | python -c "import sys,json; d=json.load(sys.stdin); print(d.get('data',''))" 2>/dev/null)
+FINAL=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('data',''))" 2>/dev/null)
 if echo "$FINAL" | grep -q "version-"; then
   pass "Overwrite race: final value is $FINAL (some version won)"
 else
@@ -212,7 +207,7 @@ TASK_IDS=()
 for i in $(seq 1 30); do
   R=$(curl -s -X POST -H "$AH" -H "Content-Type: application/json" "$BASE/tasks" \
     -d "{\"title\":\"STRESS-TASK-$i\",\"description\":\"Stress test task\",\"project_id\":\"mycelium\"}")
-  ID=$(echo "$R" | python -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+  ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
   if [ -n "$ID" ] && [ "$ID" != "" ]; then
     TASK_IDS+=("$ID")
   fi
@@ -240,7 +235,7 @@ fi
 
 # Verify persistence
 R=$(curl -s -H "$AH" "$BASE/tasks?status=done&limit=40")
-FOUND=$(echo "$R" | python -c "
+FOUND=$(echo "$R" | python3 -c "
 import sys,json
 data=json.load(sys.stdin)
 tasks = data if isinstance(data, list) else data.get('done', data.get('tasks', []))
@@ -272,7 +267,7 @@ echo "  Sent $CHAN_OK channel messages in $((T6_MID-T6_START))s"
 
 # Read back
 R=$(curl -s -H "$AH" "$BASE/channels/1/messages?limit=60")
-CHAN_FOUND=$(echo "$R" | python -c "
+CHAN_FOUND=$(echo "$R" | python3 -c "
 import sys,json
 msgs=json.load(sys.stdin)
 print(sum(1 for m in msgs if 'STRESS-CHAN-' in m.get('content','')))
@@ -311,7 +306,7 @@ fi
 RECV_OK=0
 for TO in "${AGENTS[@]}"; do
   R=$(curl -s -H "$AH" "$BASE/messages?to=$TO&limit=20")
-  RECV=$(echo "$R" | python -c "
+  RECV=$(echo "$R" | python3 -c "
 import sys,json
 msgs=json.load(sys.stdin)
 print(sum(1 for m in msgs if m.get('content','').startswith('CROSS-') and m.get('to_agent')=='$TO'))
@@ -353,7 +348,7 @@ fi
 echo ""
 echo "--- Test 9: Large Payload (10KB context value) ---"
 # Generate 10KB of data
-LARGE=$(python -c "print('X' * 10240)")
+LARGE=$(python3 -c "print('X' * 10240)")
 R=$(curl -s -X PUT -H "$AH" -H "Content-Type: application/json" \
   "$BASE/context/keys/stress-large/big-value" -d "{\"data\":\"$LARGE\"}")
 if echo "$R" | grep -q '"ok":true'; then
@@ -363,7 +358,7 @@ else
 fi
 
 R=$(curl -s -H "$AH" "$BASE/context/keys/stress-large/big-value")
-SIZE=$(echo "$R" | python -c "import sys,json; d=json.load(sys.stdin); print(len(str(d.get('data',''))))" 2>/dev/null)
+SIZE=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(str(d.get('data',''))))" 2>/dev/null)
 if [ "${SIZE:-0}" -ge 10000 ]; then
   pass "10KB value read back intact (${SIZE} chars)"
 else
@@ -390,7 +385,7 @@ NS_OK=0
 NS_TOTAL=0
 for ns in stress-ns-1 stress-ns-2 stress-ns-3 stress-ns-4 stress-ns-5; do
   R=$(curl -s -H "$AH" "$BASE/context/keys/$ns")
-  COUNT=$(echo "$R" | python -c "import sys,json; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else len(d.keys()) if isinstance(d,dict) else 0)" 2>/dev/null)
+  COUNT=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else len(d.keys()) if isinstance(d,dict) else 0)" 2>/dev/null)
   NS_TOTAL=$((NS_TOTAL+1))
   if [ "${COUNT:-0}" -ge 20 ]; then
     NS_OK=$((NS_OK+1))


### PR DESCRIPTION
`tools/qa-test.sh` and `tools/stress-test.sh` hardcoded a real admin key in an `X-Admin-Key` header pointed at the (now-retired) `mycelium.fyi` production instance. **The key has already been rotated** — but a committed credential reads as "this project commits secrets" to anyone (or any Claude) scanning the repo, so it gets scrubbed regardless of being live.

- Admin key → `${ADMIN_KEY:?...}` — required env var, fails clearly if unset
- Base URL → `${MYCELIUM_URL:-http://localhost:3002}` — self-host default; drops the hardcoded dead `.fyi` production host
- **`stress-test.sh` had CRLF line endings** → bash couldn't parse it at all (`syntax error near unexpected token 'do'`); normalized to LF
- `python` → `python3` (bare `python` is gone on modern macOS/Linux)

Both scripts now pass `bash -n`.

> **On git history:** the key is also in history. It's rotated/dead, so this PR scrubs the **working tree** (what a `grep`/secret-scan of the checkout sees) without a history rewrite — a rewrite would invalidate the open PRs (#129/#130/#131) and any forks/clones. A reviewer who digs into history finds a *dead* key plus this remediation commit, which reads as "found and fixed," not "exposed." If you want zero trace, a coordinated `git filter-repo` is a separate deliberate op once the in-flight PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)