### PR TITLE
reliability(sdk): heartbeat / orphaned tasks / request timeout

### DIFF
--- a/sdk/src/agent.js
+++ b/sdk/src/agent.js
@@ -366,12 +366,23 @@ export class MyceliumAgent {
     if (this._running) return
     this._running = true
 
-    // Start heartbeat
-    this._heartbeatTimer = setInterval(() => {
-      this.heartbeat().catch(err => {
+    // Start heartbeat — self-rescheduling so a slow beat never overlaps the
+    // next one. setInterval fires on a fixed cadence regardless of whether the
+    // previous async beat has settled, which stampedes the server when latency
+    // exceeds the interval. The next beat is scheduled only after this one
+    // settles (resolve or reject); clearTimeout in stop() cancels any pending.
+    const heartbeatLoop = async () => {
+      try {
+        await this.heartbeat()
+      } catch (err) {
         console.error('[mycelium] heartbeat error:', err.message)
-      })
-    }, this.heartbeatInterval)
+      } finally {
+        if (this._running) {
+          this._heartbeatTimer = setTimeout(heartbeatLoop, this.heartbeatInterval)
+        }
+      }
+    }
+    this._heartbeatTimer = setTimeout(heartbeatLoop, this.heartbeatInterval)
 
     // Start work polling
     if (this._workHandler || this._idleHandler) {
@@ -385,7 +396,7 @@ export class MyceliumAgent {
 
   async stop() {
     this._running = false
-    if (this._heartbeatTimer) clearInterval(this._heartbeatTimer)
+    if (this._heartbeatTimer) clearTimeout(this._heartbeatTimer)
     if (this._pollTimer) clearTimeout(this._pollTimer)
     if (this._pollResolve) {
       this._pollResolve()
@@ -425,6 +436,23 @@ export class MyceliumAgent {
               }
             } catch (err) {
               console.error('[mycelium] work handler error:', err.message)
+              // Report the failure to the server so the task is not orphaned in
+              // in_progress. Only task-typed items have a server-side status to
+              // transition (messages/requests/directives are not tasks); 'failed'
+              // is not a valid status, so we use 'cancelled' with a note carrying
+              // the error — returning the task to a re-claimable state.
+              var itemType = item.type || item.msg_type
+              var isTask = item.id && itemType !== 'message' && itemType !== 'request' && itemType !== 'directive'
+              if (isTask) {
+                try {
+                  await this.updateTask(item.id, {
+                    status: 'cancelled',
+                    notes: 'Handler error: ' + err.message
+                  })
+                } catch (reportErr) {
+                  console.error('[mycelium] failed to report task error:', reportErr.message)
+                }
+              }
             }
             this.workingOn = ''
           } else if (this._idleHandler) {

--- a/sdk/src/api.js
+++ b/sdk/src/api.js
@@ -6,6 +6,11 @@ export function createClient(opts) {
   var apiKey = opts.apiKey
   var role = opts.role || 'agent'
   var agentId = opts.agentId || ''
+  // Configurable request timeout. Every Mycelium endpoint is an immediate REST
+  // call (GET /work/:agentId returns at once — it does NOT long-poll), so a
+  // uniform default is safe and catches hung/dropped connections instead of
+  // leaving the agent wedged on a fetch that never settles.
+  var defaultTimeout = opts.timeout || 30000
 
   function headers() {
     var h = {}
@@ -26,6 +31,10 @@ export function createClient(opts) {
       h['Content-Type'] = 'application/json'
       fetchOpts.body = JSON.stringify(body)
     }
+    // Abort a hung/dropped connection after the configured timeout instead of
+    // pending forever. AbortSignal.timeout is available on Node >= 17.3
+    // (this SDK requires >= 20).
+    fetchOpts.signal = AbortSignal.timeout(defaultTimeout)
     var res = await fetch(url, fetchOpts)
     var text = await res.text()
     var data

--- a/sdk/test/api_timeout.test.js
+++ b/sdk/test/api_timeout.test.js
@@ -1,0 +1,87 @@
+// Fix under test: request()'s fetch() had no timeout, so a hung/dropped backend
+// connection left the promise pending forever (zombie agent, stalled loops).
+// The fix attaches AbortSignal.timeout(defaultTimeout) so a hung request aborts.
+// defaultTimeout is configurable via the client's `timeout` option (default 30s).
+//
+// Run:  node --test sdk/test/api_timeout.test.js
+
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { createClient } from '../src/api.js'
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+test('a hung request aborts after the configured timeout, not forever', async () => {
+  const realFetch = globalThis.fetch
+  // Hung connection that rejects only when the abort signal fires — mirroring
+  // how a real fetch rejects when AbortSignal.timeout elapses.
+  globalThis.fetch = (url, opts = {}) => new Promise((_, reject) => {
+    const signal = opts.signal
+    if (!signal) return // never resolves (defensive; we always pass a signal)
+    if (signal.aborted) {
+      const e = new Error('The operation timed out'); e.name = 'TimeoutError'; return reject(e)
+    }
+    signal.addEventListener('abort', () => {
+      const e = new Error('The operation timed out'); e.name = 'TimeoutError'; reject(e)
+    })
+  })
+
+  try {
+    const api = createClient({
+      apiUrl: 'http://localhost:9/api/mycelium',
+      apiKey: 'x',
+      timeout: 50
+    })
+
+    const start = Date.now()
+    await assert.rejects(
+      () => api.get('/test'),
+      (err) => err.name === 'TimeoutError' || /timeout|abort/i.test(err.message)
+    )
+    const elapsed = Date.now() - start
+
+    assert.ok(elapsed < 1000, `request should abort quickly, took ${elapsed}ms`)
+  } finally {
+    globalThis.fetch = realFetch
+  }
+})
+
+test('default 30s timeout is used when not overridden', async () => {
+  const realFetch = globalThis.fetch
+  const realTimeout = AbortSignal.timeout
+  // Capture the timeout the client requested WITHOUT arming a real 30s timer
+  // (which would keep the test process alive for 30s). Return a benign signal.
+  let requestedMs = null
+  AbortSignal.timeout = (ms) => { requestedMs = ms; return new AbortController().signal }
+  globalThis.fetch = () => Promise.resolve(new Response('{}', { status: 200 }))
+
+  try {
+    const api = createClient({ apiUrl: 'http://localhost:9/api/mycelium', apiKey: 'x' })
+    await api.get('/test')
+    assert.strictEqual(requestedMs, 30000, 'default timeout should be 30000ms')
+  } finally {
+    globalThis.fetch = realFetch
+    AbortSignal.timeout = realTimeout
+  }
+})
+
+test('constructor timeout override is respected', async () => {
+  const realFetch = globalThis.fetch
+  const realTimeout = AbortSignal.timeout
+  let requestedMs = null
+  AbortSignal.timeout = (ms) => { requestedMs = ms; return new AbortController().signal }
+  globalThis.fetch = () => Promise.resolve(new Response('{}', { status: 200 }))
+
+  try {
+    const api = createClient({
+      apiUrl: 'http://localhost:9/api/mycelium',
+      apiKey: 'x',
+      timeout: 5000
+    })
+    await api.get('/test')
+    assert.strictEqual(requestedMs, 5000, 'constructor timeout override should be used')
+  } finally {
+    globalThis.fetch = realFetch
+    AbortSignal.timeout = realTimeout
+  }
+})

--- a/sdk/test/heartbeat_no_overlap.test.js
+++ b/sdk/test/heartbeat_no_overlap.test.js
@@ -1,0 +1,54 @@
+// Fix under test: start() used setInterval for heartbeats. setInterval fires on
+// a fixed cadence regardless of whether the previous async beat has settled, so
+// when server latency exceeds the interval multiple heartbeats overlap (stampede).
+// The fix reschedules the next beat only after the current one settles, so at
+// most one heartbeat is ever in flight.
+//
+// Run:  node --test sdk/test/heartbeat_no_overlap.test.js
+
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { MyceliumAgent } from '../src/agent.js'
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+test('heartbeats do not overlap when a beat takes longer than the interval', async () => {
+  const agent = new MyceliumAgent({
+    agentId: 'test-agent',
+    apiUrl: 'http://localhost:9/api/mycelium',
+    apiKey: 'test-key',
+    heartbeatInterval: 50,    // very short cadence
+    pollInterval: 600000      // not exercised — no work handler registered
+  })
+
+  // No network. stop() issues a final api.post heartbeat, so stub the client.
+  agent.api = {
+    get: async () => ({}),
+    post: async () => ({}),
+    put: async () => ({}),
+    del: async () => ({})
+  }
+
+  // Slow heartbeat: each beat takes 80ms — LONGER than the 50ms interval. With
+  // the old setInterval this would fire ~5 times in 250ms (overlapping beats);
+  // with the self-rescheduling fix beats are serial.
+  let beats = 0
+  agent.heartbeat = async () => {
+    beats++
+    await sleep(80)
+  }
+
+  agent.start()
+  await sleep(250)
+  await agent.stop()
+
+  // Fixed (self-rescheduling): ~2 beats in the window — first starts at ~50ms,
+  // settles at ~130ms, the next is scheduled at +50ms = ~180ms. The old
+  // setInterval would have fired ~5. The wide ceiling avoids timing flakiness
+  // while still proving no stampede.
+  assert.ok(beats >= 1, `expected at least one heartbeat, got ${beats}`)
+  assert.ok(
+    beats <= 3,
+    `heartbeats overlapped — ${beats} beats fired in 250ms with an 80ms beat (the bug)`
+  )
+})

--- a/sdk/test/orphaned_task_failure.test.js
+++ b/sdk/test/orphaned_task_failure.test.js
@@ -1,0 +1,50 @@
+// Fix under test: when the work handler threw, _startWorkLoop only logged and
+// reset workingOn, leaving the server-side task stranded in in_progress forever
+// (an orphan). The fix reports the failure via updateTask so the task transitions
+// out of in_progress. 'failed' is not a valid server status, so it uses
+// 'cancelled' with a note carrying the error.
+//
+// Run:  node --test sdk/test/orphaned_task_failure.test.js
+
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { MyceliumAgent } from '../src/agent.js'
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+test('a throwing work handler reports the task as cancelled, not orphaned', async () => {
+  const agent = new MyceliumAgent({
+    agentId: 'test-agent',
+    apiUrl: 'http://localhost:9/api/mycelium',
+    apiKey: 'test-key',
+    pollInterval: 50,
+    heartbeatInterval: 600000   // not exercised
+  })
+
+  const puts = []
+  agent.api = {
+    // The work queue hands back a claimed task item.
+    get: async () => ({ claimed: { id: 42, type: 'task', title: 'do the thing' } }),
+    post: async () => ({}),
+    put: async (path, body) => { puts.push({ path, body }); return {} },
+    del: async () => ({})
+  }
+
+  // The handler throws on every item.
+  agent.onWork(async () => { throw new Error('boom') })
+
+  agent.start()
+  // First loop iteration runs immediately: claim → throw → report. 120ms is
+  // plenty for one full cycle to complete and reset workingOn.
+  await sleep(120)
+  await agent.stop()
+
+  const report = puts.find((p) => p.path === '/tasks/42')
+  assert.ok(
+    report,
+    'updateTask was never called for the failed task — it was orphaned in in_progress (the bug)'
+  )
+  assert.strictEqual(report.body.status, 'cancelled')
+  assert.strictEqual(report.body.notes, 'Handler error: boom')
+  assert.strictEqual(agent.workingOn, '', 'workingOn must be reset after the handler error')
+})


### PR DESCRIPTION
## SDK reliability — heartbeat / orphaned tasks / request timeout

From a GLM-5.2 audit of the SDK; built by the local squad, byte-reviewed by m5Max with each claim checked against the server code.

- **Overlapping heartbeats (HIGH):** `start()` used `setInterval` to fire an async `heartbeat()` on a fixed cadence — under latency exceeding the interval, beats overlapped and could stampede the server / exhaust sockets. Now a self-rescheduling `setTimeout` schedules the next beat only after the current one settles.
- **Orphaned tasks (HIGH):** a throwing work handler left the server-side task stuck `in_progress` forever. Now it reports the task `cancelled` — verified as the valid non-terminal task status (`'failed'` isn't in `TASK_STATUSES` and PUT `/tasks/:id` would reject it), guarded to task-typed items and wrapped so a report failure can't crash the loop.
- **Zombie agents (MED):** `api.js request()` had no timeout — a hung connection left the promise pending forever, wedging heartbeat + work loop. Now `AbortSignal.timeout` (default 30s). Safe because `getWork` returns immediately (the loop sleeps between polls; no long-poll to clip).

SDK tests: **6/6** (4 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
