### PR TITLE
security: harden SSRF guard (resolve hostnames, v4-mapped v6, fail closed)

### DIFF
--- a/server/lib/ssrf-guard.js
+++ b/server/lib/ssrf-guard.js
@@ -1,114 +1,115 @@
 // SSRF Guard - Prevent Server-Side Request Forgery
 //
-// This module provides a function to validate URLs and ensure they don't
-// point to internal/private IP ranges that could be used for SSRF attacks.
-//
-// The function parses a URL, validates the scheme (http/https only), resolves the hostname
-// to IP addresses, and checks that none of those IPs are in private ranges.
-//
+// Validates a URL: http/https only, resolves the hostname via DNS, and refuses
+// any resolved IP in a private / loopback / link-local / metadata range.
+// Fails CLOSED: an unresolvable or unparseable host is rejected, not dispatched.
 // See: https://en.wikipedia.org/wiki/Reserved_IP_addresses
 
-/**
- * Check if an IP address is in a private/closed network range.
- * @param {string} ip - IP address string
- * @returns {boolean} True if the IP is in a private range
- */
-function isPrivateIP(ip) {
-  // Handle IPv4 addresses
-  if (ip.includes('.')) {
-    // Directly check against known private ranges
-    if (ip.startsWith('127.')) return true; // 127.0.0.0/8
-    if (ip.startsWith('10.')) return true; // 10.0.0.0/8
-    if (ip.startsWith('172.') && parseInt(ip.split('.')[1]) >= 16 && parseInt(ip.split('.')[1]) <= 31) return true; // 172.16.0.0/12
-    if (ip.startsWith('192.168.')) return true; // 192.168.0.0/16
-    if (ip.startsWith('169.254.')) return true; // 169.254.0.0/16
-    if (ip.startsWith('100.64.')) return true; // 100.64.0.0/10
-    if (ip.startsWith('0.')) return true; // 0.0.0.0/8
-  }
-  
-  // Handle IPv6 addresses
-  if (ip.includes(':')) {
-    const low = ip.toLowerCase();
-    if (low === '::1' || low === '::') return true; // loopback / unspecified
-    if (low.startsWith('fc') || low.startsWith('fd')) return true; // fc00::/7 unique-local (ULA)
-    if (low.startsWith('fe80')) return true; // fe80::/10 link-local
-  }
-  
-  return false;
-}
+import net from 'net';
 
