### PR TITLE
security: pin plugin registry to a commit SHA (not a moving branch)

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -5681,7 +5681,21 @@ router.get('/plugins/workers', asyncHandler(function (req, res) {
 // ---- Marketplace ----
 
 var registryCache = { data: null, fetched: 0 };
-var REGISTRY_URL = 'https://raw.githubusercontent.com/SoftBacon-Software/mycelium-plugins/main/registry.json';
+// SECURITY: pin the plugin registry to a specific commit SHA, never a moving
+// branch (main/master/HEAD). A moving ref would let a compromised branch on
+// SoftBacon-Software/mycelium-plugins push arbitrary plugin manifests to every
+// install. BUMP PROCEDURE:
+//   1. git ls-remote https://github.com/SoftBacon-Software/mycelium-plugins.git refs/heads/main
+//   2. Review the compare diff before trusting the new commit:
+//      https://github.com/SoftBacon-Software/mycelium-plugins/compare/<OLD_SHA>...<NEW_SHA>
+//   3. Update REGISTRY_COMMIT below to the new 40-char SHA.
+var REGISTRY_COMMIT = '972a3b351c952d6b39a8e47f62a12cb8aa9c465b';
+var REGISTRY_URL = 'https://raw.githubusercontent.com/SoftBacon-Software/mycelium-plugins/' + REGISTRY_COMMIT + '/registry.json';
+// Fail fast at module load if REGISTRY_URL is ever reverted to a moving ref.
+if (!/\/[0-9a-f]{40}\//.test(REGISTRY_URL)) {
+  throw new Error('REGISTRY_URL must be commit-pinned to a 40-char hex SHA; got: ' + REGISTRY_URL);
+}
+export { REGISTRY_COMMIT, REGISTRY_URL };
 var REGISTRY_TTL = 3600000; // 1 hour
 
 router.get('/plugins/registry', asyncHandler(function (req, res) {

--- a/test/unit/registry-commit-pin.test.js
+++ b/test/unit/registry-commit-pin.test.js
@@ -1,0 +1,72 @@
+import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import express from 'express'
+import request from 'supertest'
+
+// Security regression: the plugin registry URL MUST be pinned to a specific
+// commit SHA, never a moving branch (main/master/HEAD). Otherwise a compromised
+// branch on SoftBacon-Software/mycelium-plugins could push arbitrary plugin
+// manifests to every install. These tests pin that contract.
+//
+// Harness mirrors test/unit/auth-roles.test.js: real router, fresh temp DB, env
+// set before the dynamic import; pool:'forks' isolates us.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const JWT_SECRET = 'test-jwt-secret'
+
+let tmpDataDir
+let db
+let app
+let REGISTRY_URL
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-registry-pin-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+  process.env.JWT_SECRET = JWT_SECRET
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  const routesMod = await import('../../server/routes/mycelium.js')
+  REGISTRY_URL = routesMod.REGISTRY_URL
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routesMod.default)
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+describe('plugin registry commit-pinning', () => {
+  test('REGISTRY_URL is pinned to a 40-char commit SHA, not a moving branch', () => {
+    // Must contain a 40-char lowercase-hex commit SHA path segment ...
+    expect(REGISTRY_URL).toMatch(/\/[0-9a-f]{40}\//)
+    // ... and must NOT point at a moving ref.
+    expect(REGISTRY_URL).not.toMatch(/\/(main|master|HEAD)\//)
+  })
+
+  test('registry refresh fetches the pinned commit URL (not a moving branch)', async () => {
+    const fetched = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ plugins: [] }),
+    }))
+    const origFetch = globalThis.fetch
+    globalThis.fetch = fetched
+    try {
+      const res = await request(app)
+        .get('/api/mycelium/plugins/registry')
+        .set('X-Admin-Key', ADMIN_KEY)
+        .set('X-Acting-As', 'admin')
+      expect(res.status).toBe(200)
+      expect(fetched).toHaveBeenCalled()
+      // The URL handed to fetch must be the pinned commit URL, verbatim.
+      expect(fetched).toHaveBeenCalledWith(REGISTRY_URL)
+    } finally {
+      globalThis.fetch = origFetch
+    }
+  })
+})


### PR DESCRIPTION
## What

The plugin marketplace registry URL in `server/routes/mycelium.js` pointed at the `mycelium-plugins` repo's **`main` branch** — a moving ref. A compromised or force-pushed `main` would let an attacker push arbitrary plugin manifests to **every install** that refreshes the registry.

## Change

- Pin `REGISTRY_URL` to a specific 40-char commit SHA (`REGISTRY_COMMIT` = `972a3b3…`, HEAD of `main` at pin time).
- Module-load guard: throws if `REGISTRY_URL` is ever reverted to a moving ref (`main`/`master`/`HEAD`/non-pinned), so it can't silently regress.
- Inline bump procedure (ls-remote → review the compare diff → update the SHA).
- `test/unit/registry-commit-pin.test.js`: asserts SHA-pinning and that a registry refresh fetches the pinned URL. `vitest` green (2/2).

One fix per PR; no behavior change beyond the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
