### PR TITLE
perf+correctness(semantic-memory): vector collapse + task-completion content + N+1

### DIFF
--- a/server/plugins/semantic-memory/db.js
+++ b/server/plugins/semantic-memory/db.js
@@ -292,7 +292,11 @@ export default function createMemoryDB(db) {
       }
 
       scored.sort(function (a, b) { return b.score - a.score; });
-      var topIds = scored.slice(0, limit);
+      // Collapse chunked docs to their best chunk BEFORE slicing to the page
+      // limit — otherwise one multi-chunk doc floods the results. Mirrors
+      // searchKeyword (collapse then slice). scored rows carry source_type +
+      // source_id, so collapseChunks keys them directly.
+      var topIds = this.collapseChunks(scored).slice(0, limit);
 
       // Fetch full rows only for top results
       return topIds.map(function (s) {

--- a/server/plugins/semantic-memory/handlers.js
+++ b/server/plugins/semantic-memory/handlers.js
@@ -180,7 +180,15 @@ export function registerHooks(core) {
     try {
       var data = parseEventData(eventData);
       var taskId = data.task_id || data.id || '';
-      var text = 'COMPLETED: ' + (eventData.summary || '');
+      // Preserve the task's previously-indexed title + description so it
+      // stays searchable after completion. indexAndEmbed upserts (replacing
+      // the doc), so dropping the prior content would make a completed task
+      // unfindable by its original title/description.
+      var existing = db.getDocChunks('task', String(taskId));
+      var priorContent = existing.length > 0
+        ? existing.map(function (c) { return c.content_text; }).join('')
+        : '';
+      var text = 'COMPLETED: ' + (eventData.summary || '') + '\n' + priorContent;
       if (text.length < 10) return;
 
       indexAndEmbed('task', String(taskId), text, {

--- a/server/plugins/semantic-memory/routes.js
+++ b/server/plugins/semantic-memory/routes.js
@@ -218,10 +218,11 @@ export default function (core) {
   function expandOversizedRows(rows) {
     var work = [];
     var rechunked = {}; // source_type:source_id — re-chunk each doc once
+    var chunkSize = db.getChunkSize(); // hoisted — static per request, not per row (N+1)
     for (var row of rows) {
       var key = row.source_type + ':' + row.source_id;
       if (rechunked[key]) continue;
-      if (row.content_text.length > db.getChunkSize()) {
+      if (row.content_text.length > chunkSize) {
         rechunked[key] = true;
         var docRows = db.getDocChunks(row.source_type, row.source_id);
         var fullText = docRows.map(function (c) { return c.content_text; }).join('');

--- a/server/plugins/semantic-memory/test.js
+++ b/server/plugins/semantic-memory/test.js
@@ -721,3 +721,106 @@ test('db: updateEmbedding(null) keeps row as SQL NULL, not the string "null"', f
   ).get('test', 'null-embed-test').c;
   assert.strictEqual(unembedded, 1, 'row still backfill-visible (embedding IS NULL)');
 });
+
+// ---- 3 P1 correctness fixes: searchVector chunk-collapse, task_completed
+// content preservation, and the getChunkSize N+1 hoist ----
+
+// P1 fix 1: searchVector collapses chunked docs to their best chunk BEFORE
+// slicing to the page limit (mirrors searchKeyword). Pre-fix a single
+// multi-chunk doc could occupy every slot on the result page.
+test('db: searchVector collapses multi-chunk docs to one result per document', function () {
+  mem.setConfig('chunk_size', '600');
+  var big = makeBigText('vcollapse', 10);
+  var chunks = mem.indexDoc('test', 'vec-multi', big);
+  assert.ok(chunks.length > 1, 'doc split into multiple chunks');
+  // A distinct embedding vector makes this doc the unique top match; every
+  // other doc in the shared DB carries FAKE_VECTOR (lower cosine sim).
+  var V = [1, 0, 0];
+  for (var i = 0; i < chunks.length; i++) {
+    mem.updateEmbedding('test', 'vec-multi', i, V, 'test-model');
+  }
+  var results = mem.searchVector(V, { limit: 3 });
+  var hits = results.filter(function (r) { return r.source_id === 'vec-multi'; });
+  assert.equal(hits.length, 1, 'multi-chunk doc collapsed to a single vector result');
+  var ids = results.map(function (r) { return r.source_type + ':' + r.source_id; });
+  assert.equal(ids.length, new Set(ids).size, 'no duplicate docs across the vector page');
+});
+
+// P1 fix 2: task_completed re-indexes with COMPLETED: + summary but PRESERVES
+// the task's original title + description. indexAndEmbed upserts (replacing
+// the doc), so pre-fix a completed task became unfindable by its own title.
+test('handler: task_completed preserves original task title + description', function () {
+  fire('task_created', {
+    agent: 'tester',
+    data: { task_id: 501, title: 'Refactor the embedding pipeline', description: 'Split generate and batch paths for clarity', project_id: 'mycelium' }
+  });
+  var before = getDoc('task', '501');
+  assert.ok(before, 'task indexed on creation');
+  assert.match(before.content_text, /Refactor the embedding pipeline/);
+  assert.match(before.content_text, /Split generate and batch paths/);
+
+  fire('task_completed', { agent: 'lucy', summary: 'shipped the refactor', data: { task_id: 501 }, project_id: 'mycelium' });
+  var after = getDoc('task', '501');
+  assert.ok(after, 'task still indexed after completion');
+  assert.match(after.content_text, /^COMPLETED: shipped the refactor/, 'completion marker + summary prepended');
+  assert.match(after.content_text, /Refactor the embedding pipeline/, 'original title preserved');
+  assert.match(after.content_text, /Split generate and batch paths/, 'original description preserved');
+});
+
+// P1 fix 3: expandOversizedRows hoists getChunkSize() above the loop (one
+// call per request, not one per row). A Proxy over the isolated db counts
+// getConfig('chunk_size') SELECTs — the only such caller during backfill is
+// getChunkSize (embeddings.js calls neither). indexDoc also calls it once
+// per re-chunked doc, so the post-hoist total is 1 + N; pre-hoist it was N + N.
+test('routes: expandOversizedRows calls getChunkSize once per request, not per row', async function () {
+  var iso = new Database(':memory:');
+  iso.exec(fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8'));
+  iso.exec(PLATFORM_TABLES);
+
+  var chunkSizeCalls = 0;
+  var countingDb = new Proxy(iso, {
+    get: function (target, prop) {
+      var val = target[prop];
+      if (prop === 'prepare') {
+        return function (sql) {
+          if (sql === 'SELECT value FROM sm_config WHERE key = ?') chunkSizeCalls++;
+          return target.prepare(sql);
+        };
+      }
+      return typeof val === 'function' ? val.bind(target) : val;
+    }
+  });
+
+  var isoMem = createMemoryDB(iso);
+  isoMem.setConfig('embedding_provider', 'ollama');
+  isoMem.setConfig('embedding_url', 'http://localhost:11434');
+  isoMem.setConfig('embedding_model', 'nomic-embed-text');
+  isoMem.setConfig('chunk_size', '600');
+
+  var N = 4;
+  var big = makeBigText('nplusone', 8);
+  for (var i = 0; i < N; i++) {
+    isoMem.index('m5max_memory', 'nq-' + i, big, { metadata: { t: i } });
+  }
+  assert.equal(isoMem.countUnembedded(), N, 'seeded N oversized NULL rows');
+
+  var isoCore = makeCore(countingDb);
+  var isoApp = express();
+  isoApp.use(express.json({ limit: '10mb' }));
+  isoApp.use('/memory', createRoutes(isoCore));
+  var isoServer = http.createServer(isoApp);
+  await new Promise(function (r) { isoServer.listen(0, '127.0.0.1', r); });
+  var isoBase = 'http://127.0.0.1:' + isoServer.address().port;
+
+  var res = await realFetch(isoBase + '/memory/backfill-embeddings?limit=50', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }
+  });
+  var rj = await res.json();
+  isoServer.close();
+  iso.close();
+
+  assert.equal(res.status, 200);
+  assert.equal(rj.failed, 0, 'all oversized docs chunked + embedded');
+  // Post-hoist: 1 (loop) + N (indexDoc re-chunks). Pre-hoist: N (loop) + N.
+  assert.equal(chunkSizeCalls, 1 + N, 'getChunkSize hoisted above the loop (1 + N), not called per row (2N)');
+});


### PR DESCRIPTION
## semantic-memory P1 batch — vector collapse / task-completion content / N+1 lookup

GLM-5.2 audit P1s; built by the local squad, byte-reviewed by m5Max. Tests 27/27.

- **Vector search chunk-flood:** `searchVector` returned top-N raw rows, so a doc split into 8 chunks could take 8 of 10 slots. Now collapses to best-chunk-per-doc *before* slicing (mirrors `searchKeyword`), over the full scored list so the page still fills to N distinct docs.
- **Task-completion content loss:** the `task_completed` handler overwrote the indexed memory with just `COMPLETED: <summary>`, dropping the title/description. Now preserves the previously-indexed content alongside the summary (re-uses the plugin's own chunks — no cross-table dependency).
- **N+1 config lookup:** `expandOversizedRows` called `db.getChunkSize()` inside the per-row loop (2000+ queries on a 1000-row backfill). Now hoisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
