### PR TITLE
fix(x): direct-publish no longer orphans approval records (#1)

### DIFF
--- a/server/plugins/marketing/x/handlers.js
+++ b/server/plugins/marketing/x/handlers.js
@@ -63,7 +63,15 @@ export function registerHooks(core) {
 
       var post = db.getPost(postId);
       if (!post || !post.tweet_text) return;
-      if (post.status === 'published') return;
+      if (post.status === 'published') {
+        // Post already published (e.g. via direct-publish before this fired) — the
+        // approval is fulfilled, so mark it executed instead of stranding it at
+        // 'approved' (bug #1).
+        core.db.prepare(
+          "UPDATE approvals SET status = 'executed', executed_at = datetime('now'), updated_at = datetime('now') WHERE id = ? AND status != 'executed'"
+        ).run(approvalId);
+        return;
+      }
 
       var creds = getCredentials(core.db);
       if (!creds.api_key || !creds.api_secret || !creds.access_token || !creds.access_token_secret) {

--- a/server/plugins/marketing/x/routes.js
+++ b/server/plugins/marketing/x/routes.js
@@ -133,9 +133,11 @@ export default function (core) {
           posted_at: new Date().toISOString()
         });
         
-        // Find the approval for this post_id (most recent pending one)
+        // Find the approval for this post_id — pending OR already-approved-but-not-
+        // executed. Bug #1: a 'pending'-only match stranded an approval that was
+        // approved first and then direct-published, leaving it orphaned at 'approved'.
         var approval = core.db.prepare(
-          "SELECT id FROM approvals WHERE action_type = 'x_publish' AND status = 'pending' AND json_extract(payload, '$.post_id') = ? ORDER BY id DESC LIMIT 1"
+          "SELECT id FROM approvals WHERE action_type = 'x_publish' AND status IN ('pending','approved') AND json_extract(payload, '$.post_id') = ? ORDER BY id DESC LIMIT 1"
         ).get(post.id);
         if (approval) {
           core.db.prepare(
@@ -227,6 +229,16 @@ export default function (core) {
                 tweet_url: tweetUrl,
                 posted_at: new Date().toISOString()
               });
+              // Bug #1: flip any pending/approved approval for this tweet so a thread
+              // direct-publish doesn't orphan it (the single-post path does this too).
+              var threadAppr = core.db.prepare(
+                "SELECT id FROM approvals WHERE action_type = 'x_publish' AND status IN ('pending','approved') AND json_extract(payload, '$.post_id') = ? ORDER BY id DESC LIMIT 1"
+              ).get(tweet.id);
+              if (threadAppr) {
+                core.db.prepare(
+                  "UPDATE approvals SET status = 'executed', decided_by = ?, decided_at = datetime('now'), executed_at = datetime('now'), reason = 'Admin direct-publish (thread)', updated_at = datetime('now') WHERE id = ?"
+                ).run(who, threadAppr.id);
+              }
               results.push({ id: tweet.id, tweet_id: tweetId, tweet_url: tweetUrl });
               return tweetId;
             } else {


### PR DESCRIPTION
Closes mycelium bug #1 — x_publish leaving approval records orphaned.

An approval could stay stranded at `approved` (its post already published) instead of advancing to `executed`. Three sources, all closed:

- single-post direct-publish flip matched only `status='pending'` → now `pending` OR `approved`
- the thread publish path flipped nothing → now flips each tweet's pending/approved approval
- the `approval_approved` handler early-returned when the post was already published → now marks it executed

`npm test`: 154/154. The 3 pre-existing orphan records were backfilled separately (data fix, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)