### PR TITLE
fix: undefined resolveAgentId in PR-merge route (crash)

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -6144,7 +6144,7 @@ router.get('/github/prs/:owner/:repo', asyncHandler(function (req, res) {
 router.post('/github/prs/:owner/:repo/:number/merge', asyncHandler(function (req, res) {
   if (!checkAdmin(req, res)) return;
   // Enforcement rules check
-  var who = resolveAgentId(req);
+  var who = getAdminDisplayName(req);
   var enforcement = checkEnforcementRules('merge_pr', { owner: req.params.owner, repo: req.params.repo, number: req.params.number }, who);
   if (!enforcement.allowed) {
     return res.status(403).json({ error: enforcement.blocks[0].message, enforcement_rule: enforcement.blocks[0].rule_id });


### PR DESCRIPTION
## Bug
The admin-only `POST /github/prs/:owner/:repo/:number/merge` route called `resolveAgentId(req)`, which is **defined nowhere in the codebase** — every merge attempt threw `ReferenceError: resolveAgentId is not defined`.

## Fix
Every other admin route resolves the acting identity via `getAdminDisplayName(req)` (defined at `server/routes/mycelium.js:565`). One line aligns the merge route with that pattern so `checkEnforcementRules('merge_pr', …, who)` gets a valid actor.

## Verification
`npm test` → **165 passed**.

Surfaced by a GLM-5.2 architecture review of the platform; verified against the source before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)