### PR TITLE
Squad batch: GLM-audit hardening + residency + security fixes

### DIFF
--- a/sdk/src/agent.js
+++ b/sdk/src/agent.js
@@ -36,6 +36,7 @@ export class MyceliumAgent {
     this.bootData = null
     this._heartbeatTimer = null
     this._pollTimer = null
+    this._pollResolve = null
     this._running = false
     this._workHandler = null
     this._messageHandler = null
@@ -386,6 +387,10 @@ export class MyceliumAgent {
     this._running = false
     if (this._heartbeatTimer) clearInterval(this._heartbeatTimer)
     if (this._pollTimer) clearTimeout(this._pollTimer)
+    if (this._pollResolve) {
+      this._pollResolve()
+      this._pollResolve = null
+    }
 
     // Final heartbeat — go offline
     try {
@@ -436,8 +441,10 @@ export class MyceliumAgent {
 
       // Wait before next poll
       await new Promise(resolve => {
+        this._pollResolve = resolve
         this._pollTimer = setTimeout(resolve, this.pollInterval)
       })
+      this._pollResolve = null
     }
   }
 

--- a/sdk/test/agent_stop.test.js
+++ b/sdk/test/agent_stop.test.js
@@ -1,0 +1,60 @@
+// Verifies the fix for: agent.stop() strands the work loop's poll-pause Promise
+// (clearTimeout cancels the timer but the resolve is unreachable → the loop hangs).
+//
+// Run:  node --test sdk/test/agent_stop.test.js
+
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { MyceliumAgent } from '../src/agent.js'
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+test('stop() terminates the work loop promptly — does not hang', async () => {
+  const agent = new MyceliumAgent({
+    agentId: 'test-agent',
+    apiKey: 'test-key',
+    pollInterval: 100,        // short so the test is fast
+    heartbeatInterval: 600000 // never fires during this test
+  })
+
+  // Stub the HTTP client so NO real network is needed. getWork() calls
+  // api.get() → {} (no `.claimed`), so the loop just idles and polls.
+  agent.api = {
+    get: async () => ({}),
+    post: async () => ({}),
+    put: async () => ({}),
+    del: async () => ({})
+  }
+
+  // start() only launches the work loop when a handler is registered.
+  agent.onIdle(async () => {})
+
+  // Capture the work-loop promise so we can assert it actually settles.
+  let loopPromise
+  const realStartWorkLoop = agent._startWorkLoop.bind(agent)
+  agent._startWorkLoop = function () {
+    loopPromise = realStartWorkLoop()
+    return loopPromise
+  }
+
+  agent.start()
+
+  // Let the loop run a poll and settle into its poll-pause.
+  await sleep(150)
+
+  let settled = false
+  loopPromise.then(() => { settled = true })
+
+  const t0 = Date.now()
+  await agent.stop()
+  const stopElapsed = Date.now() - t0
+
+  // Grace window for the loop to unwind after stop() resolves the pause.
+  await sleep(300)
+
+  assert.strictEqual(agent._running, false, '_running must be false after stop()')
+  assert.ok(stopElapsed < 1000, `stop() took ${stopElapsed}ms, expected < 1000ms`)
+  // This is the assertion that catches the bug: without the fix the loop's
+  // poll-pause Promise never resolves, so loopPromise never settles.
+  assert.ok(settled, 'work loop did NOT terminate after stop() — it hung (the bug)')
+})

--- a/server/plugins/appointments/db.js
+++ b/server/plugins/appointments/db.js
@@ -1,0 +1,63 @@
+export default function createAppointmentsDB(db) {
+  const stmtUpsert = db.prepare(`
+    INSERT INTO appointments (role, model_id, engine, host, flag_overrides, capability, updated_at)
+    VALUES (@role, @model_id, @engine, @host, @flag_overrides, @capability, datetime('now'))
+    ON CONFLICT(role) DO UPDATE SET
+      model_id      = excluded.model_id,
+      engine        = excluded.engine,
+      host          = excluded.host,
+      flag_overrides = excluded.flag_overrides,
+      capability    = excluded.capability,
+      updated_at    = datetime('now')
+  `);
+
+  const stmtGetAll = db.prepare(`SELECT * FROM appointments ORDER BY role ASC`);
+  const stmtGet    = db.prepare(`SELECT * FROM appointments WHERE role = ?`);
+  const stmtDelete = db.prepare(`DELETE FROM appointments WHERE role = ?`);
+
+  function parseRow(row) {
+    if (!row) return null;
+    return {
+      role: row.role,
+      model_id: row.model_id,
+      engine: row.engine,
+      host: row.host,
+      flag_overrides: JSON.parse(row.flag_overrides || '{}'),
+      capability: JSON.parse(row.capability || '{}'),
+      updated_at: row.updated_at,
+    };
+  }
+
+  function upsertAppointment(role, {
+    model_id,
+    engine,
+    host,
+    flag_overrides = {},
+    capability = {},
+  }) {
+    stmtUpsert.run({
+      role,
+      model_id,
+      engine,
+      host,
+      flag_overrides: JSON.stringify(flag_overrides),
+      capability: JSON.stringify(capability),
+    });
+    return parseRow(stmtGet.get(role));
+  }
+
+  function getAppointments() {
+    return stmtGetAll.all().map(parseRow);
+  }
+
+  function getAppointment(role) {
+    return parseRow(stmtGet.get(role));
+  }
+
+  function deleteAppointment(role) {
+    const info = stmtDelete.run(role);
+    return { ok: info.changes > 0, changes: info.changes };
+  }
+
+  return { upsertAppointment, getAppointments, getAppointment, deleteAppointment };
+}

--- a/server/plugins/appointments/routes.js
+++ b/server/plugins/appointments/routes.js
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import createAppointmentsDB from './db.js';
+
+export default function (core) {
+  const router = Router();
+  const db = createAppointmentsDB(core.db);
+  const { checkAgentOrAdmin } = core.auth;
+  const { apiError } = core;
+
+  router.get('/', (req, res) => {
+    if (!checkAgentOrAdmin(req, res)) return;
+    res.json({ appointments: db.getAppointments() });
+  });
+
+  router.put('/:role', (req, res) => {
+    if (!checkAgentOrAdmin(req, res)) return;
+    const { role } = req.params;
+    const { model_id, engine, host, flag_overrides, capability } = req.body || {};
+    if (!model_id || !engine || !host) {
+      return apiError(res, 400, 'model_id, engine, and host are required');
+    }
+    const appointment = db.upsertAppointment(role, {
+      model_id, engine, host, flag_overrides, capability,
+    });
+    res.json({ appointment });
+  });
+
+  router.delete('/:role', (req, res) => {
+    if (!checkAgentOrAdmin(req, res)) return;
+    res.json(db.deleteAppointment(req.params.role));
+  });
+
+  return router;
+}

--- a/server/plugins/appointments/schema.sql
+++ b/server/plugins/appointments/schema.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS appointments (
+  role TEXT PRIMARY KEY,
+  model_id TEXT NOT NULL,
+  engine TEXT NOT NULL,
+  host TEXT NOT NULL,
+  flag_overrides TEXT DEFAULT '{}',
+  capability TEXT DEFAULT '{}',
+  updated_at TEXT DEFAULT (datetime('now'))
+);

--- a/server/plugins/appointments/test.js
+++ b/server/plugins/appointments/test.js
@@ -1,0 +1,106 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import Database from 'better-sqlite3';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import createAppointmentsDB from './db.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function makeDB() {
+  const db = new Database(':memory:');
+  db.exec(readFileSync(join(here, 'schema.sql'), 'utf8'));
+  return db;
+}
+
+test('upsert returns parsed row; getAppointment returns parsed flag_overrides/capability', () => {
+  const db = makeDB();
+  const api = createAppointmentsDB(db);
+
+  const created = api.upsertAppointment('coder', {
+    model_id: 'gpt-4o',
+    engine: 'openai',
+    host: 'api.openai.com',
+    flag_overrides: { streaming: true, temperature: 0.2 },
+    capability: { tools: true, vision: false },
+  });
+
+  assert.equal(created.role, 'coder');
+  assert.equal(created.model_id, 'gpt-4o');
+  assert.equal(created.engine, 'openai');
+  assert.equal(created.host, 'api.openai.com');
+  assert.deepEqual(created.flag_overrides, { streaming: true, temperature: 0.2 });
+  assert.deepEqual(created.capability, { tools: true, vision: false });
+  assert.ok(typeof created.updated_at === 'string' && created.updated_at.length > 0);
+
+  const got = api.getAppointment('coder');
+  assert.equal(got.role, 'coder');
+  assert.deepEqual(got.flag_overrides, { streaming: true, temperature: 0.2 });
+  assert.deepEqual(got.capability, { tools: true, vision: false });
+});
+
+test('getAppointments includes upserted row', () => {
+  const db = makeDB();
+  const api = createAppointmentsDB(db);
+
+  api.upsertAppointment('coder', {
+    model_id: 'gpt-4o', engine: 'openai', host: 'api.openai.com',
+    flag_overrides: { x: 1 }, capability: { y: 2 },
+  });
+
+  const all = api.getAppointments();
+  assert.equal(all.length, 1);
+  assert.equal(all[0].role, 'coder');
+  assert.deepEqual(all[0].flag_overrides, { x: 1 });
+  assert.deepEqual(all[0].capability, { y: 2 });
+});
+
+test('re-upsert with new model_id updates in place (still one row)', () => {
+  const db = makeDB();
+  const api = createAppointmentsDB(db);
+
+  api.upsertAppointment('coder', {
+    model_id: 'gpt-4o', engine: 'openai', host: 'api.openai.com',
+    flag_overrides: {}, capability: {},
+  });
+  api.upsertAppointment('coder', {
+    model_id: 'claude-3-5-sonnet', engine: 'anthropic', host: 'api.anthropic.com',
+    flag_overrides: { beta: true }, capability: { tools: true },
+  });
+
+  const all = api.getAppointments();
+  assert.equal(all.length, 1);
+
+  const row = api.getAppointment('coder');
+  assert.equal(row.model_id, 'claude-3-5-sonnet');
+  assert.equal(row.engine, 'anthropic');
+  assert.equal(row.host, 'api.anthropic.com');
+  assert.deepEqual(row.flag_overrides, { beta: true });
+  assert.deepEqual(row.capability, { tools: true });
+});
+
+test('deleteAppointment removes the row', () => {
+  const db = makeDB();
+  const api = createAppointmentsDB(db);
+
+  api.upsertAppointment('coder', {
+    model_id: 'gpt-4o', engine: 'openai', host: 'api.openai.com',
+    flag_overrides: {}, capability: {},
+  });
+
+  const result = api.deleteAppointment('coder');
+  assert.equal(result.ok, true);
+  assert.equal(result.changes, 1);
+  assert.equal(api.getAppointment('coder'), null);
+
+  const second = api.deleteAppointment('coder');
+  assert.equal(second.ok, false);
+  assert.equal(second.changes, 0);
+});
+
+test('getAppointment on unknown role returns null', () => {
+  const db = makeDB();
+  const api = createAppointmentsDB(db);
+  assert.equal(api.getAppointment('nope'), null);
+});

--- a/server/plugins/residency/README.md
+++ b/server/plugins/residency/README.md
@@ -1,0 +1,169 @@
+# residency
+
+A mycelium plugin that tracks the **model-residency map**: which models are
+resident on which nodes, each node's RAM budget, and which backend each seat
+prefers. It is the foundation for a residency-aware router that keeps the right
+models warm on the right backends.
+
+**Status — P1 (foundation).** State model + read API + co-reside/swap policy.
+There is **no actuator and no actuation** in P1: this plugin describes residency
+and *decides* what should happen, it does not yet load or evict models. That
+comes in P2.
+
+---
+
+## What it is
+
+Three tables hold the live picture:
+
+- **nodes** — each compute node, its total RAM, the RAM *budget* reserved for
+  resident models, and (later) how to talk to its actuator.
+- **models** — the resident set per node: which model, on which backend, whether
+  it is `api` or `local`, its lifecycle `state`, and its measured RSS.
+- **seat_routes** — which backend + kind a given seat (e.g. an agent role)
+  prefers, plus an optional mode preference.
+
+A single read endpoint, `GET /api/mycelium/residency`, returns the whole map as
+JSON. A pure policy function, `decideResidency()`, answers "can this model
+co-reside, or must we swap?".
+
+## Schema
+
+Defined in [`schema.sql`](./schema.sql):
+
+| table                  | key                          | purpose                                            |
+| ---------------------- | ---------------------------- | -------------------------------------------------- |
+| `residency_nodes`      | `node_id`                    | node + RAM budget + actuator descriptor            |
+| `residency_models`     | `(node_id, model_id)`        | one row per resident model on a node               |
+| `residency_seat_routes`| `seat`                       | seat → backend/kind/mode preference                |
+
+`residency_models.kind` is `api` or `local`; `state` is one of
+`cold | loading | warm | resident` (enforced by `CHECK` constraints).
+
+## API
+
+### `GET /api/mycelium/residency`
+
+Returns the live map. No request parameters.
+
+```json
+{
+  "ok": true,
+  "residency": {
+    "nodes": [
+      {
+        "node_id": "mac",
+        "ram_total_gb": 128,
+        "ram_budget_gb": 120,
+        "actuator_kind": "omlx",
+        "actuator_url": "http://localhost:8080",
+        "updated_at": "2026-06-30T22:44:00.000Z",
+        "resident_set": [
+          { "node_id": "mac", "model_id": "ds4", "backend": "omlx",
+            "kind": "local", "state": "resident", "rss_gb": 80,
+            "last_used_at": "2026-06-30T22:44:00.000Z" }
+        ]
+      }
+    ],
+    "seat_routes": [
+      { "seat": "lucy", "backend": "omlx", "kind": "local", "mode_pref": "local-first" }
+    ]
+  }
+}
+```
+
+P1 exposes this single read endpoint. State is seeded through the `db.js`
+helpers (`upsertNode`, `upsertModel`, `upsertRoute`, …) — today by tests,
+tomorrow by an ingestion/actuator step.
+
+## Policy
+
+`policy.js` exports `decideResidency(currentResidentSet, requestedModel, ramBudgetGb)`
+→ `{ action: 'co-reside' | 'swap', reason, total_gb }`.
+
+Logic:
+
+1. Sum the RSS of the current resident set + the estimated RSS of the requested
+   model.
+2. If the total fits the node's `ram_budget_gb` → **co-reside**.
+3. Otherwise → **swap** (evict the resident set, load the requested model).
+
+RSS is estimated from a small lookup table (`modelRssLookup`), falling back to
+`default-local` (8 GB) for unknown local models and `default-api` (0 GB) for API
+models. Defaults:
+
+| model id         | RSS (GB) |
+| ---------------- | -------- |
+| `ds4`            | 80       |
+| `squad-glm`      | 27       |
+| `oMLX-Lucy-30B`  | 30       |
+| `default-local`  | 8        |
+| `default-api`    | 0        |
+
+The function is pure (no I/O), so it is trivially unit-testable and reusable
+from the future actuator, the endpoint, or any caller.
+
+## Files
+
+| file            | role                                                                  |
+| --------------- | --------------------------------------------------------------------- |
+| `schema.sql`    | table DDL (applied by the platform loader)                            |
+| `db.js`         | `createResidencyDB(db)` — better-sqlite3 CRUD + `getMap()` (JS core)  |
+| `src/policy.ts` | `decideResidency()` + `modelRssLookup` + `estimateRss()` (pure, TS)   |
+| `src/index.ts`  | `createResidencyPlugin(dbPath)` factory — self-contained, testable (TS) |
+| `routes.js`     | Express adapter mounted by the platform loader under `/residency`     |
+| `plugin.json`   | manifest (`routePrefix: /residency`)                                  |
+
+> **Why the split?** The typed, testable surface (`src/index.ts`, `src/policy.ts`)
+> is TypeScript. The DB core (`db.js`) and the platform adapter (`routes.js`)
+> stay JavaScript because the platform loader (`server/plugins.js`) imports
+> `routes.js` in plain Node, which cannot load `.ts` directly. `src/index.ts`
+> imports `db.js`, so both the typed factory and the platform share one DB core.
+
+Two entry points share the same core:
+
+- **`createResidencyPlugin(dbPath)`** (in `src/index.ts`) opens its own DB
+  connection and returns `{ name, version, schema, init, routes, cleanup }`.
+  This is what the test suite uses.
+- **`routes.js`** is the platform's directory-plugin adapter: the loader passes
+  it the shared `core.db` and mounts it at `/api/mycelium/residency`.
+
+## How to extend
+
+### Add a node actuator (P2)
+
+1. Populate `actuator_kind` / `actuator_url` on the node (via `upsertNode`).
+2. Add an actuator module that, given a `swap` decision, performs the
+   load/evict against that backend and updates `residency_models.state`.
+3. Wire new actuation endpoints in `routes.js` (POST/PATCH). P1 intentionally
+   exposes none.
+
+### Add / tune a policy
+
+- **Tune weights:** edit `modelRssLookup` in `src/policy.ts`, or pass explicit
+  `rss_gb` on resident/model entries (telemetry overrides the lookup).
+- **New policy:** add a function alongside `decideResidency` (e.g. one that
+  prefers evicting the least-recently-used resident instead of the whole set)
+  and select between them at the call site. Keep it pure and unit-tested.
+
+### Add a new node / model / route
+
+```js
+import { createResidencyDB } from './db.js';
+const store = createResidencyDB(db); // db = open better-sqlite3 connection
+
+store.upsertNode({ node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 120,
+                   actuator_kind: 'omlx', actuator_url: 'http://localhost:8080' });
+store.upsertModel({ node_id: 'mac', model_id: 'ds4', backend: 'omlx',
+                    kind: 'local', state: 'resident', rss_gb: 80 });
+store.upsertRoute({ seat: 'lucy', backend: 'omlx', kind: 'local', mode_pref: 'local-first' });
+```
+
+## Tests
+
+```
+npm test -- residency
+```
+
+The suite (`test/unit/residency.test.js`) covers schema CRUD, the GET map
+shape, and the co-reside/swap policy decisions.

--- a/server/plugins/residency/db.js
+++ b/server/plugins/residency/db.js
@@ -1,0 +1,158 @@
+// residency plugin — DB helpers (better-sqlite3)
+//
+// Framework-agnostic CRUD over the residency tables. Takes an already-open
+// better-sqlite3 connection (shared with the platform under the directory
+// plugin convention, or opened by the createResidencyPlugin() factory). Mirrors
+// the createXxxDB(db) idiom used by every other mycelium plugin.
+//
+// Self-sufficient: createResidencyDB() applies the schema (idempotent
+// CREATE TABLE IF NOT EXISTS) so any caller — tests, the factory, the loader
+// path — gets working tables from a single call. Re-application is a no-op.
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const SCHEMA_SQL = readFileSync(join(__dirname, 'schema.sql'), 'utf8');
+
+export function applySchema(db) {
+  db.exec(SCHEMA_SQL);
+}
+
+export default function createResidencyDB(db) {
+  applySchema(db);
+
+  function nowIso() {
+    return new Date().toISOString();
+  }
+
+  // --- nodes -------------------------------------------------------------
+  function upsertNode(n) {
+    db.prepare(
+      `INSERT INTO residency_nodes
+         (node_id, ram_total_gb, ram_budget_gb, actuator_kind, actuator_url, updated_at)
+       VALUES (@node_id, @ram_total_gb, @ram_budget_gb, @actuator_kind, @actuator_url, @updated_at)
+       ON CONFLICT(node_id) DO UPDATE SET
+         ram_total_gb  = excluded.ram_total_gb,
+         ram_budget_gb = excluded.ram_budget_gb,
+         actuator_kind = excluded.actuator_kind,
+         actuator_url  = excluded.actuator_url,
+         updated_at    = excluded.updated_at`
+    ).run({
+      node_id: n.node_id,
+      ram_total_gb: n.ram_total_gb,
+      ram_budget_gb: n.ram_budget_gb,
+      actuator_kind: n.actuator_kind || null,
+      actuator_url: n.actuator_url || null,
+      updated_at: nowIso()
+    });
+    return getNode(n.node_id);
+  }
+
+  function getNode(nodeId) {
+    return db.prepare('SELECT * FROM residency_nodes WHERE node_id = ?').get(nodeId) || null;
+  }
+
+  function listNodes() {
+    return db.prepare('SELECT * FROM residency_nodes ORDER BY node_id').all();
+  }
+
+  function removeNode(nodeId) {
+    db.prepare('DELETE FROM residency_models WHERE node_id = ?').run(nodeId);
+    return db.prepare('DELETE FROM residency_nodes WHERE node_id = ?').run(nodeId).changes;
+  }
+
+  // --- models (resident set) --------------------------------------------
+  function upsertModel(m) {
+    db.prepare(
+      `INSERT INTO residency_models
+         (node_id, model_id, backend, kind, state, rss_gb, last_used_at)
+       VALUES (@node_id, @model_id, @backend, @kind, @state, @rss_gb, @last_used_at)
+       ON CONFLICT(node_id, model_id) DO UPDATE SET
+         backend     = excluded.backend,
+         kind        = excluded.kind,
+         state       = excluded.state,
+         rss_gb      = excluded.rss_gb,
+         last_used_at = excluded.last_used_at`
+    ).run({
+      node_id: m.node_id,
+      model_id: m.model_id,
+      backend: m.backend,
+      kind: m.kind,
+      state: m.state,
+      rss_gb: m.rss_gb != null ? m.rss_gb : 0,
+      last_used_at: m.last_used_at || nowIso()
+    });
+    return m;
+  }
+
+  function listModelsForNode(nodeId) {
+    return db
+      .prepare('SELECT * FROM residency_models WHERE node_id = ? ORDER BY model_id')
+      .all(nodeId);
+  }
+
+  function setModelState(nodeId, modelId, state) {
+    return db
+      .prepare(
+        `UPDATE residency_models SET state = ?, last_used_at = ?
+         WHERE node_id = ? AND model_id = ?`
+      )
+      .run(state, nowIso(), nodeId, modelId).changes;
+  }
+
+  function removeModel(nodeId, modelId) {
+    return db
+      .prepare('DELETE FROM residency_models WHERE node_id = ? AND model_id = ?')
+      .run(nodeId, modelId).changes;
+  }
+
+  // --- seat routes -------------------------------------------------------
+  function upsertRoute(r) {
+    db.prepare(
+      `INSERT INTO residency_seat_routes (seat, backend, kind, mode_pref)
+       VALUES (@seat, @backend, @kind, @mode_pref)
+       ON CONFLICT(seat) DO UPDATE SET
+         backend = excluded.backend,
+         kind    = excluded.kind,
+         mode_pref = excluded.mode_pref`
+    ).run({
+      seat: r.seat,
+      backend: r.backend,
+      kind: r.kind,
+      mode_pref: r.mode_pref || null
+    });
+    return r;
+  }
+
+  function listRoutes() {
+    return db.prepare('SELECT * FROM residency_seat_routes ORDER BY seat').all();
+  }
+
+  // --- aggregate live map (what GET /residency returns) ------------------
+  function getMap() {
+    var nodes = listNodes();
+    var seatRoutes = listRoutes();
+    // Attach each node's resident set (resident/warm/loading models).
+    var nodesWithSets = nodes.map(function (node) {
+      var residentSet = listModelsForNode(node.node_id);
+      return Object.assign({}, node, { resident_set: residentSet });
+    });
+    return { nodes: nodesWithSets, seat_routes: seatRoutes };
+  }
+
+  return {
+    upsertNode,
+    getNode,
+    listNodes,
+    removeNode,
+    upsertModel,
+    listModelsForNode,
+    setModelState,
+    removeModel,
+    upsertRoute,
+    listRoutes,
+    getMap
+  };
+}

--- a/server/plugins/residency/plugin.json
+++ b/server/plugins/residency/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "residency",
+  "version": "0.1.0",
+  "displayName": "Residency",
+  "description": "Model-residency state map: nodes, RAM budgets, resident model sets, and seat routes. P1 = state + GET map + co-reside/swap policy (no actuation).",
+  "enabled": true,
+  "routePrefix": "/residency",
+  "schema": "schema.sql"
+}

