### PR TITLE
fix(core): wire checkGuardrails into 8 uncovered write routes (M1)

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -2000,6 +2000,7 @@ router.put('/context/:projectId', asyncHandler(function (req, res) {
 router.post('/spend', asyncHandler(function (req, res) {
   var agentId = checkAgentOrAdmin(req, res);
   if (!agentId) return;
+  if (!checkGuardrails(req, res, 'spend_logged', { agent: agentId, project_id: req.body.project_id, cost_usd: req.body.cost_usd })) return;
   var costUsd = parseFloat(req.body.cost_usd) || 0;
   if (costUsd < 0) return res.status(400).json({ error: 'cost_usd must be non-negative' });
   logAgentSpend(
@@ -2043,6 +2044,7 @@ router.get('/spend', asyncHandler(function (req, res) {
 router.post('/runs', asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
+  if (!checkGuardrails(req, res, 'run_started', { agent: who, project_id: req.body.project_id })) return;
   // Bind the run to the AUTHENTICATED agent — a non-admin can't attribute a run to
   // another agent. Admin (e.g. the bridge recording on behalf of an agent) may set it.
   var ownerAgent = req._authIsAdmin ? (req.body.agent_id || who) : (req._authAgentId || who);
@@ -2593,6 +2595,7 @@ router.get('/assets', asyncHandler(function (req, res) {
 router.post('/assets', asyncHandler(function (req, res) {
   var agentId = checkAgentOrAdmin(req, res);
   if (!agentId) return;
+  if (!checkGuardrails(req, res, 'asset_registered', { agent: agentId, project_id: req.body.project_id, name: req.body.name })) return;
   var name = escapeHtml(req.body.name);
   if (!name) return res.status(400).json({ error: 'name is required' });
   var type = req.body.type || 'sprite';
@@ -2734,6 +2737,7 @@ router.get('/events', asyncHandler(function (req, res) {
 router.post('/events', asyncHandler(function (req, res) {
   var agentId = checkAgentOrAdmin(req, res);
   if (!agentId) return;
+  if (!checkGuardrails(req, res, 'event_emitted', { agent: agentId, project_id: req.body.project_id, type: req.body.type, summary: req.body.summary })) return;
   var type = req.body.type || 'custom';
   var projectId = req.body.project_id || null;
   var summary = escapeHtml(req.body.summary || '');
@@ -2835,6 +2839,7 @@ router.get('/requests/pending', asyncHandler(function (req, res) {
 router.post('/requests', asyncHandler(function (req, res) {
   var agentId = checkAgentOrAdmin(req, res);
   if (!agentId) return;
+  if (!checkGuardrails(req, res, 'request_created', { agent: agentId, project_id: req.body.project_id, to_agent: req.body.to_agent, content: (req.body.content || '').substring(0, 200) })) return;
   var content = req.body.content;
   if (!content) return res.status(400).json({ error: 'content is required' });
   var toAgent = req.body.to_agent || null;
@@ -3101,6 +3106,7 @@ router.get('/plans', asyncHandler(function (req, res) {
 router.post('/plans', asyncHandler(function (req, res) {
   var agentId = checkAgentOrAdmin(req, res);
   if (!agentId) return;
+  if (!checkGuardrails(req, res, 'plan_created', { agent: agentId, project_id: req.body.project_id, title: req.body.title })) return;
   var gate = checkApprovalGate(req, agentId, 'plan_create');
   var title = escapeHtml(req.body.title);
   if (!title) return res.status(400).json({ error: 'title is required' });
@@ -4588,6 +4594,7 @@ router.get('/files', asyncHandler(function (req, res) {
 router.post('/bugs', agentWriteLimiter, asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
+  if (!checkGuardrails(req, res, 'bug_created', { agent: who, project_id: req.body.project_id, title: req.body.title })) return;
   var { project_id, title, description, category, severity, assignee, diagnostic_data } = req.body;
   var projectId = project_id;
   if (!title || !description) return res.status(400).json({ error: 'title and description are required' });
@@ -6049,6 +6056,7 @@ router.get('/feedback', asyncHandler(async function (req, res) {
 router.post('/feedback', asyncHandler(async function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
+  if (!checkGuardrails(req, res, 'feedback_submitted', { agent: who, entity_type: req.body.entity_type, agent_id: req.body.agent_id, rating: req.body.rating })) return;
   var { entity_type, entity_id, subject, rating, comment, agent_id } = req.body;
   if (!rating || rating < 1 || rating > 5) {
     return apiError(res, 400, 'rating must be 1-5');

--- a/test/unit/guardrails-route-coverage.test.js
+++ b/test/unit/guardrails-route-coverage.test.js
@@ -1,0 +1,107 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+
+// Verifies the 8 POST routes newly wired to checkGuardrails each call it with
+// the correct event kind, return-on-block (403), and do NOT over-block on the
+// happy path. Mirrors the directive-and-upload-auth harness: real router, fresh
+// temp DB, env set before the dynamic import so db.js / routes pick up DATA_DIR
+// + ADMIN_KEY. The guardrails check is stubbed on the app (req.app._guardrailsCheck)
+// — exactly the field the guardrails plugin attaches in production — so this
+// exercises the real route wiring without needing the guardrail_rules DB table.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const BLOCKED_KEY = 'dvk_' + 'b'.repeat(48)
+const ALLOWED_KEY = 'dvk_' + 'c'.repeat(48)
+
+const BLOCKED_AGENT = 'blocked-test'
+const ALLOWED_AGENT = 'allowed-test'
+
+// The 8 newly-covered routes and the event kind each must pass to checkGuardrails.
+const COVERED = [
+  { path: '/spend', kind: 'spend_logged' },
+  { path: '/runs', kind: 'run_started' },
+  { path: '/assets', kind: 'asset_registered' },
+  { path: '/events', kind: 'event_emitted' },
+  { path: '/requests', kind: 'request_created' },
+  { path: '/plans', kind: 'plan_created' },
+  { path: '/bugs', kind: 'bug_created' },
+  { path: '/feedback', kind: 'feedback_submitted' }
+]
+const NEW_KINDS = new Set(COVERED.map((c) => c.kind))
+
+let tmpDataDir
+let db
+let app
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-guardrails-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  const routes = (await import('../../server/routes/mycelium.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routes)
+
+  // Stub the guardrails check exactly as the guardrails plugin attaches it
+  // (req.app._guardrailsCheck). Blocks any of the new event kinds coming from
+  // BLOCKED_AGENT; allows everything else. Returning rule_name = 'block-<kind>'
+  // lets the 403 assertion confirm the EXACT event kind each route passed.
+  app._guardrailsCheck = function (eventType, eventData) {
+    if (eventData && eventData.agent === BLOCKED_AGENT && NEW_KINDS.has(eventType)) {
+      return { allowed: false, violations: [{ rule_name: 'block-' + eventType }] }
+    }
+    return { allowed: true, violations: [] }
+  }
+
+  const mkHash = (k) => crypto.createHash('sha256').update(k).digest('hex')
+  db.createAgent(BLOCKED_AGENT, 'Blocked Test', 'proj', mkHash(BLOCKED_KEY), '["code"]')
+  db.createAgent(ALLOWED_AGENT, 'Allowed Test', 'proj', mkHash(ALLOWED_KEY), '["code"]')
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+describe('newly-covered POST routes call checkGuardrails with the correct event kind', () => {
+  test.each(COVERED)(
+    'POST $path is blocked (403) with the $kind guardrail rule for a blocked agent',
+    async ({ path, kind }) => {
+      // Guardrail fires immediately after auth, before any payload validation,
+      // so an empty body is enough to prove the wiring.
+      const res = await request(app)
+        .post('/api/mycelium' + path)
+        .set('X-Agent-Key', BLOCKED_KEY)
+        .send({})
+      expect(res.status).toBe(403)
+      // rule_name carries the exact event kind the route passed -> confirms mapping.
+      expect(res.body.error).toBe('Blocked by guardrail: block-' + kind)
+    }
+  )
+
+  test('happy path is NOT over-blocked: allowed agent POST /spend -> 200', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/spend')
+      .set('X-Agent-Key', ALLOWED_KEY)
+      .send({ cost_usd: 0.5, source: 'test', description: 'unit test' })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+
+  test('happy path is NOT over-blocked: allowed agent POST /events -> 200', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/events')
+      .set('X-Agent-Key', ALLOWED_KEY)
+      .send({ type: 'custom', summary: 'unit test' })
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('id')
+  })
+})


### PR DESCRIPTION
## fix(core): wire checkGuardrails into 8 uncovered write routes (M1 guardrail coverage)

From a GLM-5.2 audit; squad-built, byte-reviewed. Tests 10/10.

`checkGuardrails` fired on only 4 events (`task_created`, `task_updated`, `message_sent`, `drone_job_queued`), so any guardrail rule targeting other write events silently no-op'd. Wired it into the eight uncovered POST handlers — `/plans`, `/bugs`, `/assets`, `/requests`, `/events`, `/spend`, `/runs`, `/feedback` — one `return`-on-block check per handler with the appropriate event kind, matching the existing `/tasks` pattern. No other handler behavior changed.

Tests: 10/10 (`guardrails-route-coverage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
