### PR TITLE
security: redact embedding_api_key on PUT /memory/config

### DIFF
--- a/server/plugins/semantic-memory/routes.js
+++ b/server/plugins/semantic-memory/routes.js
@@ -200,7 +200,12 @@ export default function (core) {
         db.setConfig(key, String(req.body[key]));
       }
     }
-    res.json({ ok: true, config: db.getAllConfig() });
+    // Mirror GET /config: strip the API key from the response. getAllConfig()
+    // builds a fresh object each call (stored state lives in sm_config), so
+    // delete here never touches what's persisted.
+    var config = db.getAllConfig();
+    delete config.embedding_api_key;
+    res.json({ ok: true, config: config });
   });
 
   // Oversized NULL-embedding rows can never embed whole — the provider

--- a/server/plugins/semantic-memory/test.js
+++ b/server/plugins/semantic-memory/test.js
@@ -199,6 +199,36 @@ test('config: plugin_config fallback merges under sm_config', function () {
   assert.equal(mem.getConfig('embedding_model'), 'nomic-embed-text');
 });
 
+// Redaction guard: PUT /memory/config must not echo the embedding API key
+// back in its response body — mirrors the GET handler's redaction.
+test('routes: PUT /memory/config response does NOT leak embedding_api_key', async function () {
+  // Set a fake API key in config
+  mem.setConfig('embedding_api_key', 'sk-fake-test-key-12345');
+  assert.strictEqual(mem.getConfig('embedding_api_key'), 'sk-fake-test-key-12345', 'key is stored');
+
+  // PUT config — update another field. NOTE: we restore embedding_provider
+  // below; leaving it as 'openai' would re-route downstream embedding tests
+  // off the hermetic Ollama fetch-patch and break them (shared in-memory DB).
+  var prevProvider = mem.getConfig('embedding_provider');
+  var r = await call('PUT', '/memory/config', { embedding_provider: 'openai' });
+  assert.equal(r.status, 200);
+  assert.ok(r.body.config, 'response contains config object');
+
+  // The critical assertion: API key must NOT be in the response
+  assert.strictEqual(r.body.config.embedding_api_key, undefined, 'embedding_api_key redacted from PUT response');
+
+  // Verify the key is still persisted (we only redact the response, not the stored value)
+  assert.strictEqual(mem.getConfig('embedding_api_key'), 'sk-fake-test-key-12345', 'key still persisted');
+
+  // Also verify GET still redacts (regression guard)
+  var g = await call('GET', '/memory/config');
+  assert.strictEqual(g.body.embedding_api_key, undefined, 'embedding_api_key redacted from GET response');
+
+  // Teardown: restore the provider so we don't pollute the shared DB for
+  // later embedding tests.
+  mem.setConfig('embedding_provider', prevProvider);
+});
+
 // #191: concept_created carries no data payload — the handler resolves the
 // concept from the summary + concepts table, indexes it, and embeds it.
 test('handler: concept_created indexes + embeds the concept', async function () {


### PR DESCRIPTION
## Redact `embedding_api_key` on PUT /memory/config (security)

`GET /memory/config` already strips the embedding-provider API key before responding; `PUT /memory/config` returned it **raw**, leaking the credential into the response body (logs, browser devtools, proxy captures) on every config write.

**Fix:** mirror GET's redaction on the PUT path. Persisted config is untouched — `getAllConfig()` builds a fresh object each call, so the delete only affects the response.

**Test** (semantic-memory suite, 24/24): asserts the key is absent from the PUT response, still persisted in `sm_config`, and that GET still redacts (regression guard).

Found by a GLM-5.2 audit of the semantic-memory plugin; built by the local squad, byte-reviewed by m5Max. This substrate uses local ollama embeddings (no key to leak on our own instance) — this protects any deployment using a hosted embedding provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