--- a/server/plugins/residency/routes.js
+++ b/server/plugins/residency/routes.js
@@ -1,0 +1,30 @@
+// residency plugin — Express adapter for the mycelium platform loader
+//
+// The platform loader (server/plugins.js) dynamically imports this module and
+// calls the default export with a `core` object whose `db` is the shared
+// mycelium better-sqlite3 connection. Mounted under routePrefix "/residency",
+// so GET / here resolves to GET /api/mycelium/residency.
+//
+// P1 is read-only: only the map endpoint is exposed. State is seeded through
+// db.js helpers (by tests today; by a future ingestion/actuator step later).
+
+import { Router } from 'express';
+import createResidencyDB from './db.js';
+
+export default function residencyRoutes(core) {
+  var router = Router();
+  var store = createResidencyDB(core.db);
+  var auth = core && core.auth ? core.auth.checkAgentOrAdmin : function (_req, _res, next) { next(); };
+
+  // GET /api/mycelium/residency — live map: nodes + budgets, resident set per
+  // node, and seat routes.
+  router.get('/', auth, function (_req, res) {
+    try {
+      res.json({ ok: true, residency: store.getMap() });
+    } catch (err) {
+      core.apiError(res, 500, 'failed to read residency map: ' + err.message);
+    }
+  });
+
+  return router;
+}

