### PR TITLE
security+fix(core): bound bcrypt-fallback DoS + drop wrong-tool escapeHtml on project_id

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -428,8 +428,24 @@ var AGENT_KEY_CACHE_MAX = 1000;
 var AGENT_KEY_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 var agentKeyCache = new Map();
 
+// Lazily-computed flag: are there ANY agents whose api_key_hash is a legacy
+// bcrypt ($2b$/$2a$) hash? null = not yet computed. When false, checkAgent skips
+// the O(N_agents) bcrypt fallback sweep entirely, so a forged X-Agent-Key header
+// cannot burn O(N x bcrypt_cost) CPU per request (DoS). Invalidated by
+// clearAgentKeyCache (called on key rotation / auto-migrate) so it re-checks.
+var HAS_LEGACY_BCRYPT_AGENTS = null;
+
+function hasLegacyBcryptAgents() {
+  if (HAS_LEGACY_BCRYPT_AGENTS === null) {
+    var row = getDB().prepare("SELECT COUNT(*) AS c FROM agents WHERE api_key_hash LIKE '$2b$%' OR api_key_hash LIKE '$2a$%'").get();
+    HAS_LEGACY_BCRYPT_AGENTS = !!(row && row.c > 0);
+  }
+  return HAS_LEGACY_BCRYPT_AGENTS;
+}
+
 function clearAgentKeyCache() {
   agentKeyCache.clear();
+  HAS_LEGACY_BCRYPT_AGENTS = null; // re-check legacy presence on next cache miss
 }
 
 function getFromAgentKeyCache(keyHash) {
@@ -517,18 +533,22 @@ function checkAgent(req, res) {
     req._authProjectId = directMatch.project_id || null;
     return directMatch.id;
   }
-  // Fallback: scan for legacy bcrypt hashes and auto-migrate
-  var agents = listAllAgentsIncludingDrones();
-  for (var a of agents) {
-    var full = getAgent(a.id);
-    if (!full || !full.api_key_hash) continue;
-    if ((full.api_key_hash.startsWith('$2b$') || full.api_key_hash.startsWith('$2a$')) && bcrypt.compareSync(key, full.api_key_hash)) {
-      updateAgentKey(a.id, keyHash);
-      clearAgentKeyCache();
-      setInAgentKeyCache(keyHash, { id: a.id, project_id: full.project_id || null });
-      req._authAgentId = a.id;
-      req._authProjectId = full.project_id || null;
-      return a.id;
+  // Fallback: scan for legacy bcrypt hashes and auto-migrate.
+  // Guarded: skip the O(N) bcrypt sweep entirely when no legacy hashes exist, so
+  // a forged key can't trigger a full bcrypt comparison pass (DoS).
+  if (hasLegacyBcryptAgents()) {
+    var agents = listAllAgentsIncludingDrones();
+    for (var a of agents) {
+      var full = getAgent(a.id);
+      if (!full || !full.api_key_hash) continue;
+      if ((full.api_key_hash.startsWith('$2b$') || full.api_key_hash.startsWith('$2a$')) && bcrypt.compareSync(key, full.api_key_hash)) {
+        updateAgentKey(a.id, keyHash);
+        clearAgentKeyCache();
+        setInAgentKeyCache(keyHash, { id: a.id, project_id: full.project_id || null });
+        req._authAgentId = a.id;
+        req._authProjectId = full.project_id || null;
+        return a.id;
+      }
     }
   }
   // Track failed attempt for rate limiting
@@ -1541,7 +1561,7 @@ router.post('/tasks', agentWriteLimiter, asyncHandler(function (req, res) {
   if (!validateStringLength(res, req.body.title, MAX_TITLE, 'title')) return;
   if (!validateStringLength(res, req.body.description, MAX_DESCRIPTION, 'description')) return;
   var description = escapeHtml(req.body.description || '');
-  var projectId = escapeHtml(req.body.project_id || '');
+  var projectId = req.body.project_id || '';
   var priority = req.body.priority || 'normal';
   var tags = req.body.tags ? JSON.stringify(req.body.tags) : '[]';
   var id = createTask(title, description, projectId, agentId, priority, tags);
@@ -3087,7 +3107,7 @@ router.post('/plans', asyncHandler(function (req, res) {
   if (!validateStringLength(res, req.body.title, MAX_TITLE, 'title')) return;
   if (!validateStringLength(res, req.body.description, MAX_DESCRIPTION, 'description')) return;
   var description = escapeHtml(req.body.description || '');
-  var projectId = escapeHtml(req.body.project_id || '');
+  var projectId = req.body.project_id || '';
   var owner = escapeHtml(req.body.owner || '');
   var priority = req.body.priority || 'normal';
   var tags = req.body.tags ? JSON.stringify(req.body.tags) : '[]';
@@ -3138,7 +3158,7 @@ router.put('/plans/:id', asyncHandler(function (req, res) {
   if (req.body.owner !== undefined) fields.owner = escapeHtml(req.body.owner);
   if (req.body.priority !== undefined) fields.priority = req.body.priority;
   if (req.body.tags !== undefined) fields.tags = req.body.tags;
-  if (req.body.project_id !== undefined) fields.project_id = escapeHtml(req.body.project_id);
+  if (req.body.project_id !== undefined) fields.project_id = req.body.project_id;
   updatePlan(plan.id, fields);
   if (fields.status) {
     emitEvent('plan_' + fields.status, agentId, plan.project_id, agentId + ' set plan #' + plan.id + ' to ' + fields.status, { plan_id: plan.id });
@@ -6203,6 +6223,7 @@ export async function initPlugins() {
 }
 
 export { isAdminKey };
+export { hasLegacyBcryptAgents, clearAgentKeyCache };
 
 // ── GitHub Proxy Routes ────────────────────────────────────────
 // Proxies GitHub API via server-side GITHUB_TOKEN so agents don't need their own tokens.

--- a/test/unit/bcrypt-fallback-dos.test.js
+++ b/test/unit/bcrypt-fallback-dos.test.js
@@ -1,0 +1,66 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// C3: bcrypt-fallback DoS protection.
+//
+// checkAgent() guards its O(N_agents) bcrypt fallback sweep with
+// hasLegacyBcryptAgents(). When NO agent carries a legacy $2b$/$2a$ key hash,
+// the gate is `false` and a forged X-Agent-Key header can never trigger a full
+// bcrypt.compareSync pass (each comparison is intentionally ~100-300ms, so an
+// unguarded sweep is a CPU-DoS). The flag is lazily computed once, cached, and
+// reset by clearAgentKeyCache() (key rotation / auto-migrate).
+//
+// These tests pin the gate's accuracy + caching against a real temp DB so a
+// regression that re-enables the unguarded sweep fails the suite. db.js reads
+// DATA_DIR at module-eval time, so it MUST be set before importing mycelium.js.
+
+let tmpDataDir
+let db
+let mycelium
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-bcrypt-dos-'))
+  process.env.DATA_DIR = tmpDataDir
+  db = await import('../../server/db.js')
+  mycelium = await import('../../server/routes/mycelium.js')
+  db.initDB()
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+// Seed an agent whose api_key_hash is a legacy bcrypt hash (prefix $2b$).
+function seedLegacyAgent(id) {
+  db.createAgent(id, 'Legacy-' + id, 'proj-legacy',
+    '$2b$12$abcdefghijklmnopqrstuv1234567890abcdefghijklmnopqrstuv', '[]')
+}
+
+describe('C3: bcrypt-fallback DoS protection', () => {
+  test('fresh DB with no legacy hashes -> gate is false (forged key skips the sweep)', () => {
+    mycelium.clearAgentKeyCache()
+    // No agent in this fresh DB has a $2b$/$2a$ hash, so the gate is false and
+    // checkAgent's `if (hasLegacyBcryptAgents())` block is never entered for a
+    // forged key — i.e. zero bcrypt.compareSync calls.
+    expect(mycelium.hasLegacyBcryptAgents()).toBe(false)
+  })
+
+  test('gate is accurate: detects a seeded legacy bcrypt agent', () => {
+    mycelium.clearAgentKeyCache()
+    seedLegacyAgent('legacy-dos-1')
+    expect(mycelium.hasLegacyBcryptAgents()).toBe(true)
+    db.deleteAgent('legacy-dos-1')
+  })
+
+  test('gate is cached until clearAgentKeyCache resets it', () => {
+    mycelium.clearAgentKeyCache()
+    expect(mycelium.hasLegacyBcryptAgents()).toBe(false) // prime -> cached false
+    seedLegacyAgent('legacy-dos-2')                       // add legacy WITHOUT clearing
+    expect(mycelium.hasLegacyBcryptAgents()).toBe(false)  // still cached, no re-query
+    mycelium.clearAgentKeyCache()                         // now reset
+    expect(mycelium.hasLegacyBcryptAgents()).toBe(true)   // re-query sees it
+    db.deleteAgent('legacy-dos-2')
+  })
+})

--- a/test/unit/project-id-no-escape.test.js
+++ b/test/unit/project-id-no-escape.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import express from 'express'
+import request from 'supertest'
+
+// H1: project_id must NOT be HTML-escaped before storage.
+//
+// Previously the POST /tasks, POST /plans and PUT /plans handlers ran
+// `escapeHtml(req.body.project_id)`, corrupting any id containing &, < or >
+// (e.g. "proj&a" was stored as "proj&amp;a"). The downstream inserts use
+// parameterized (?-placeholder) queries, so escapeHtml was both wrong (a
+// misplaced XSS guard on DB-bound data) and unnecessary (SQL injection is
+// already prevented). This test round-trips a special-char project_id through
+// the REAL POST /tasks route via supertest and asserts it is stored verbatim.
+//
+// db.js reads DATA_DIR at module-eval time -> set it before importing the route.
+
+const ADMIN_KEY = 'test-admin-key-for-project-id'
+
+let tmpDataDir
+let db
+let app
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-project-id-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+  db = await import('../../server/db.js')
+  const router = (await import('../../server/routes/mycelium.js')).default
+  db.initDB()
+  app = express()
+  app.use(express.json())
+  app.use('/api', router)
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+describe('H1: project_id is not HTML-escaped (round-trips verbatim)', () => {
+  test('POST /tasks stores a special-char project_id unchanged', async () => {
+    const special = 'proj&a<b>"x"'
+    const res = await request(app)
+      .post('/api/tasks')
+      .set('X-Admin-Key', ADMIN_KEY)
+      .send({ title: 'round-trip test', project_id: special })
+
+    expect(res.status).toBe(200)
+    expect(res.body.id).toBeTruthy()
+
+    // The DB row must hold the project_id EXACTLY as the client sent it.
+    const task = db.getTask(res.body.id)
+    expect(task.project_id).toBe(special)
+  })
+
+  test('no escapeHtml(req.body.project_id) remains in the route source', async () => {
+    // Regression guard: if escapeHtml is re-wrapped around project_id in any of
+    // the three handlers, this assertion fails.
+    const { readFileSync } = await import('node:fs')
+    const src = readFileSync(join(process.cwd(), 'server/routes/mycelium.js'), 'utf8')
+    expect(src).not.toContain('escapeHtml(req.body.project_id')
+  })
+})


### PR DESCRIPTION
## security+fix(core): bound bcrypt-fallback DoS (C3) + drop wrong-tool escapeHtml on project_id (H1)

From a GLM-5.2 audit; squad-built, byte-reviewed. Tests 5/5.

### C3 — bcrypt-fallback DoS
`checkAgent`'s legacy fallback iterated **every** agent and ran `bcrypt.compareSync` on each legacy hash on **every key-miss** — so a botnet spraying forged `X-Agent-Key` headers burned O(N × bcrypt) CPU per request. **Fix:** a lazily-computed `hasLegacyBcryptAgents()` flag (cheap `COUNT WHERE api_key_hash LIKE '$2b$%'`) guards the sweep — once agents are migrated, it's skipped entirely. Flag invalidates on key rotation / auto-migrate.

### H1 — wrong-tool escaping
`/tasks` and `/plans` HTML-escaped `project_id` before using it as a **DB key** — corrupting any id with `&` `<` `>`, with zero injection protection (the parameterized query does that). **Fix:** removed the escape. `PUT /agents/:id` already stored `project_id` raw, so this makes the write path consistent rather than introducing a novel raw path. (Output-side escaping at render is a pre-existing, separate concern.)

Tests: 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
