### PR TITLE
security(core): close directive auth-bypass + pre-auth file upload (C1/H3/C4)

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -607,6 +607,16 @@ function checkAgentOrAdmin(req, res) {
   return checkAgent(req, res);
 }
 
+// Auth guard for upload routes. checkAgentOrAdmin authenticates and writes the
+// 401/403 response itself on failure; here we simply halt the chain (return)
+// before next() — and therefore before upload.single() runs — so an
+// unauthenticated request is rejected before any bytes hit disk.
+function requireAuth(req, res, next) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return; // response already sent (401/403)
+  next();
+}
+
 
 // ---- SSE clients registry ----
 // Each entry: { res, filters: { project_id, type, agent } }
@@ -2584,7 +2594,7 @@ router.put('/assets/:id', asyncHandler(function (req, res) {
   res.json({ ok: true, id: asset.id });
 }));
 
-router.post('/assets/:id/upload', upload.single('file'), asyncHandler(function (req, res) {
+router.post('/assets/:id/upload', requireAuth, upload.single('file'), asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
   var asset = getAsset(parseIntParam(req.params.id));
@@ -2868,11 +2878,21 @@ router.post('/messages', agentWriteLimiter, asyncHandler(function (req, res) {
     return res.status(403).json({ error: enforcement.blocks[0].message, enforcement_rule: enforcement.blocks[0].rule_id });
   }
 
-  // Only admin and operators can send directives
+  // Only admin and operators can send directives — privilege is derived from
+  // AUTH (req._authIsAdmin flag + the caller's role), NEVER from the
+  // client-supplied req.body.from, which is trivially spoofable (e.g. a regular
+  // agent posting from: '__admin__' used to sail straight through).
   var msgType = req.body.msg_type || 'message';
   if (msgType === 'directive') {
-    var sender = req.body.from || agentId;
-    if (sender !== '__admin__' && sender.indexOf('-claude') !== -1) {
+    var directiveStudioUser = getStudioUser(req);
+    var callerIsOperator = false;
+    if (directiveStudioUser) {
+      callerIsOperator = directiveStudioUser.role === 'operator';
+    } else {
+      var callerAgent = getAgent(agentId);
+      callerIsOperator = !!(callerAgent && callerAgent.role === 'operator');
+    }
+    if (!req._authIsAdmin && !callerIsOperator) {
       return res.status(403).json({ error: 'Only admin or operators can send directives' });
     }
   }
@@ -4466,7 +4486,7 @@ setInterval(function () {
 // POST /files — upload a temp file (multipart form, field name: "file")
 // curl -X POST -H "X-Agent-Key: <key>" -F "file=@myimage.png" https://mycelium.fyi/api/mycelium/files
 // Files auto-delete after 24 hours. Download with wget/curl before then.
-router.post('/files', upload.single('file'), asyncHandler(function (req, res) {
+router.post('/files', requireAuth, upload.single('file'), asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
   if (!req.file) return res.status(400).json({ error: 'No file uploaded. Use multipart form with field name "file"' });
@@ -5387,7 +5407,7 @@ router.post('/drones/profiles/:profileId/setup-complete', asyncHandler(function 
 // Must be before /drones/:id to prevent :id from catching "artifacts"
 
 // Upload a drone artifact (persistent, no TTL) — admin or drone agents
-router.post('/drones/artifacts', artifactUpload.single('file'), asyncHandler(function (req, res) {
+router.post('/drones/artifacts', requireAuth, artifactUpload.single('file'), asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
   if (!req.file) return res.status(400).json({ error: 'No file uploaded. Use multipart form with field name "file"' });

--- a/test/unit/directive-and-upload-auth.test.js
+++ b/test/unit/directive-and-upload-auth.test.js
@@ -1,0 +1,116 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+
+// Regression tests for two CRITICAL auth fixes in routes/mycelium.js:
+//
+// (1) Directive gate on POST /messages: privilege is now derived from AUTH
+//     (the req._authIsAdmin flag + the caller's role via getStudioUser /
+//     getAgent), NEVER from the client-supplied req.body.from. A regular agent
+//     spoofing from:'__admin__' used to sail straight through; it must now be
+//     rejected with 403.
+//
+// (2) Upload routes (POST /files, /assets/:id/upload, /drones/artifacts): a
+//     requireAuth middleware now runs BEFORE upload.single, so an
+//     unauthenticated request is rejected (401) before multer writes any bytes
+//     to disk.
+//
+// Harness mirrors auth-roles.test.js: real router, fresh temp DB, env set
+// before the dynamic import so db.js / routes pick up DATA_DIR + ADMIN_KEY.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const AGENT_KEY = 'dvk_' + 'a'.repeat(48)
+
+let tmpDataDir
+let db
+let app
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-auth-directive-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  const routes = (await import('../../server/routes/mycelium.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routes)
+
+  // A regular agent (default role 'agent') whose key we hold.
+  const hash = crypto.createHash('sha256').update(AGENT_KEY).digest('hex')
+  db.createAgent('lucy-test', 'Lucy Test', 'auth-proj', hash, '["code"]')
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+function countFiles(dir) {
+  if (!existsSync(dir)) return 0
+  return readdirSync(dir, { withFileTypes: true }).filter((e) => e.isFile()).length
+}
+
+describe('POST /messages — directive gate derives privilege from AUTH, not req.body.from', () => {
+  test('a regular agent spoofing from:"__admin__" is STILL 403 on a directive', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/messages')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({
+        to: 'echo-test',
+        content: 'shut down everything',
+        msg_type: 'directive',
+        from: '__admin__' // the spoof that used to bypass the gate
+      })
+    expect(res.status).toBe(403)
+    expect(res.body.error).toBe('Only admin or operators can send directives')
+  })
+
+  test('an admin KEY can still send a directive (gate is not over-restrictive)', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/messages')
+      .set('X-Admin-Key', ADMIN_KEY)
+      .set('X-Acting-As', 'greatness')
+      .send({ content: 'legitimate directive', msg_type: 'directive' })
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('id')
+  })
+})
+
+describe('upload routes — requireAuth runs BEFORE upload.single', () => {
+  test('unauthenticated POST /files is 401 and writes NOTHING to disk', async () => {
+    const filesDir = join(tmpDataDir, 'files')
+    const before = countFiles(filesDir)
+
+    const res = await request(app)
+      .post('/api/mycelium/files')
+      .attach('file', Buffer.from('evil payload that must never reach disk'), 'evil.txt')
+
+    expect(res.status).toBe(401)
+    expect(countFiles(filesDir)).toBe(before) // nothing written before the rejection
+  })
+
+  test('unauthenticated POST /assets/:id/upload is 401 before bytes hit disk', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/assets/123/upload')
+      .attach('file', Buffer.from('x'), 'evil.png')
+    expect(res.status).toBe(401)
+  })
+
+  test('unauthenticated POST /drones/artifacts is 401 and writes NOTHING to disk', async () => {
+    const artifactsDir = join(tmpDataDir, 'drone_artifacts')
+    const before = countFiles(artifactsDir)
+
+    const res = await request(app)
+      .post('/api/mycelium/drones/artifacts')
+      .attach('file', Buffer.from('artifact payload that must never reach disk'), 'evil.bin')
+
+    expect(res.status).toBe(401)
+    expect(countFiles(artifactsDir)).toBe(before) // nothing written before the rejection
+  })
+})


### PR DESCRIPTION
## security(core): close directive auth-bypass + pre-auth file upload

Two verified CRITICAL auth bugs in the core router (`server/routes/mycelium.js`), from a GLM-5.2 audit; squad-built, byte-reviewed with the fix verified against the exact attack.

### C1+H3 — directive auth bypass
`POST /messages` gated directive privilege on `sender = req.body.from || agentId` plus a `-claude` name-suffix heuristic. Any authenticated agent posting `from: '__admin__'` (or any string without `-claude`) could send a privileged directive. **Fix:** privilege now derives from the **authenticated** identity only — `req._authIsAdmin` + the caller's `operator` role — never the request body.

### C4 — pre-auth file upload
`/files`, `/assets/:id/upload`, `/drones/artifacts` ran multer *before* auth, so an unauthenticated client could stream a file to disk (artifacts have **no TTL**) before the 401. **Fix:** a `requireAuth` guard before `upload.single()` on all three — nothing hits disk until authenticated.

### Tests
`directive-and-upload-auth.test.js` (5/5): the `from:'__admin__'` spoof is still 403, an admin key still sends directives, and unauthenticated uploads write **zero bytes** before rejection. `auth-roles` 9/9 — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
