### PR TITLE
feat(agents): brain/telemetry in GET /agents roster (lights the cockpit live meters)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -279,7 +279,7 @@ export function resolveAssignee(assignee) {
 }
 
 export function listAgents() {
-  return stmt('dvListAgents3', "SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, avatar_url, role, operator_id, project, created_at FROM agents WHERE project_id != 'drone' ORDER BY created_at").all();
+  return stmt('dvListAgents4', "SELECT id, name, project_id, status, working_on, last_heartbeat, capabilities, avatar_url, role, operator_id, project, llm_backend, llm_model, runtime, system_diagnostics, agent_type, primary_team_id, created_at FROM agents WHERE project_id != 'drone' ORDER BY created_at").all();
 }
 
 export function listAllAgentsIncludingDrones() {

--- a/test/unit/agents-list-telemetry.test.js
+++ b/test/unit/agents-list-telemetry.test.js
@@ -1,0 +1,53 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// listAgents() returned a TRIMMED roster (no brain/telemetry columns), forcing
+// the cockpit into a GET /agents/:id per agent it never does — so the live
+// meters (tps, brain-residency, watts) read empty even though the app parses
+// and renders them. This pins that the roster now carries brain/telemetry
+// inline, still without api_key_hash. Same harness as db-agent-heartbeat:
+// set DATA_DIR before the dynamic import; initDB writes only to the temp dir.
+
+let tmpDataDir
+let db
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-agents-telemetry-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = 'test-admin-key'
+  process.env.JWT_SECRET = 'test-jwt-secret'
+  db = await import('../../server/db.js')
+  db.initDB()
+  db.createAgent('lucy-test', 'Lucy Test', 'proj', 'secret-hash', '["code"]')
+  db.updateAgent('lucy-test', {
+    llm_backend: 'omlx',
+    llm_model: 'Qwen3-Coder-Next-8bit',
+    runtime: 'oMLX',
+    agent_type: 'agent',
+    system_diagnostics: { ram_gb: 82, tps: 42, watts_per_tok: 2.1 },
+  })
+})
+
+afterAll(() => { if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true }) })
+
+describe('GET /agents roster carries brain/telemetry inline', () => {
+  test('listAgents() row includes llm_*/runtime/system_diagnostics/agent_type', () => {
+    const row = db.listAgents().find((a) => a.id === 'lucy-test')
+    expect(row).toBeDefined()
+    expect(row.llm_model).toBe('Qwen3-Coder-Next-8bit')
+    expect(row.llm_backend).toBe('omlx')
+    expect(row.runtime).toBe('oMLX')
+    expect(row.agent_type).toBe('agent')
+    // system_diagnostics is stored + returned as a JSON string (the app decodes
+    // it, exactly as it already does for capabilities). Don't double-encode.
+    expect(typeof row.system_diagnostics).toBe('string')
+    expect(JSON.parse(row.system_diagnostics).tps).toBe(42)
+  })
+
+  test('roster still excludes api_key_hash', () => {
+    const row = db.listAgents().find((a) => a.id === 'lucy-test')
+    expect(row.api_key_hash).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What

`listAgents()` (the `GET /agents` roster) returned a **trimmed** row — no `llm_backend`, `llm_model`, `runtime`, `system_diagnostics`, `agent_type`, or `primary_team_id`. Any client wanting brain badges or live meters had to fan out a `GET /agents/:id` per agent — which the cockpit never does. So brain-swap badges and the live tps/watts/RAM meters rendered empty even though the app already parses and renders them.

This extends the SELECT to carry the brain + telemetry columns inline, still **excluding `api_key_hash`**.

## Why this is the keystone

The macOS app (`mycelium-app`) already decodes `system_diagnostics` (as a JSON string, exactly like `capabilities`) and renders brain-swap + meter UI off the roster call. One SELECT extension lights that whole surface live with zero per-agent fan-out.

## Bonus

The drone filter at `routes/mycelium.js:2051` keys on `a.agent_type` — a column the roster wasn't selecting, so the filter was silently dead. It now has the column it reads.

## Test

`test/unit/agents-list-telemetry.test.js` (TDD — written failing first):
- roster row carries `llm_*` / `runtime` / `agent_type`
- `system_diagnostics` returned as a JSON string (app decodes it like `capabilities` — no double-encoding)
- roster still omits `api_key_hash`

Full suite: **154 passing** (was 152, +2 from this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)