-/**
- * Assert that a URL points to a public host, not an internal/private IP.
- * 
- * @param {string} url - The URL to validate
- * @param {Object} options - Options for validation
- * @param {boolean} options.allowLoopback - Whether to allow localhost (127.0.0.1) addresses
- * @returns {Promise<{hostname: string, ip: string}>} Resolves with hostname and IP if valid
- * @throws {SSRFBlockedError} If the URL points to a private/internal IP
- */
-export async function assertPublicHost(url, { allowLoopback = false } = {}) {
-  try {
-    const urlObj = new URL(url);
-    
-    // Only allow http and https schemes
-    if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
-      throw new SSRFBlockedError(`Invalid URL scheme: ${urlObj.protocol}. Only http and https are allowed.`);
-    }
-    
-    const hostname = urlObj.hostname;
-    
-    // If it's a direct IP address, check if it's private
-    if (hostname.includes('.')) {
-      // IPv4 address or localhost
-      if (isPrivateIP(hostname) && !(allowLoopback && hostname === '127.0.0.1')) {
-        throw new SSRFBlockedError(`URL points to private IP address: ${hostname}`);
-      }
-      return { hostname, ip: hostname };
-    } else if (hostname.includes(':')) {
-      // IPv6 address — URL.hostname keeps the brackets ([::1]); strip before checking
-      const ip6 = hostname.replace(/^\[|\]$/g, '');
-      if (isPrivateIP(ip6)) {
-        throw new SSRFBlockedError(`URL points to private IPv6 address: ${ip6}`);
-      }
-      return { hostname, ip: ip6 };
-    } else {
-      // It's a hostname - resolve to IP addresses
-      try {
-        const dns = await import('dns').then(m => m.promises);
-        const result = await dns.lookup(hostname, { all: true });
-        
-        for (const record of result) {
-          const ip = record.address;
-          
-          // Check if it's a private IP
-          if (isPrivateIP(ip) && !(allowLoopback && ip === '127.0.0.1')) {
-            throw new SSRFBlockedError(`URL resolves to private IP address: ${ip}`);
-          }
-        }
-        
-        // Return the first IP (we only need one for the caller)
-        return { hostname, ip: result[0].address };
-      } catch (dnsError) {
-        // If DNS lookup fails, we still allow the request but warn
-        console.warn(`[ssrf] DNS resolution failed for ${hostname}: ${dnsError.message}`);
-        return { hostname, ip: 'unknown' };
-      }
-    }
-  } catch (error) {
-    if (error instanceof SSRFBlockedError) {
-      throw error;
-    }
-    // Re-throw with more context if needed
-    throw new SSRFBlockedError(`Failed to validate URL: ${url} - ${error.message}`);
-  }
-}
-
-/**
- * Custom error class for SSRF violations
- */
+/** Custom error for SSRF violations. */
 export class SSRFBlockedError extends Error {
   constructor(message) {
     super(message);
     this.name = 'SSRFBlockedError';
   }
+}
+
+/**
+ * Is this IP literal in a private / closed range?
+ * @param {string} ip - a literal IPv4 or IPv6 address (no brackets)
+ * @returns {boolean}
+ */
+function isPrivateIP(ip) {
+  // IPv4
+  if (net.isIP(ip) === 4) {
+    const o = ip.split('.').map(Number);
+    if (o[0] === 127) return true;                        // 127.0.0.0/8 loopback
+    if (o[0] === 10) return true;                         // 10.0.0.0/8
+    if (o[0] === 172 && o[1] >= 16 && o[1] <= 31) return true; // 172.16.0.0/12
+    if (o[0] === 192 && o[1] === 168) return true;        // 192.168.0.0/16
+    if (o[0] === 169 && o[1] === 254) return true;        // 169.254.0.0/16 link-local + cloud metadata
+    if (o[0] === 100 && o[1] >= 64 && o[1] <= 127) return true; // 100.64.0.0/10 CGNAT
+    if (o[0] === 0) return true;                          // 0.0.0.0/8
+    return false;
+  }
+  // IPv6
+  if (ip.includes(':')) {
+    const low = ip.toLowerCase();
+    if (low === '::1' || low === '::') return true;        // loopback / unspecified
+    if (low.startsWith('fc') || low.startsWith('fd')) return true; // fc00::/7 unique-local (ULA)
+    if (low.startsWith('fe80')) return true;               // fe80::/10 link-local
+    // IPv4-mapped IPv6 — embedded v4 may be dotted (::ffff:10.0.0.1) or
+    // hex-normalized by URL parsing (::ffff:a00:1). Decode both and check.
+    if (low.startsWith('::ffff:')) {
+      const tail = low.slice('::ffff:'.length);
+      let v4 = null;
+      if (tail.includes('.')) {
+        v4 = tail;
+      } else {
+        const g = tail.split(':');
+        if (g.length === 2) {
+          const hi = parseInt(g[0], 16), lo = parseInt(g[1], 16);
+          if (!Number.isNaN(hi) && !Number.isNaN(lo)) {
+            v4 = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+          }
+        }
+      }
+      if (v4 && net.isIP(v4) === 4 && isPrivateIP(v4)) return true;
+    }
+    return false;
+  }
+  return false;
+}
+
+/**
+ * Assert a URL points to a public host. Resolves hostnames and checks every
+ * returned record. Fails CLOSED.
+ * @param {string} url
+ * @param {{allowLoopback?: boolean}} options
+ * @returns {Promise<{hostname: string, ip: string}>}
+ * @throws {SSRFBlockedError}
+ */
+export async function assertPublicHost(url, { allowLoopback = false } = {}) {
+  let urlObj;
+  try {
+    urlObj = new URL(url);
+  } catch (e) {
+    throw new SSRFBlockedError(`Invalid URL: ${url}`);
+  }
+  if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+    throw new SSRFBlockedError(`Invalid URL scheme: ${urlObj.protocol}. Only http and https are allowed.`);
+  }
+
+  // URL.hostname keeps IPv6 brackets ([::1]) — strip them
+  const host = urlObj.hostname.replace(/^\[|\]$/g, '');
+
+  const check = (ip) => {
+    const isLoopback = ip === '127.0.0.1' || ip === '::1';
+    if (isPrivateIP(ip) && !(allowLoopback && isLoopback)) {
+      throw new SSRFBlockedError(`URL points to private IP address: ${ip}`);
+    }
+  };
+
+  const fam = net.isIP(host);
+  if (fam === 4 || fam === 6) {
+    // Literal IP — check directly, no DNS needed
+    check(host);
+    return { hostname: host, ip: host };
+  }
+
+  // It's a hostname — ALWAYS resolve and check EVERY resolved address (A + AAAA)
+  let records;
+  try {
+    const dns = (await import('dns')).promises;
+    records = await dns.lookup(host, { all: true, family: 0 });
+  } catch (dnsError) {
+    // Fail CLOSED: an unresolvable host is not provably public
+    throw new SSRFBlockedError(`DNS resolution failed for ${host}: ${dnsError.message}`);
+  }
+  if (!records || records.length === 0) {
+    throw new SSRFBlockedError(`No DNS records for ${host}`);
+  }
+  for (const r of records) check(r.address);
+  return { hostname: host, ip: records[0].address };
 }

--- a/test/unit/ssrf-guard.test.js
+++ b/test/unit/ssrf-guard.test.js
@@ -119,3 +119,15 @@ test('assertPublicHost handles IPv6 addresses properly', async () => {
   await expect(assertPublicHost('http://[::1]/test', { allowLoopback: false }))
     .rejects.toThrow(SSRFBlockedError);
 });
+
+test('assertPublicHost fails CLOSED when DNS resolution fails', async () => {
+  // .invalid is reserved to never resolve — an unresolvable host must be rejected, not dispatched
+  await expect(assertPublicHost('http://nonexistent-host-xyz.invalid/test', { allowLoopback: false }))
+    .rejects.toThrow(SSRFBlockedError);
+});
+
+test('assertPublicHost blocks IPv4-mapped IPv6 private addresses', async () => {
+  // ::ffff:10.0.0.1 maps to a private v4 — must be blocked
+  await expect(assertPublicHost('http://[::ffff:10.0.0.1]/test', { allowLoopback: false }))
+    .rejects.toThrow(SSRFBlockedError);
+});


### PR DESCRIPTION
Follow-up to #139, fixing 3 findings from automated security review that my byte-review missed:

- **CRITICAL** — the guard treated any dotted string as a literal IP and **skipped DNS resolution**, so any real hostname bypassed the check. Now `net.isIP` distinguishes literal IPs from hostnames, and hostnames are **always resolved** with every A/AAAA record checked.
- **HIGH** — IPv4-mapped IPv6 (`::ffff:10.0.0.1`, normalized to `::ffff:a00:1`) bypassed the v4 private check. Now decoded.
- **MEDIUM** — DNS errors **failed open** (dispatched anyway). Now **fail closed**.

+2 tests. `npm test` → **183 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)