### PR TITLE
harden: isAdminKey fail-closed + boot env check (GLM-directed)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -54,12 +54,8 @@ var pkgJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.jso
 var APP_VERSION = pkgJson.version || '0.0.0';
 
 // ---- Startup validation ----
-if (!process.env.JWT_SECRET) {
-  console.error('FATAL: JWT_SECRET environment variable is required.');
-  process.exit(1);
-}
-if (!process.env.ADMIN_KEY) {
-  console.error('FATAL: ADMIN_KEY environment variable is required.');
+if (!process.env.ADMIN_KEY || !process.env.JWT_SECRET) {
+  console.error('FATAL: ADMIN_KEY and JWT_SECRET must be set');
   process.exit(1);
 }
 if (!process.env.TURN_SECRET) {

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -185,7 +185,8 @@ import { broadcast, addClient, clientCount } from '../eventBus.js';
 
 var ADMIN_KEY = process.env.ADMIN_KEY;
 function isAdminKey(key) {
-  return key && key.length === ADMIN_KEY.length && crypto.timingSafeEqual(Buffer.from(key), Buffer.from(ADMIN_KEY));
+  if (!ADMIN_KEY || !key) return false;
+  return key.length === ADMIN_KEY.length && crypto.timingSafeEqual(Buffer.from(key), Buffer.from(ADMIN_KEY));
 }
 var JWT_SECRET = process.env.JWT_SECRET;
 var STUDIO_JWT_EXPIRY = '7d';
@@ -6102,6 +6103,8 @@ export async function initPlugins() {
   };
   await loadPlugins(pluginCore, router);
 }
+
+export { isAdminKey };
 
 // ── GitHub Proxy Routes ────────────────────────────────────────
 // Proxies GitHub API via server-side GITHUB_TOKEN so agents don't need their own tokens.

--- a/test/unit/is-admin-key.test.js
+++ b/test/unit/is-admin-key.test.js
@@ -1,0 +1,13 @@
+import { describe, test, expect } from 'vitest'
+
+describe('isAdminKey null-guard', () => {
+  test('returns false without throwing when ADMIN_KEY env is missing', async () => {
+    const saved = process.env.ADMIN_KEY
+    delete process.env.ADMIN_KEY
+    // Re-import to pick up the cleared env (pool: forks isolates module state)
+    const { isAdminKey } = await import('../../server/routes/mycelium.js')
+    expect(() => isAdminKey('x')).not.toThrow()
+    expect(isAdminKey('x')).toBe(false)
+    process.env.ADMIN_KEY = saved
+  })
+})


### PR DESCRIPTION
## Change
- `isAdminKey` returns `false` (no TypeError) when `ADMIN_KEY` is unset.
- Boot guard in `index.js` consolidated to require both `ADMIN_KEY` and `JWT_SECRET`.
- `isAdminKey` exported + a unit test added (`test/unit/is-admin-key.test.js`).

## Provenance
GLM-5.2 architecture review **directed** this fix; the local squad **implemented** it (wf#101); m5Max byte-review **caught and reverted a collateral `initPlugins` regression** (inbox dropped from `pluginCore` + a duplicate init loop) that `npm test` and the verifier both missed.

## Verification
`npm test` → **166 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)