### PR TITLE
Slice 2a: tasks.review_metadata — landing/review data for the app review surface

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -486,7 +486,7 @@ export function updateTask(id, fields) {
   if (f.needs_approval !== undefined) f.needs_approval = f.needs_approval ? 1 : 0;
   if (f.blocked_by !== undefined) f.blocked_by = JSON.stringify(f.blocked_by);
   if (f.blocks !== undefined) f.blocks = JSON.stringify(f.blocks);
-  buildUpdate('tasks', id, f, ['title', 'description', 'status', 'assignee', 'priority', 'tags', 'needs_approval', 'blocked_by', 'blocks', 'branch', 'pr_url', 'repo'], { updatedAt: true });
+  buildUpdate('tasks', id, f, ['title', 'description', 'status', 'assignee', 'priority', 'tags', 'needs_approval', 'blocked_by', 'blocks', 'branch', 'pr_url', 'repo', 'review_metadata'], { updatedAt: true });
 }
 
 // -- Task dependencies --

--- a/server/index.js
+++ b/server/index.js
@@ -86,6 +86,18 @@ try {
   process.stdout.write('[boot] context_keys migration note: ' + e.message + '\n');
 }
 
+// Migrate: add review_metadata column to tasks if missing (Slice-2a landing data)
+try {
+  var _tdb = getDB();
+  var _tcols = _tdb.pragma('table_info(tasks)').map(function(c) { return c.name; });
+  if (!_tcols.includes('review_metadata')) {
+    _tdb.prepare("ALTER TABLE tasks ADD COLUMN review_metadata TEXT NOT NULL DEFAULT '{}'").run();
+    process.stdout.write('[boot] migrated tasks: added review_metadata column\n');
+  }
+} catch (e) {
+  process.stdout.write('[boot] tasks review_metadata migration note: ' + e.message + '\n');
+}
+
 // Purge expired context keys on boot
 var purged = purgeExpiredContextKeys();
 if (purged > 0) process.stdout.write('[boot] purged ' + purged + ' expired context keys\n');

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -1570,6 +1570,7 @@ router.put('/tasks/:id', asyncHandler(function (req, res) {
   if (req.body.branch !== undefined) fields.branch = req.body.branch;
   if (req.body.pr_url !== undefined) fields.pr_url = req.body.pr_url;
   if (req.body.repo !== undefined) fields.repo = req.body.repo;
+  if (req.body.review_metadata !== undefined) fields.review_metadata = typeof req.body.review_metadata === 'string' ? req.body.review_metadata : JSON.stringify(req.body.review_metadata);
   updateTask(task.id, fields);
 
   var result = { ok: true, id: task.id };

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -71,7 +71,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   request_id      INTEGER,
   branch          TEXT,
   pr_url          TEXT,
-  repo            TEXT
+  repo            TEXT,
+  review_metadata TEXT NOT NULL DEFAULT '{}'
 );
 
 -- Per-project context snapshots (legacy)


### PR DESCRIPTION
Slice 2a of the squad worktree-landing + local-review design (spec lives in jarvis: `squad/docs/specs/2026-06-16-squad-worktree-landing-and-local-review-design.md`).

Adds `tasks.review_metadata` (JSON TEXT) carrying per-task landing/review data — `{branch, head_sha, files, diff, review_state}` — for the app's Engine Room review surface (Slice 2b).

- **schema.sql**: new `review_metadata` column on `tasks` (fresh DBs).
- **index.js**: idempotent boot migration `ALTER`s the live DB (mirrors the `context_keys` pattern).
- **routes/mycelium.js**: `PUT /tasks/:id` accepts `review_metadata` (stringifies objects).
- **db.js**: `review_metadata` added to the `updateTask` whitelist; `getTask` (`SELECT *`) returns it.

No new routes. The jarvis bridge publishes the payload on landing (commit `4448cf2`). Full vitest suite green (154/154).

🤖 Generated with [Claude Code](https://claude.com/claude-code)