--- a/server/plugins/residency/schema.sql
+++ b/server/plugins/residency/schema.sql
@@ -1,0 +1,33 @@
+-- residency plugin — P1 foundation schema
+-- Tracks the live model-residency map: nodes + their RAM budgets, the resident
+-- model set per node, and seat→backend route preferences. P1 is state + read API
+-- + policy only — no actuator columns are wired to actuation yet.
+
+CREATE TABLE IF NOT EXISTS residency_nodes (
+  node_id        TEXT PRIMARY KEY,
+  ram_total_gb   REAL NOT NULL,
+  ram_budget_gb  REAL NOT NULL,
+  actuator_kind  TEXT,
+  actuator_url   TEXT,
+  updated_at     TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS residency_models (
+  node_id      TEXT NOT NULL,
+  model_id     TEXT NOT NULL,
+  backend      TEXT NOT NULL,
+  kind         TEXT NOT NULL CHECK (kind IN ('api', 'local')),
+  state        TEXT NOT NULL CHECK (state IN ('cold', 'loading', 'warm', 'resident')),
+  rss_gb       REAL NOT NULL DEFAULT 0,
+  last_used_at TEXT,
+  PRIMARY KEY (node_id, model_id)
+);
+
+CREATE TABLE IF NOT EXISTS residency_seat_routes (
+  seat      TEXT PRIMARY KEY,
+  backend   TEXT NOT NULL,
+  kind      TEXT NOT NULL,
+  mode_pref TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_residency_models_node ON residency_models (node_id);

--- a/server/plugins/residency/src/index.js
+++ b/server/plugins/residency/src/index.js
@@ -1,0 +1,93 @@
+// residency plugin — factory entry point (plain JavaScript / ESM) — the briefed shape
+//
+//   createResidencyPlugin(dbPath) -> MyceliumPlugin
+//
+// Returns a self-contained plugin object: it opens its OWN better-sqlite3
+// connection at `dbPath`, creates the tables in init(), and exposes a read-only
+// GET route plus the raw SQL schema and a cleanup() hook. This is the unit the
+// vitest suite exercises (no platform wiring required) and the shape future
+// actuators / ingestion will build on.
+//
+// The platform's directory-plugin loader (server/plugins.js) instead mounts
+// routes.js against the shared core.db; both paths share db.js (the DB core
+// stays JavaScript because the loader imports routes.js in plain Node, which
+// cannot load .ts). This module + policy.js are the testable surface.
+
+import Database from 'better-sqlite3';
+import createResidencyDB, { SCHEMA_SQL } from '../db.js';
+import { decideResidency, estimateRss, modelRssLookup } from './policy.js';
+
+// ---- Factory --------------------------------------------------------------
+
+// GET /api/mycelium/residency — the live residency map.
+function buildGetHandler(store) {
+  return function getResidency() {
+    return { ok: true, residency: store.getMap() };
+  };
+}
+
+export function createResidencyPlugin(dbPath) {
+  let db = null;
+  let store = null;
+
+  return {
+    name: 'residency',
+    version: '0.1.0',
+
+    // Raw DDL — single source of truth in schema.sql (re-exported via db.js).
+    schema: SCHEMA_SQL,
+
+    // Open the connection and create tables (createResidencyDB applies the
+    // idempotent schema). `hub` is optional and unused in P1 (no event
+    // subscriptions yet); accepted for forward-compat with the loader.
+    init(_hub) {
+      db = new Database(dbPath);
+      if (dbPath !== ':memory:') {
+        try {
+          db.pragma('journal_mode = WAL');
+        } catch (_e) {
+          /* WAL not applicable / unavailable — non-fatal */
+        }
+      }
+      store = createResidencyDB(db);
+      return this;
+    },
+
+    // P1 exposes a single read-only route. The handler returns the JSON body
+    // directly; an Express adapter (routes.js) wraps it in res.json().
+    routes: [
+      {
+        method: 'GET',
+        path: '/api/mycelium/residency',
+        handler: function () {
+          if (!store) throw new Error('residency plugin not initialised — call init() first');
+          return buildGetHandler(store)();
+        }
+      }
+    ],
+
+    // Close the DB connection. Safe to call once.
+    cleanup() {
+      if (db) {
+        db.close();
+        db = null;
+        store = null;
+      }
+    },
+
+    // Exposed for tests + future ingestion/actuator code.
+    getStore() {
+      return store;
+    },
+
+    // Exposed so callers can inspect/apply the schema without init() (e.g. the
+    // platform loader, which owns its own connection).
+    getSchema() {
+      return SCHEMA_SQL;
+    }
+  };
+}
+
+// Re-exports — single entry point for consumers.
+export { SCHEMA_SQL, createResidencyDB };
+export { decideResidency, estimateRss, modelRssLookup };

--- a/server/plugins/residency/src/policy.js
+++ b/server/plugins/residency/src/policy.js
@@ -1,0 +1,108 @@
+// residency plugin — co-reside / swap policy (pure, no I/O) — plain JavaScript (ESM)
+//
+// decideResidency() answers: given what is currently resident on a node and a
+// model someone wants to load there, can it co-reside within the RAM budget, or
+// must we swap (evict the resident set and load the requested model)?
+//
+// P1 is decision-only — the actuator that performs a swap is P2. This module is
+// deliberately side-effect free so it is trivially unit-testable and reusable
+// from the future actuator, the GET endpoint, or any caller.
+
+/** A model's footprint descriptor. `rss_gb`, when present, overrides the lookup. */
+// ModelFootprint: { model_id?: string, kind?: 'api'|'local', rss_gb?: number }
+
+/** Anything we can estimate an RSS for: a footprint object or a bare model id. */
+// ModelRef: ModelFootprint | string
+
+// ResidencyDecision: { action: 'co-reside'|'swap', reason: string, total_gb: number }
+
+// Estimated resident-set footprint (GB) by model id. Local weights reflect
+// model size + typical KV/cache headroom; API models cost 0 local RAM because
+// they run on a remote backend. Tune as real telemetry comes in.
+export const modelRssLookup = {
+  ds4: 80,
+  'squad-glm': 27,
+  'oMLX-Lucy-30B': 30,
+  'default-local': 8,
+  'default-api': 0
+};
+
+// Estimate the local RAM footprint (GB) of a model.
+//
+// Accepts either:
+//   - a string model id, or
+//   - an object { model_id, kind, rss_gb? }
+//
+// Resolution order: explicit rss_gb > lookup by model_id > default by kind.
+export function estimateRss(model) {
+  if (model == null) return 0;
+  if (typeof model === 'string') {
+    return Object.prototype.hasOwnProperty.call(modelRssLookup, model)
+      ? modelRssLookup[model]
+      : modelRssLookup['default-local'];
+  }
+  if (typeof model.rss_gb === 'number' && model.rss_gb > 0) return model.rss_gb;
+  const id = model.model_id;
+  if (id && Object.prototype.hasOwnProperty.call(modelRssLookup, id)) {
+    return modelRssLookup[id];
+  }
+  return model.kind === 'api' ? modelRssLookup['default-api'] : modelRssLookup['default-local'];
+}
+
+// Sum the footprint of the currently resident set. Entries may carry their own
+// rss_gb (from telemetry); otherwise we estimate from the lookup table.
+function sumResidentRss(currentResidentSet) {
+  if (!Array.isArray(currentResidentSet)) return 0;
+  let total = 0;
+  for (let i = 0; i < currentResidentSet.length; i++) {
+    total += estimateRss(currentResidentSet[i]);
+  }
+  return total;
+}
+
+function modelLabel(model) {
+  if (model == null) return '<unknown>';
+  if (typeof model === 'string') return model;
+  return model.model_id || '<unknown>';
+}
+
+// Decide whether `requestedModel` can co-reside with `currentResidentSet`
+// inside `ramBudgetGb`, or whether the resident set must be evicted (swap).
+//
+//   currentResidentSet : Array<{ model_id?, kind?, rss_gb? }> | Array<string>
+//   requestedModel     : { model_id?, kind?, rss_gb? } | string
+//   ramBudgetGb        : number
+//
+// Returns { action: 'co-reside' | 'swap', reason: string, total_gb: number }.
+export function decideResidency(currentResidentSet, requestedModel, ramBudgetGb) {
+  const budget = Number(ramBudgetGb);
+  if (!Number.isFinite(budget) || budget < 0) {
+    return {
+      action: 'swap',
+      reason: 'invalid RAM budget (' + ramBudgetGb + '); refusing to co-reside',
+      total_gb: NaN
+    };
+  }
+
+  const currentRss = sumResidentRss(currentResidentSet);
+  const requestedRss = estimateRss(requestedModel);
+  const total = currentRss + requestedRss;
+
+  if (total <= budget) {
+    return {
+      action: 'co-reside',
+      reason:
+        'resident set ' + currentRss + 'GB + ' + modelLabel(requestedModel) + ' ' +
+        requestedRss + 'GB = ' + total + 'GB ≤ budget ' + budget + 'GB; co-reside',
+      total_gb: total
+    };
+  }
+
+  return {
+    action: 'swap',
+    reason:
+      'resident set ' + currentRss + 'GB + ' + modelLabel(requestedModel) + ' ' +
+      requestedRss + 'GB = ' + total + 'GB > budget ' + budget + 'GB; evict resident set and load',
+    total_gb: total
+  };
+}

--- a/server/plugins/semantic-memory/db.js
+++ b/server/plugins/semantic-memory/db.js
@@ -4,9 +4,12 @@ import { cosineSimilarity } from './embeddings.js';
 import { chunkText, DEFAULT_CHUNK_SIZE } from './chunking.js';
 import * as sqliteVec from 'sqlite-vec';
 
-var _vecAvailable = null;
-
 export default function createMemoryDB(db) {
+  // Per-instance flag: whether THIS db loaded the sqlite-vec extension.
+  // Was module-level — a singleton whose first-call result leaked to every
+  // later instance, even against a db that couldn't load the extension.
+  var _vecAvailable = null;
+
   // Try to load sqlite-vec extension on first use
   if (_vecAvailable === null) {
     try {
@@ -128,7 +131,7 @@ export default function createMemoryDB(db) {
       var rows = [];
       var txn = db.transaction(function (items) {
         for (var item of items) {
-          if (item.chunk_index) {
+          if (item.chunk_index !== undefined && item.chunk_index !== null) {
             self.index(item.source_type, item.source_id, item.content_text, {
               namespace: item.namespace, chunk_index: item.chunk_index,
               metadata: item.metadata, embedding: item.embedding,
@@ -302,7 +305,10 @@ export default function createMemoryDB(db) {
     },
 
     updateEmbedding(sourceType, sourceId, chunkIndex, embedding, model) {
-      var embeddingStr = JSON.stringify(embedding);
+      // A null embedding must NOT be stored as the string "null" — that
+      // escapes `embedding IS NULL` and orphans the row from backfill.
+      if (embedding == null) return;
+      var embeddingStr = embedding == null ? null : JSON.stringify(embedding);
       db.prepare(
         "UPDATE sm_embeddings SET embedding = ?, embedding_model = ?, updated_at = datetime('now') WHERE source_type = ? AND source_id = ? AND chunk_index = ?"
       ).run(embeddingStr, model, sourceType, sourceId, chunkIndex || 0);

--- a/server/plugins/semantic-memory/test.js
+++ b/server/plugins/semantic-memory/test.js
@@ -612,3 +612,82 @@ test('search: multi-chunk doc collapses to its best chunk', async function () {
     assert.equal(bigHits[0].embedding, undefined, mode + ': raw vectors stripped');
   }
 });
+
+// ---- 3 bounded correctness fixes: per-instance _vecAvailable, chunk_index:0,
+// and null-embedding stringification ----
+
+// Fix (a): _vecAvailable is per-instance, not a module-level singleton.
+// Each createMemoryDB() independently determines whether ITS db can load
+// sqlite-vec — the first instance no longer poisons every later one.
+test('db: vecAvailable is per-instance, not a module-level singleton', function () {
+  var db1 = new Database(':memory:');
+  db1.exec(fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8'));
+  var mem1 = createMemoryDB(db1);
+
+  var db2 = new Database(':memory:');
+  db2.exec(fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8'));
+  var mem2 = createMemoryDB(db2);
+
+  // Both instances independently settle to a boolean (ran their own check,
+  // not a cached module-level value left at null).
+  assert.strictEqual(typeof mem1.vecAvailable(), 'boolean');
+  assert.strictEqual(typeof mem2.vecAvailable(), 'boolean');
+
+  // stats() reads the SAME per-instance flag, not a shared module var.
+  assert.strictEqual(mem1.stats().vec_available, mem1.vecAvailable());
+  assert.strictEqual(mem2.stats().vec_available, mem2.vecAvailable());
+
+  db1.close();
+  db2.close();
+});
+
+// Fix (b): bulkIndex honors an explicit chunk_index of 0. Pre-fix,
+// `if (item.chunk_index)` treated 0 as falsy and fell through to indexDoc,
+// which re-chunked oversized content and discarded the caller's assignment.
+// NOTE: this only manifests with OVERSIZED content — small content produces
+// a single chunk either way, so the test must use oversized text to catch it.
+test('db: bulkIndex respects explicit chunk_index 0 — oversized content stays one row', function () {
+  mem.setConfig('chunk_size', '600');
+  var big = makeBigText('chunkzero', 8); // oversized — would auto-chunk without the fix
+  assert.ok(big.length > 600, 'content is oversized');
+
+  var rows = mem.bulkIndex([
+    { source_type: 'test', source_id: 'chunk-zero', content_text: big, chunk_index: 0 }
+  ]);
+  // Explicit chunk_index: 0 => stored as a SINGLE row, NOT auto-chunked.
+  assert.strictEqual(rows.length, 1, 'one row — caller chunk_index honored');
+  assert.strictEqual(rows[0].chunk_index, 0);
+  assert.strictEqual(rows[0].content_text, big, 'full content, not a fragment');
+
+  assert.strictEqual(getChunkRows('test', 'chunk-zero').length, 1, 'exactly one DB row');
+  var doc = mem.getDoc('test', 'chunk-zero', 0);
+  assert.ok(doc);
+  assert.strictEqual(doc.content_text, big);
+});
+
+// Fix (c): updateEmbedding(null) must keep the column as SQL NULL, not the
+// string "null". The string would escape `embedding IS NULL` and permanently
+// hide the row from backfill — silent data loss. Scoped to this one row so
+// it is immune to other tests' in-flight async embeds.
+test('db: updateEmbedding(null) keeps row as SQL NULL, not the string "null"', function () {
+  mem.index('test', 'null-embed-test', 'content for null embedding test', {});
+  var row0 = db.prepare(
+    'SELECT embedding FROM sm_embeddings WHERE source_type = ? AND source_id = ? AND chunk_index = ?'
+  ).get('test', 'null-embed-test', 0);
+  assert.strictEqual(row0.embedding, null, 'freshly indexed row has NULL embedding');
+
+  mem.updateEmbedding('test', 'null-embed-test', 0, null, 'some-model');
+
+  // The null must NOT have been stringified to "null" — column stays SQL NULL.
+  var row = db.prepare(
+    'SELECT embedding FROM sm_embeddings WHERE source_type = ? AND source_id = ? AND chunk_index = ?'
+  ).get('test', 'null-embed-test', 0);
+  assert.strictEqual(row.embedding, null, 'embedding column is SQL NULL');
+  assert.notStrictEqual(row.embedding, 'null', 'not the string "null"');
+
+  // Still matches `embedding IS NULL` => remains backfill-visible.
+  var unembedded = db.prepare(
+    'SELECT COUNT(*) AS c FROM sm_embeddings WHERE source_type = ? AND source_id = ? AND embedding IS NULL'
+  ).get('test', 'null-embed-test').c;
+  assert.strictEqual(unembedded, 1, 'row still backfill-visible (embedding IS NULL)');
+});

--- a/server/plugins/workflows/db.js
+++ b/server/plugins/workflows/db.js
@@ -20,7 +20,7 @@ var TRANSITIONS = {
 export var EVENT_KINDS = [
   'created', 'claimed', 'risk_assessed', 'wave_started',
   'invocation_started', 'invocation_finished', 'invocation_failed',
-  'awaiting_approval', 'resumed',
+  'awaiting_approval', 'resumed', 'cancelling',
   'completed', 'failed', 'cancelled'
 ];
 
@@ -87,10 +87,23 @@ function parseInvocation(row) {
   return row;
 }
 
+// Events are stored JSON.stringify(payload) in addEvent; parse it back so the
+// app gets an object, not an escaped JSON string (mirrors parseInvocation).
+function parseEvent(row) {
+  if (!row) return null;
+  try { row.payload = JSON.parse(row.payload); } catch (e) { /* keep raw */ }
+  return row;
+}
+
 export default function createWorkflowsDB(db) {
   // Migration: the approval-gate link — an awaiting_approval workflow references
-  // the approval it's paused on. Idempotent (no-op once the column exists).
-  try { db.exec('ALTER TABLE workflows ADD COLUMN approval_id INTEGER'); } catch (e) { /* column exists */ }
+  // the approval it's paused on. Idempotent: check the column exists first so a
+  // real error (disk I/O, db-locked) is NOT swallowed by a blanket try/catch.
+  var hasApprovalId = db.prepare('PRAGMA table_info(workflows)').all()
+    .some(function (col) { return col.name === 'approval_id'; });
+  if (!hasApprovalId) {
+    db.exec('ALTER TABLE workflows ADD COLUMN approval_id INTEGER');
+  }
 
   function addEvent(workflowId, kind, payload) {
     return db.prepare(
@@ -133,7 +146,7 @@ export default function createWorkflowsDB(db) {
       ).all(id).map(parseInvocation);
       wf.events = db.prepare(
         'SELECT * FROM workflow_events WHERE workflow_id = ? ORDER BY id DESC LIMIT 50'
-      ).all(id).reverse();
+      ).all(id).map(parseEvent).reverse();
       return wf;
     },
 
@@ -171,6 +184,12 @@ export default function createWorkflowsDB(db) {
       fields = fields || {};
       var wf = api.getWorkflow(id);
       if (!wf) return { ok: false, error: 'not found' };
+      // Terminal states cannot be modified at all — not even field-only updates
+      // (a PUT {risk:'red'} with no status used to bypass the transition guard
+      // because newStatus was falsy). Block everything once it's finished.
+      if (['completed', 'failed', 'cancelled'].indexOf(wf.status) !== -1) {
+        return { ok: false, error: 'cannot modify terminal state: ' + wf.status };
+      }
       var allowed = TRANSITIONS[wf.status] || [];
       if (newStatus && newStatus !== wf.status && allowed.indexOf(newStatus) === -1) {
         return { ok: false, from: wf.status,
@@ -218,6 +237,7 @@ export default function createWorkflowsDB(db) {
       }
       if (wf.status === 'running') {
         db.prepare("UPDATE workflows SET status = 'cancelling' WHERE id = ?").run(id);
+        addEvent(id, 'cancelling', { was: wf.status });
         return { ok: true, status: 'cancelling' };
       }
       if (wf.status === 'cancelling') return { ok: true, status: 'cancelling' };

--- a/server/plugins/workflows/db.js
+++ b/server/plugins/workflows/db.js
@@ -9,7 +9,8 @@ export var TRUNCATION_MARKER = '\n...[truncated at ' + RESULT_CAP + ' chars]';
 var TRANSITIONS = {
   pending:    ['claimed', 'cancelled'],
   claimed:    ['running', 'failed', 'cancelled'],
-  running:    ['completed', 'failed', 'cancelling'],
+  running:    ['completed', 'failed', 'cancelling', 'awaiting_approval'],
+  awaiting_approval: ['running', 'failed', 'cancelled'],
   cancelling: ['cancelled', 'completed', 'failed'],
   completed:  [],
   failed:     [],
@@ -19,6 +20,7 @@ var TRANSITIONS = {
 export var EVENT_KINDS = [
   'created', 'claimed', 'risk_assessed', 'wave_started',
   'invocation_started', 'invocation_finished', 'invocation_failed',
+  'awaiting_approval', 'resumed',
   'completed', 'failed', 'cancelled'
 ];
 
@@ -86,6 +88,10 @@ function parseInvocation(row) {
 }
 
 export default function createWorkflowsDB(db) {
+  // Migration: the approval-gate link — an awaiting_approval workflow references
+  // the approval it's paused on. Idempotent (no-op once the column exists).
+  try { db.exec('ALTER TABLE workflows ADD COLUMN approval_id INTEGER'); } catch (e) { /* column exists */ }
+
   function addEvent(workflowId, kind, payload) {
     return db.prepare(
       'INSERT INTO workflow_events (workflow_id, kind, payload) VALUES (?, ?, ?) RETURNING id'
@@ -182,12 +188,19 @@ export default function createWorkflowsDB(db) {
       }
       if (fields.risk !== undefined) { sets.push('risk = ?'); values.push(fields.risk); }
       if (fields.error !== undefined) { sets.push('error = ?'); values.push(fields.error); }
+      // The approval-gate link: set when pausing on a gate, cleared (null) on resume.
+      if (fields.approval_id !== undefined) { sets.push('approval_id = ?'); values.push(fields.approval_id); }
       if (sets.length === 0) return { ok: true, workflow: wf };
       values.push(id);
       db.prepare('UPDATE workflows SET ' + sets.join(', ') + ' WHERE id = ?').run(...values);
-      if (newStatus && newStatus !== wf.status &&
-          ['completed', 'failed', 'cancelled'].indexOf(newStatus) !== -1) {
-        addEvent(id, newStatus, fields.error ? { error: fields.error } : {});
+      if (newStatus && newStatus !== wf.status) {
+        if (['completed', 'failed', 'cancelled'].indexOf(newStatus) !== -1) {
+          addEvent(id, newStatus, fields.error ? { error: fields.error } : {});
+        } else if (newStatus === 'awaiting_approval') {
+          addEvent(id, 'awaiting_approval', { approval_id: fields.approval_id });
+        } else if (newStatus === 'running' && wf.status === 'awaiting_approval') {
+          addEvent(id, 'resumed', {});
+        }
       }
       return { ok: true, workflow: api.getWorkflow(id) };
     },

--- a/server/plugins/workflows/routes.js
+++ b/server/plugins/workflows/routes.js
@@ -114,6 +114,17 @@ export default function (core) {
       transcript_path: req.body.transcript_path
     });
     if (!r.ok) return apiError(res, r.error === 'invocation not found' ? 404 : 400, r.error);
+    // Emit a lifecycle event on terminal invocation status so the app/cockpit
+    // animates each invocation finishing live (mirrors the PUT /:id workflow-
+    // status emit + the POST /:id/events re-emit convention).
+    if (req.body.status &&
+        ['completed', 'failed', 'skipped'].indexOf(req.body.status) !== -1) {
+      var eventKind = 'invocation_finished';
+      if (req.body.status === 'failed') eventKind = 'invocation_failed';
+      core.emitEvent('workflow_' + eventKind, who, wf.project_id || '',
+        'invocation ' + req.params.invId + ' of workflow #' + wf.id + ': ' + req.body.status,
+        { workflow_id: wf.id, inv_id: req.params.invId, status: req.body.status });
+    }
     res.json({ ok: true, invocation: r.invocation });
   });
 

--- a/server/plugins/workflows/routes.js
+++ b/server/plugins/workflows/routes.js
@@ -90,12 +90,13 @@ export default function (core) {
     var wf = getWorkflowOr404(req, res);
     if (!wf) return;
     var r = db.updateWorkflowStatus(wf.id, req.body.status,
-      { risk: req.body.risk, error: req.body.error });
+      { risk: req.body.risk, error: req.body.error, approval_id: req.body.approval_id });
     if (!r.ok) return apiError(res, 400, r.error, { from: r.from });
-    if (req.body.status && ['completed', 'failed', 'cancelled'].indexOf(req.body.status) !== -1) {
+    if (req.body.status &&
+        ['completed', 'failed', 'cancelled', 'awaiting_approval'].indexOf(req.body.status) !== -1) {
       core.emitEvent('workflow_' + req.body.status, who, wf.project_id || '',
         'workflow #' + wf.id + ' (' + wf.name + ') ' + req.body.status,
-        { workflow_id: wf.id, error: req.body.error });
+        { workflow_id: wf.id, error: req.body.error, approval_id: req.body.approval_id });
     }
     res.json({ ok: true, workflow: r.workflow });
   });

--- a/server/plugins/workflows/schema.sql
+++ b/server/plugins/workflows/schema.sql
@@ -8,14 +8,15 @@ CREATE TABLE IF NOT EXISTS workflows (
   shape        TEXT NOT NULL DEFAULT 'custom',     -- display label only (fanout|pipeline|repair|custom)
   spec         TEXT NOT NULL,                      -- JSON {invocations:[{id,agent,model,brief,deps}], params?:{}}
   project_id   TEXT,
-  status       TEXT NOT NULL DEFAULT 'pending',    -- pending|claimed|running|cancelling|completed|failed|cancelled
+  status       TEXT NOT NULL DEFAULT 'pending',    -- pending|claimed|running|awaiting_approval|cancelling|completed|failed|cancelled
   risk         TEXT,                               -- green|yellow|red (runner-computed at claim)
   requested_by TEXT NOT NULL DEFAULT '',
   claimed_by   TEXT,
   error        TEXT,
   created_at   TEXT DEFAULT (datetime('now')),
   started_at   TEXT,
-  finished_at  TEXT
+  finished_at  TEXT,
+  approval_id  INTEGER                              -- the approval this workflow is paused on (awaiting_approval)
 );
 
 CREATE TABLE IF NOT EXISTS workflow_invocations (

--- a/server/plugins/workflows/test.js
+++ b/server/plugins/workflows/test.js
@@ -216,6 +216,43 @@ test('invocation: result capped loudly, lifecycle stamps set', async function ()
   assert.equal(badStatus.status, 400);
 });
 
+// 5b. Invocation update emits workflow_invocation_finished/failed on terminal
+// status, nothing on non-terminal (live cockpit animation).
+test('invocation: terminal status emits event for live cockpit animation', async function () {
+  var wf = (await call('POST', '/workflows', FANOUT)).body.workflow;
+  emitted = []; // clear from create
+
+  // non-terminal (running) -> no emit
+  await call('PUT', '/workflows/' + wf.id + '/invocations/w0', { status: 'running' });
+  assert.equal(emitted.length, 0, 'running does not emit');
+
+  // completed -> workflow_invocation_finished
+  var fin = await call('PUT', '/workflows/' + wf.id + '/invocations/w0',
+    { status: 'completed', result: 'done' });
+  assert.equal(fin.status, 200);
+  var finishedEvt = emitted.find(function (e) { return e.type === 'workflow_invocation_finished'; });
+  assert.ok(finishedEvt, 'completed emits workflow_invocation_finished');
+  assert.equal(finishedEvt.data.workflow_id, wf.id);
+  assert.equal(finishedEvt.data.inv_id, 'w0');
+  assert.equal(finishedEvt.data.status, 'completed');
+
+  // failed -> workflow_invocation_failed
+  var fail = await call('PUT', '/workflows/' + wf.id + '/invocations/w1',
+    { status: 'failed', result: 'boom' });
+  assert.equal(fail.status, 200);
+  var failedEvt = emitted.find(function (e) { return e.type === 'workflow_invocation_failed'; });
+  assert.ok(failedEvt, 'failed emits workflow_invocation_failed');
+  assert.equal(failedEvt.data.inv_id, 'w1');
+  assert.equal(failedEvt.data.status, 'failed');
+
+  // skipped -> workflow_invocation_finished (same bucket as completed)
+  var skip = await call('PUT', '/workflows/' + wf.id + '/invocations/verify',
+    { status: 'skipped' });
+  assert.equal(skip.status, 200);
+  var skippedEvt = emitted.find(function (e) { return e.type === 'workflow_invocation_finished' && e.data.status === 'skipped'; });
+  assert.ok(skippedEvt, 'skipped emits workflow_invocation_finished');
+});
+
 // 6. Cancel: running -> cancelling (cooperative); runner marks cancelled; events flow.
 test('cancel: cooperative stop + event log', async function () {
   var wf = (await call('POST', '/workflows', FANOUT)).body.workflow;
@@ -240,6 +277,7 @@ test('cancel: cooperative stop + event log', async function () {
   assert.ok(kinds.includes('created'));
   assert.ok(kinds.includes('claimed'));
   assert.ok(kinds.includes('wave_started'));
+  assert.ok(kinds.includes('cancelling'), 'running->cancelling transition logged as event');
   assert.ok(kinds.includes('cancelled'));
 
   // pending workflows cancel immediately
@@ -275,4 +313,53 @@ test('validateInvocations: unit', function () {
   assert.match(validateInvocations([]), /non-empty/);
   assert.match(validateInvocations([{ id: 'a' }]), /agent/);
   assert.match(validateInvocations([{ id: 'a', agent: 'x', deps: 'w0' }]), /array/);
+});
+
+// (a) getWorkflowFull: event payloads come back as parsed objects, not escaped
+// JSON strings (events are stored JSON.stringify(payload) in addEvent).
+test('getWorkflowFull: event payloads parsed as objects', async function () {
+  var wf = (await call('POST', '/workflows', FANOUT)).body.workflow;
+  var full = (await call('GET', '/workflows/' + wf.id)).body;
+  var createdEvt = full.events.find(function (e) { return e.kind === 'created'; });
+  assert.ok(createdEvt, 'created event exists');
+  assert.equal(typeof createdEvt.payload, 'object', 'payload is parsed object, not string');
+  assert.notEqual(createdEvt.payload, null, 'payload is not null');
+  assert.equal(createdEvt.payload.name, wf.name, 'payload.name accessible');
+  assert.equal(typeof createdEvt.payload.invocations, 'number', 'payload.invocations is number');
+});
+
+// (b) The approval_id migration is idempotent and does not blanket-swallow
+// errors: PRAGMA-check first, ALTER only if the column is missing.
+test('migration: approval_id column added safely, idempotent on re-open', async function () {
+  var db2 = new Database(':memory:');
+  db2.exec(fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8'));
+  var dbApi = createWorkflowsDB(db2);
+  assert.ok(dbApi, 'createWorkflowsDB succeeds on fresh schema');
+  var cols = db2.prepare('PRAGMA table_info(workflows)').all();
+  assert.ok(cols.some(function (c) { return c.name === 'approval_id'; }), 'approval_id column present');
+  // Re-creating on the same DB must not throw (idempotent — no blanket ALTER).
+  var dbApi2 = createWorkflowsDB(db2);
+  assert.ok(dbApi2, 'createWorkflowsDB idempotent on existing column');
+});
+
+// (c) updateWorkflowStatus: terminal-state workflows reject ALL mutations,
+// including field-only updates (a PUT {risk:'red'} with no status used to
+// bypass the transition guard because newStatus was falsy).
+test('status: terminal workflow rejects field-only mutation', async function () {
+  var wf = (await call('POST', '/workflows', FANOUT)).body.workflow;
+  await call('POST', '/workflows/' + wf.id + '/claim', {});
+  await call('PUT', '/workflows/' + wf.id, { status: 'running' });
+  await call('PUT', '/workflows/' + wf.id, { status: 'completed' });
+
+  var mutate = await call('PUT', '/workflows/' + wf.id, { risk: 'red' });
+  assert.equal(mutate.status, 400);
+  assert.match(mutate.body.error, /terminal/);
+
+  var wf2 = (await call('POST', '/workflows', FANOUT)).body.workflow;
+  await call('POST', '/workflows/' + wf2.id + '/claim', {});
+  await call('PUT', '/workflows/' + wf2.id, { status: 'running' });
+  await call('PUT', '/workflows/' + wf2.id, { status: 'failed' });
+  var mutate2 = await call('PUT', '/workflows/' + wf2.id, { error: 'new error' });
+  assert.equal(mutate2.status, 400);
+  assert.match(mutate2.body.error, /terminal/);
 });

--- a/server/plugins/workflows/test.js
+++ b/server/plugins/workflows/test.js
@@ -169,6 +169,33 @@ test('status: transition guard', async function () {
   assert.equal(undead.status, 400);
 });
 
+// 4b. Approval gate: running -> awaiting_approval (linked to an approval) -> running.
+test('gate: running -> awaiting_approval (approval link) -> running, surfaced on the stream', async function () {
+  var wf = (await call('POST', '/workflows', FANOUT)).body.workflow;
+  await call('POST', '/workflows/' + wf.id + '/claim', {});
+  await call('PUT', '/workflows/' + wf.id, { status: 'running' });
+
+  // pause on a gate, linking the approval the workflow waits on
+  var pause = await call('PUT', '/workflows/' + wf.id, { status: 'awaiting_approval', approval_id: 42 });
+  assert.equal(pause.status, 200);
+  assert.equal(pause.body.workflow.status, 'awaiting_approval');
+  assert.equal(pause.body.workflow.approval_id, 42, 'approval link set on the workflow');
+  assert.ok(emitted.some(function (e) {
+    return e.type === 'workflow_awaiting_approval' && e.data && e.data.workflow_id === wf.id;
+  }), 'awaiting_approval surfaced on the stream so the app can prompt');
+
+  // a gate is not terminal: cannot jump straight to completed
+  var jump = await call('PUT', '/workflows/' + wf.id, { status: 'completed' });
+  assert.equal(jump.status, 400);
+
+  // resume on approve, then it can complete normally
+  var resume = await call('PUT', '/workflows/' + wf.id, { status: 'running' });
+  assert.equal(resume.status, 200);
+  assert.equal(resume.body.workflow.status, 'running');
+  var done = await call('PUT', '/workflows/' + wf.id, { status: 'completed' });
+  assert.equal(done.status, 200);
+});
+
 // 5. Result > 32000 chars stored capped with a LOUD truncation marker.
 test('invocation: result capped loudly, lifecycle stamps set', async function () {
   var wf = (await call('POST', '/workflows', FANOUT)).body.workflow;

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -203,8 +203,18 @@ function formatSavepointSummary(diff) {
 
 // ---- MCP Config Helpers ----
 function getInstanceUrl(req) {
-  var proto = req.get('x-forwarded-proto') || req.protocol || 'https';
+  // Tier 1: explicit operator override — always trusted, no header parsing.
+  if (process.env.PUBLIC_BASE_URL) return process.env.PUBLIC_BASE_URL.replace(/\/$/, '');
+  // Tier 2: allowlist gate — if set, the Host header must match an entry.
   var host = req.get('host');
+  var allowed = (process.env.ALLOWED_HOSTS || '').split(',').map(function(s){return s.trim();}).filter(Boolean);
+  if (allowed.length) {
+    if (!allowed.includes(host)) {
+      throw new Error('Host not allowed: ' + host);
+    }
+  }
+  // Tier 3: legacy fallback — current behavior when neither env var is set.
+  var proto = req.get('x-forwarded-proto') || req.protocol || 'https';
   return proto + '://' + host;
 }
 
@@ -3858,7 +3868,12 @@ router.post('/admin/agents', adminWriteLimiter, asyncHandler(async function (req
     addChannelMember(generalChannel.id, id, 'agent', 'member');
   }
   emitEvent('agent_registered', '__admin__', null, 'Admin registered agent: ' + id);
-  var instanceUrl = getInstanceUrl(req);
+  var instanceUrl;
+  try {
+    instanceUrl = getInstanceUrl(req);
+  } catch (e) {
+    return res.status(400).json({ error: 'Invalid Host header: ' + e.message });
+  }
   var mcpConfig = buildMcpConfig(id, apiKey, instanceUrl);
   res.json({ id: id, api_key: apiKey, mcp_config: mcpConfig, message: 'Store this key — it will not be shown again. MCP config included for agent setup.' });
 }));
@@ -3905,7 +3920,12 @@ router.get('/agents/:id/mcp-config', asyncHandler(function (req, res) {
   if (!checkAdmin(req, res)) return;
   var agent = getAgent(req.params.id);
   if (!agent) return res.status(404).json({ error: 'Agent not found' });
-  var instanceUrl = getInstanceUrl(req);
+  var instanceUrl;
+  try {
+    instanceUrl = getInstanceUrl(req);
+  } catch (e) {
+    return res.status(400).json({ error: 'Invalid Host header: ' + e.message });
+  }
   var config = buildMcpConfig(req.params.id, '<YOUR_AGENT_API_KEY>', instanceUrl);
   res.json({ agent_id: req.params.id, mcp_config: config, note: 'Replace <YOUR_AGENT_API_KEY> with the agent\'s actual API key' });
 }));
@@ -5679,9 +5699,31 @@ router.get('/plugins/workers', asyncHandler(function (req, res) {
 }));
 
 // ---- Marketplace ----
+//
+// SECURITY: the plugin registry is PINNED to a specific commit SHA, never a
+// moving branch (main/master/HEAD). A moving ref would let a compromised branch
+// on SoftBacon-Software/mycelium-plugins push arbitrary plugin manifests to
+// every install. BUMP PROCEDURE:
+//   1. Get the target HEAD SHA:
+//        git ls-remote https://github.com/SoftBacon-Software/mycelium-plugins.git refs/heads/main
+//   2. Review the compare diff before trusting the new commit:
+//        https://github.com/SoftBacon-Software/mycelium-plugins/compare/<OLD_SHA>...<NEW_SHA>
+//   3. Update REGISTRY_COMMIT below to the new 40-char SHA.
+// TODO(registry-pin): REGISTRY_COMMIT below is a PLACEHOLDER (Git's null SHA),
+// NOT a real commit pin. Replace it with the live HEAD SHA from step 1 before
+// deploy. The squad executor (Lucy) cannot run git/network per CONTRACT.md, so
+// the live SHA was not fetched here; do NOT ship this value. The load-time guard
+// + tests (test/unit/registry-commit-pin.test.js) validate the pinning mechanism
+// for any valid 40-char SHA, so substituting the real SHA keeps everything green.
+var REGISTRY_COMMIT = '0000000000000000000000000000000000000000';
+var REGISTRY_URL = 'https://raw.githubusercontent.com/SoftBacon-Software/mycelium-plugins/' + REGISTRY_COMMIT + '/registry.json';
+// Fail fast at module load if REGISTRY_URL is ever moved back to a moving ref.
+if (!/[0-9a-f]{40}/.test(REGISTRY_URL)) {
+  throw new Error('REGISTRY_URL must be commit-pinned to a 40-char hex SHA; got: ' + REGISTRY_URL);
+}
+export { REGISTRY_COMMIT, REGISTRY_URL };
 
 var registryCache = { data: null, fetched: 0 };
-var REGISTRY_URL = 'https://raw.githubusercontent.com/SoftBacon-Software/mycelium-plugins/main/registry.json';
 var REGISTRY_TTL = 3600000; // 1 hour
 
 router.get('/plugins/registry', asyncHandler(function (req, res) {

--- a/test/unit/boot-env-validation.test.js
+++ b/test/unit/boot-env-validation.test.js
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'vitest'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..', '..')
+
+describe('boot env validation', () => {
+  test('server exits non-zero with FATAL on stderr when ADMIN_KEY + JWT_SECRET are unset', () => {
+    // Inherit the host env but explicitly strip the two required secrets so the
+    // child hits the startup-validation guard regardless of the test runner's env.
+    const env = { ...process.env }
+    delete env.ADMIN_KEY
+    delete env.JWT_SECRET
+
+    const result = spawnSync('node', ['server/index.js'], {
+      cwd: repoRoot,
+      env,
+      timeout: 15000,
+      encoding: 'utf8'
+    })
+
+    // The process must terminate (not be killed by the timeout).
+    expect(result.status, 'server should exit on its own, not time out').not.toBeNull()
+    // Non-zero exit code.
+    expect(result.status).not.toBe(0)
+    // The FATAL guard message must appear on stderr.
+    expect(result.stderr, 'stderr should contain the FATAL message').toContain('FATAL')
+  })
+})

--- a/test/unit/host-header-hardening.test.js
+++ b/test/unit/host-header-hardening.test.js
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+const JWT_SECRET = 'test-jwt-secret'
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const AGENT_KEY = 'dvk_' + 'a'.repeat(48)
+
+let tmpDataDir
+let db
+let app
+
+function jwtFor(role, displayName) {
+  return jwt.sign(
+    { studioUser: true, userId: 999, username: displayName.toLowerCase(), displayName, role },
+    JWT_SECRET,
+    { expiresIn: '1h' }
+  )
+}
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-host-hardening-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+  process.env.JWT_SECRET = JWT_SECRET
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  const routes = (await import('../../server/routes/mycelium.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routes)
+
+  const hash = crypto.createHash('sha256').update(AGENT_KEY).digest('hex')
+  db.createAgent('lucy-test', 'Lucy Test', 'host-proj', hash, '["code"]')
+})
+
+afterAll(() => {
+  // Clean up env vars so other test files aren't affected
+  delete process.env.PUBLIC_BASE_URL
+  delete process.env.ALLOWED_HOSTS
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+describe('getInstanceUrl — host-header hardening', { timeout: 10000 }, () => {
+  // Helper: pull the resolved instance URL out of the mcp-config response body.
+  function instanceUrlFrom(res) {
+    return res.body.mcp_config.mcpServers.mycelium.env.MYCELIUM_URL
+  }
+
+  // (a) PUBLIC_BASE_URL set + evil Host -> returns PUBLIC_BASE_URL (trailing slash normalized)
+  test('PUBLIC_BASE_URL overrides any Host header, trailing slash normalized', async () => {
+    process.env.PUBLIC_BASE_URL = 'https://mycelium.example.com/'
+    delete process.env.ALLOWED_HOSTS
+    const res = await request(app)
+      .get('/api/mycelium/agents/lucy-test/mcp-config')
+      .set('Authorization', 'Bearer ' + jwtFor('admin', 'Greatness'))
+      .set('Host', 'evil.attacker.com')
+    expect(res.status).toBe(200)
+    const url = instanceUrlFrom(res)
+    expect(url).toContain('https://mycelium.example.com')
+    expect(url).not.toContain('evil.attacker.com')
+  })
+
+  // (b) ALLOWED_HOSTS set + allowed Host -> returns it
+  test('ALLOWED_HOSTS accepts a permitted Host header', async () => {
+    delete process.env.PUBLIC_BASE_URL
+    process.env.ALLOWED_HOSTS = 'mycelium.example.com,localhost:3002'
+    const res = await request(app)
+      .get('/api/mycelium/agents/lucy-test/mcp-config')
+      .set('Authorization', 'Bearer ' + jwtFor('admin', 'Greatness'))
+      .set('Host', 'mycelium.example.com')
+    expect(res.status).toBe(200)
+    expect(instanceUrlFrom(res)).toContain('mycelium.example.com')
+  })
+
+  // (c) ALLOWED_HOSTS set + evil Host -> throws (never reflects the evil host)
+  test('ALLOWED_HOSTS rejects an unauthorized Host header with 400', async () => {
+    delete process.env.PUBLIC_BASE_URL
+    process.env.ALLOWED_HOSTS = 'mycelium.example.com'
+    const res = await request(app)
+      .get('/api/mycelium/agents/lucy-test/mcp-config')
+      .set('Authorization', 'Bearer ' + jwtFor('admin', 'Greatness'))
+      .set('Host', 'evil.attacker.com')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Host not allowed/i)
+  })
+
+  // (d) neither set -> current behavior (legacy fallback trusts the Host header)
+  test('no PUBLIC_BASE_URL or ALLOWED_HOSTS: falls back to Host header (legacy)', async () => {
+    delete process.env.PUBLIC_BASE_URL
+    delete process.env.ALLOWED_HOSTS
+    const res = await request(app)
+      .get('/api/mycelium/agents/lucy-test/mcp-config')
+      .set('Authorization', 'Bearer ' + jwtFor('admin', 'Greatness'))
+      .set('Host', 'localhost:3002')
+    expect(res.status).toBe(200)
+    expect(instanceUrlFrom(res)).toContain('localhost:3002')
+  })
+})

--- a/test/unit/registry-commit-pin.test.js
+++ b/test/unit/registry-commit-pin.test.js
@@ -1,0 +1,72 @@
+import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import express from 'express'
+import request from 'supertest'
+
+// Security regression: the plugin registry URL MUST be pinned to a specific
+// commit SHA, never a moving branch (main/master/HEAD). Otherwise a compromised
+// branch on SoftBacon-Software/mycelium-plugins could push arbitrary plugin
+// manifests to every install. These tests pin that contract.
+//
+// Harness mirrors test/unit/auth-roles.test.js: real router, fresh temp DB, env
+// set before the dynamic import; pool:'forks' isolates us.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const JWT_SECRET = 'test-jwt-secret'
+
+let tmpDataDir
+let db
+let app
+let REGISTRY_URL
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-registry-pin-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+  process.env.JWT_SECRET = JWT_SECRET
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  const routesMod = await import('../../server/routes/mycelium.js')
+  REGISTRY_URL = routesMod.REGISTRY_URL
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routesMod.default)
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+describe('plugin registry commit-pinning', () => {
+  test('REGISTRY_URL is pinned to a 40-char commit SHA, not a moving branch', () => {
+    // Must contain a 40-char lowercase-hex commit SHA path segment ...
+    expect(REGISTRY_URL).toMatch(/\/[0-9a-f]{40}\//)
+    // ... and must NOT point at a moving ref.
+    expect(REGISTRY_URL).not.toMatch(/\/(main|master|HEAD)\//)
+  })
+
+  test('registry refresh fetches the pinned commit URL (not a moving branch)', async () => {
+    const fetched = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ plugins: [] }),
+    }))
+    const origFetch = globalThis.fetch
+    globalThis.fetch = fetched
+    try {
+      const res = await request(app)
+        .get('/api/mycelium/plugins/registry')
+        .set('X-Admin-Key', ADMIN_KEY)
+        .set('X-Acting-As', 'admin')
+      expect(res.status).toBe(200)
+      expect(fetched).toHaveBeenCalled()
+      // The URL handed to fetch must be the pinned commit URL, verbatim.
+      expect(fetched).toHaveBeenCalledWith(REGISTRY_URL)
+    } finally {
+      globalThis.fetch = origFetch
+    }
+  })
+})

--- a/test/unit/residency.test.js
+++ b/test/unit/residency.test.js
@@ -1,0 +1,213 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
+
+import createResidencyDB from '../../server/plugins/residency/db.js';
+import { decideResidency, estimateRss, modelRssLookup } from '../../server/plugins/residency/src/policy.js';
+import { createResidencyPlugin } from '../../server/plugins/residency/src/index.js';
+
+// ---------------------------------------------------------------------------
+// 1. Schema creation + insert/query of nodes, models, routes
+// ---------------------------------------------------------------------------
+describe('residency db — schema + CRUD', () => {
+  let db, store;
+  beforeEach(() => {
+    db = new Database(':memory:');
+    store = createResidencyDB(db);
+  });
+  afterEach(() => db.close());
+
+  test('creates the three tables and round-trips a node', () => {
+    const node = store.upsertNode({
+      node_id: 'mac',
+      ram_total_gb: 128,
+      ram_budget_gb: 120,
+      actuator_kind: 'omlx',
+      actuator_url: 'http://localhost:8080'
+    });
+    expect(node.node_id).toBe('mac');
+    const nodes = store.listNodes();
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]).toMatchObject({ node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 120 });
+    expect(nodes[0].updated_at).toBeTruthy();
+  });
+
+  test('upsertNode updates an existing node in place', () => {
+    store.upsertNode({ node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 120 });
+    store.upsertNode({ node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 96 });
+    expect(store.getNode('mac').ram_budget_gb).toBe(96);
+    expect(store.listNodes()).toHaveLength(1);
+  });
+
+  test('inserts/queries resident models for a node', () => {
+    store.upsertNode({ node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 120 });
+    store.upsertModel({
+      node_id: 'mac', model_id: 'ds4', backend: 'omlx',
+      kind: 'local', state: 'resident', rss_gb: 80
+    });
+    store.upsertModel({
+      node_id: 'mac', model_id: 'gpt-4o', backend: 'openai',
+      kind: 'api', state: 'resident', rss_gb: 0
+    });
+    const models = store.listModelsForNode('mac');
+    expect(models).toHaveLength(2);
+    expect(models.map((m) => m.model_id).sort()).toEqual(['ds4', 'gpt-4o']);
+    // CHECK constraints reject bad enum values.
+    expect(() =>
+      store.upsertModel({ node_id: 'mac', model_id: 'x', backend: 'b', kind: 'bogus', state: 'resident' })
+    ).toThrow();
+    expect(() =>
+      store.upsertModel({ node_id: 'mac', model_id: 'x', backend: 'b', kind: 'local', state: 'bogus' })
+    ).toThrow();
+  });
+
+  test('inserts/queries seat routes and getMap aggregates everything', () => {
+    store.upsertNode({ node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 120 });
+    store.upsertModel({
+      node_id: 'mac', model_id: 'ds4', backend: 'omlx',
+      kind: 'local', state: 'resident', rss_gb: 80
+    });
+    store.upsertRoute({ seat: 'lucy', backend: 'omlx', kind: 'local', mode_pref: 'local-first' });
+
+    const map = store.getMap();
+    expect(map.nodes).toHaveLength(1);
+    expect(map.nodes[0].resident_set).toHaveLength(1);
+    expect(map.nodes[0].resident_set[0].model_id).toBe('ds4');
+    expect(map.seat_routes).toHaveLength(1);
+    expect(map.seat_routes[0]).toMatchObject({ seat: 'lucy', backend: 'omlx', kind: 'local' });
+  });
+
+  test('removeNode cascades its resident models', () => {
+    store.upsertNode({ node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 120 });
+    store.upsertModel({ node_id: 'mac', model_id: 'ds4', backend: 'omlx', kind: 'local', state: 'resident', rss_gb: 80 });
+    expect(store.removeNode('mac')).toBe(1);
+    expect(store.listModelsForNode('mac')).toHaveLength(0);
+    expect(store.getNode('mac')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. GET /api/mycelium/residency returns the correct JSON shape
+// ---------------------------------------------------------------------------
+describe('residency plugin — GET map handler', () => {
+  let plugin, tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'residency-'));
+    plugin = createResidencyPlugin(path.join(tmpDir, 'residency.db'));
+    plugin.init();
+    const store = plugin.getStore();
+    store.upsertNode({
+      node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 120,
+      actuator_kind: 'omlx', actuator_url: 'http://localhost:8080'
+    });
+    store.upsertModel({
+      node_id: 'mac', model_id: 'ds4', backend: 'omlx',
+      kind: 'local', state: 'resident', rss_gb: 80
+    });
+    store.upsertRoute({ seat: 'lucy', backend: 'omlx', kind: 'local', mode_pref: 'local-first' });
+  });
+
+  afterEach(() => {
+    plugin.cleanup();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('factory exposes a single GET route at the spec path', () => {
+    expect(plugin.name).toBe('residency');
+    expect(plugin.version).toBe('0.1.0');
+    const gets = plugin.routes.filter((r) => r.method === 'GET');
+    expect(gets).toHaveLength(1);
+    expect(gets[0].path).toBe('/api/mycelium/residency');
+  });
+
+  test('handler returns the live map in the documented shape', () => {
+    const route = plugin.routes.find((r) => r.method === 'GET');
+    const body = route.handler({});
+
+    expect(body.ok).toBe(true);
+    expect(body.residency.nodes).toHaveLength(1);
+
+    const node = body.residency.nodes[0];
+    expect(node).toMatchObject({
+      node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 120,
+      actuator_kind: 'omlx', actuator_url: 'http://localhost:8080'
+    });
+    expect(node.updated_at).toBeTruthy();
+    expect(node.resident_set).toHaveLength(1);
+    expect(node.resident_set[0]).toMatchObject({
+      model_id: 'ds4', backend: 'omlx', kind: 'local', state: 'resident', rss_gb: 80
+    });
+
+    expect(body.residency.seat_routes[0]).toMatchObject({
+      seat: 'lucy', backend: 'omlx', kind: 'local', mode_pref: 'local-first'
+    });
+  });
+
+  test('handler throws cleanly before init()', () => {
+    const uninit = createResidencyPlugin(path.join(tmpDir, 'x.db'));
+    const route = uninit.routes.find((r) => r.method === 'GET');
+    expect(() => route.handler({})).toThrow(/not initialised/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Policy: co-reside vs swap
+// ---------------------------------------------------------------------------
+describe('residency policy — decideResidency', () => {
+  test('co-reside when ds4 + squad fits a 120GB budget', () => {
+    // node currently has ds4 resident (80GB); squad-glm (27GB) requested.
+    const d = decideResidency(
+      [{ model_id: 'ds4', kind: 'local' }],
+      { model_id: 'squad-glm', kind: 'local' },
+      120
+    );
+    expect(d.action).toBe('co-reside');
+    expect(d.total_gb).toBe(107); // 80 + 27
+    expect(d.reason).toMatch(/co-reside/);
+  });
+
+  test('swap when ds4 + squad + Lucy exceeds a 120GB budget', () => {
+    // resident set is ds4 (80) + squad-glm (27) = 107; Lucy-30B (30) requested.
+    const d = decideResidency(
+      [{ model_id: 'ds4', kind: 'local' }, { model_id: 'squad-glm', kind: 'local' }],
+      { model_id: 'oMLX-Lucy-30B', kind: 'local' },
+      120
+    );
+    expect(d.action).toBe('swap');
+    expect(d.total_gb).toBe(137); // 80 + 27 + 30
+    expect(d.reason).toMatch(/evict/);
+  });
+
+  test('api models cost 0 RAM and co-reside freely', () => {
+    expect(estimateRss({ model_id: 'gpt-4o', kind: 'api' })).toBe(0);
+    const d = decideResidency(
+      [{ model_id: 'ds4', kind: 'local' }],
+      { model_id: 'gpt-4o', kind: 'api' },
+      80
+    );
+    expect(d.action).toBe('co-reside');
+    expect(d.total_gb).toBe(80); // 80 + 0, fits exactly
+  });
+
+  test('unknown local model falls back to default-local (8GB)', () => {
+    expect(estimateRss({ model_id: 'mystery-7b', kind: 'local' })).toBe(8);
+  });
+
+  test('explicit rss_gb overrides the lookup table', () => {
+    expect(estimateRss({ model_id: 'ds4', kind: 'local', rss_gb: 42 })).toBe(42);
+  });
+
+  test('invalid budget is fail-closed to swap', () => {
+    const d = decideResidency([], { model_id: 'ds4', kind: 'local' }, NaN);
+    expect(d.action).toBe('swap');
+  });
+
+  test('modelRssLookup has the spec defaults', () => {
+    expect(modelRssLookup).toMatchObject({
+      ds4: 80, 'squad-glm': 27, 'oMLX-Lucy-30B': 30, 'default-local': 8, 'default-api': 0
+    });
+  });
+});


### PR DESCRIPTION
## Squad batch — GLM-audit hardening + residency plugin + security fixes

Built by the local squad (Ada plans → GLM-as-Lucy codes → Echo verifies) from GLM-5.2 audits of the mycelium subsystems, byte-reviewed by m5Max, tests green on every unit.

### What's in it
- **Residency plugin** (P1, new): resource/residency state model, `GET /residency`, co-reside/swap policy — the federation-wide "what's-where + will-it-fit" scheduler. **15/15**
- **Workflows plugin hardening** (5 bugs): emit-on-invocation-update (**CRITICAL** — the app never received terminal invocation events), cancelling-event log, event-payload JSON-parse, PRAGMA-checked migration (no blanket error-swallow), terminal-state mutation guard. **15/15**
- **SDK `agent.stop()` infinite hang** (**CRITICAL**): `clearTimeout` cancelled the poll-pause promise's timer so `resolve` never fired → the loop hung and leaked the event loop. `stop()` now resolves it explicitly. + regression test.
- **Semantic-memory correctness** (3× P0): per-instance vec flag (was a process-wide singleton), `chunk_index: 0` handling (falsy-0), `updateEmbedding` stores SQL NULL not the string `"null"` (backfill data-loss). **23/23**
- **Host-header hardening**: `getInstanceUrl` 3-tier (`PUBLIC_BASE_URL` → `ALLOWED_HOSTS` allowlist → legacy); callers 400 on a bad Host. + boot-env-validation + registry-commit-pin tests. **7/7**

### Deliberately NOT included
- The semantic-memory **`PUT /memory/config` credential-leak** fix (held for separate security review). Note: this substrate uses local ollama embeddings, so there is no key to leak on our instance.

### Branch commits
```
ca35895 squad batch: GLM-audit hardening + residency plugin + security fixes
0197af3 feat(appointments): role->appointment storage plugin (Task 3, role-registry foundation)
cb04a42 workflows: human approval-gate (awaiting_approval status + resume link)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
