### PR TITLE
cleanup(core): registry SHA pin (C2) + unref timers (H7) + health-patrol SSE (M7) + liveness debounce (H2); audit-closure docs

### DIFF
--- a/docs/audit-2026-07-core-hardening.md
+++ b/docs/audit-2026-07-core-hardening.md
@@ -1,0 +1,55 @@
+# Core hardening drive — June 30 / July 1, 2026
+
+A full external audit of the core router (`server/routes/mycelium.js`), the
+semantic-memory plugin, and the SDK, followed by a fix drive. The pipeline:
+an external model (GLM-5.2) audited each surface and emitted coded findings;
+the local squad (Ada plan → Lucy code → Echo verify) implemented fixes inside
+fired workflows under server-side gates; every diff got a frontier byte-review
+plus a clean-worktree test run before landing. Findings were coded
+C (critical) / H (high) / M (medium).
+
+## What landed where
+
+| Codes | Finding | PR |
+|---|---|---|
+| — | Squad batch: residency plugin, workflow fixes, SDK stop-hang, SM correctness, host-header | #142 |
+| SM P0#1 | `embedding_api_key` echoed back on PUT /memory/config | #143 |
+| SDK 2×H+M | Overlapping heartbeats, orphaned tasks, missing fetch timeout | #144 |
+| SM P1×3 | searchVector collapse, task-completion content loss, N+1 hoist | #145 |
+| SM design | Scoped drone embed auth, sqlite-vec cleanup | #146 |
+| C1, H3, C4 | Directive auth bypass (privilege from `req.body.from`), pre-auth file upload | #147 |
+| H8, M4 | Project scope on rerun/approvals, transactional done-cascade | #148 |
+| C3, H1 | bcrypt-fallback DoS bound, wrong-tool escapeHtml on project_id | #149 |
+| M1 | checkGuardrails wired into 8 uncovered write routes | #150 |
+| C2, H7, M7, H2 | Registry SHA pin, unref'd cleanup timers, health-patrol SSE broadcast, liveness-write debounce | this PR |
+
+## Deferred by design (documented, not changed)
+
+### M2 — SSE `data` field is double-stringified (intentional)
+
+`emitEvent`'s live broadcast sends `data: {...,"data":"{\"…\"}"}` — the inner
+`data` field is a JSON **string**, not an object. This is the wire contract,
+not a bug: the on-connect replay path reads events straight from the DB, where
+`createEvent` stores `data` as a JSON string, so live broadcasts re-stringify
+to match. Every SSE consumer receives `data` as a string on **both** paths and
+parses it itself. Removing the inner stringify would fork the live vs replay
+wire format and break existing clients. An inline note now guards the site in
+`emitEvent`.
+
+### M5 — bare `parseInt(...)` vs the `parseIntParam(...)` helper (cosmetic drift)
+
+The router defines a safe `parseIntParam` helper near the top of the file, but
+~39 bare `parseInt(` calls remain (a subset of them parse request params). No
+exploitable path was found on the checked routes — a `NaN` id falls through to
+not-found. This is convention drift, not a vulnerability. Convention going
+forward: new code uses `parseIntParam` for anything request-derived; sweep the
+remainder opportunistically when those lines are touched anyway.
+
+## Receipts
+
+Every fix in the table above landed with tests (unit suite grown along the
+drive; 235 tests / 34 files green at close). Fix implementation was local-squad
+work inside gated workflows; the frontier model's role was judgment: audit
+adjudication, byte-review of each diff, and the one-way-door checks (e.g.
+verifying the pinned registry commit exists upstream and resolves before C2
+landed).

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -681,6 +681,13 @@ function emitEvent(type, agentId, projectId, summary, data) {
     created_at: new Date().toISOString()
   };
   // Broadcast to connected SSE clients (with per-client filtering)
+  // NOTE (audit 2026-07, M2): the inner JSON.stringify(eventObj.data) is the
+  // INTENTIONAL wire format, not a double-encode bug. Replayed events (the
+  // on-connect backlog in the /events SSE route) read `data` straight from the
+  // DB, where createEvent stores it as a JSON string — so live broadcasts
+  // re-stringify to match: every SSE consumer receives `data` as a JSON
+  // *string* on both paths. "Fixing" this forks the live vs replay format
+  // and breaks existing clients. See docs/audit-2026-07-core-hardening.md.
   if (sseClients.size > 0) {
     var payload = 'data: ' + JSON.stringify({ ...eventObj, data: JSON.stringify(eventObj.data) }) + '\n\n';
     sseClients.forEach(function (client) {

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -407,6 +407,27 @@ function normalizeProjectField(req, res, next) {
   next();
 }
 
+// ---- Liveness-write debounce (H2) ----
+// getStudioUser runs on (nearly) every authenticated request and would
+// otherwise fire a `last_seen` UPDATE per request (2-3/req under polling).
+// Debounce per userId: at most one write per ~30s. The cache is bounded
+// (pruned every 5 min); touchStudioUserSeen() stays available for callers
+// that want an immediate write.
+var _studioSeenCache = {}; // userId -> last touch timestamp (ms)
+function touchStudioUserSeenDebounce(userId) {
+  var now = Date.now();
+  if (_studioSeenCache[userId] && (now - _studioSeenCache[userId]) < 30000) return;
+  _studioSeenCache[userId] = now;
+  touchStudioUserSeen(userId);
+}
+// Prune stale cache entries every 5 minutes (bounded memory)
+setInterval(function () {
+  var now = Date.now();
+  for (var uid in _studioSeenCache) {
+    if (now - _studioSeenCache[uid] > 300000) delete _studioSeenCache[uid];
+  }
+}, 5 * 60 * 1000).unref();
+
 // ---- Auth middleware ----
 
 // Decode studio JWT from Authorization: Bearer <token>
@@ -416,7 +437,7 @@ function getStudioUser(req) {
   try {
     var decoded = jwt.verify(auth.slice(7), JWT_SECRET, { algorithms: ['HS256'] });
     if (decoded && decoded.studioUser) {
-      if (decoded.userId) touchStudioUserSeen(decoded.userId);
+      if (decoded.userId) touchStudioUserSeenDebounce(decoded.userId);
       return decoded;
     }
     return null;
@@ -4519,7 +4540,7 @@ setInterval(function () {
       }
     }
   } catch (e) { /* cleanup is best-effort */ }
-}, 10 * 60 * 1000);
+}, 10 * 60 * 1000).unref();
 
 // Bug #137: Periodically auto-fail stale claimed drone jobs (every 15 minutes)
 // Bug #134/#132: Also flag drones offline if no heartbeat in 30 minutes
@@ -4542,7 +4563,7 @@ setInterval(function () {
       }
     }
   } catch (e) { /* cleanup is best-effort */ }
-}, 15 * 60 * 1000);
+}, 15 * 60 * 1000).unref();
 
 // POST /files — upload a temp file (multipart form, field name: "file")
 // curl -X POST -H "X-Agent-Key: <key>" -F "file=@myimage.png" https://mycelium.fyi/api/mycelium/files
@@ -5792,19 +5813,17 @@ router.get('/plugins/workers', asyncHandler(function (req, res) {
 //   2. Review the compare diff before trusting the new commit:
 //        https://github.com/SoftBacon-Software/mycelium-plugins/compare/<OLD_SHA>...<NEW_SHA>
 //   3. Update REGISTRY_COMMIT below to the new 40-char SHA.
-// TODO(registry-pin): REGISTRY_COMMIT below is a PLACEHOLDER (Git's null SHA),
-// NOT a real commit pin. Replace it with the live HEAD SHA from step 1 before
-// deploy. The squad executor (Lucy) cannot run git/network per CONTRACT.md, so
-// the live SHA was not fetched here; do NOT ship this value. The load-time guard
-// + tests (test/unit/registry-commit-pin.test.js) validate the pinning mechanism
-// for any valid 40-char SHA, so substituting the real SHA keeps everything green.
-var REGISTRY_COMMIT = '0000000000000000000000000000000000000000';
+// pinned: mycelium-plugins registry commit (SoftBacon-Software/mycelium-plugins).
+// To rotate, follow the steps above (git ls-remote + review the compare diff),
+// then update REGISTRY_COMMIT to the new 40-char SHA. The load-time guard + tests
+// (test/unit/registry-commit-pin.test.js) validate the pin for any valid SHA.
+var REGISTRY_COMMIT = '972a3b351c952d6b39a8e47f62a12cb8aa9c465b';
 var REGISTRY_URL = 'https://raw.githubusercontent.com/SoftBacon-Software/mycelium-plugins/' + REGISTRY_COMMIT + '/registry.json';
 // Fail fast at module load if REGISTRY_URL is ever moved back to a moving ref.
 if (!/[0-9a-f]{40}/.test(REGISTRY_URL)) {
   throw new Error('REGISTRY_URL must be commit-pinned to a 40-char hex SHA; got: ' + REGISTRY_URL);
 }
-export { REGISTRY_COMMIT, REGISTRY_URL };
+export { REGISTRY_COMMIT, REGISTRY_URL, _studioSeenCache, touchStudioUserSeenDebounce };
 
 var registryCache = { data: null, fetched: 0 };
 var REGISTRY_TTL = 3600000; // 1 hour
@@ -6614,21 +6633,21 @@ function runHealthPatrol() {
   var staleAgents = getStaleAgents(staleAgentMins);
   for (var a of staleAgents) {
     updateAgentHeartbeat(a.id, 'offline', '');
-    createEvent('health_patrol', '__system__', null, 'Agent ' + a.id + ' marked offline (no heartbeat in ' + staleAgentMins + ' min)', JSON.stringify({ agent_id: a.id, last_heartbeat: a.last_heartbeat }));
+    emitEvent('health_patrol', '__system__', null, 'Agent ' + a.id + ' marked offline (no heartbeat in ' + staleAgentMins + ' min)', { agent_id: a.id, last_heartbeat: a.last_heartbeat });
     results.actions.push({ type: 'agent_offline', agent_id: a.id });
   }
   results.stale_agents = staleAgents.length;
 
   var staleTasks = getStaleTasks(staleTaskMins);
   for (var t of staleTasks) {
-    createEvent('health_patrol', '__system__', null, 'Task #' + t.id + ' in_progress with no active assignee (>' + staleTaskMins + ' min)', JSON.stringify({ task_id: t.id, assignee: t.assignee }));
+    emitEvent('health_patrol', '__system__', null, 'Task #' + t.id + ' in_progress with no active assignee (>' + staleTaskMins + ' min)', { task_id: t.id, assignee: t.assignee });
     results.actions.push({ type: 'stale_task_warning', task_id: t.id, assignee: t.assignee });
   }
   results.stale_tasks = staleTasks.length;
 
   var staleReqs = getStaleRequests(staleRequestMins);
   for (var r of staleReqs) {
-    createEvent('health_patrol', '__system__', null, 'Request #' + r.id + ' pending for >' + staleRequestMins + ' min', JSON.stringify({ request_id: r.id, from: r.from_agent, to: r.to_agent }));
+    emitEvent('health_patrol', '__system__', null, 'Request #' + r.id + ' pending for >' + staleRequestMins + ' min', { request_id: r.id, from: r.from_agent, to: r.to_agent });
     results.actions.push({ type: 'stale_request', request_id: r.id });
   }
   results.stale_requests = staleReqs.length;
@@ -6637,14 +6656,14 @@ function runHealthPatrol() {
   for (var d of staleDrns) {
     updateAgentHeartbeat(d.id, 'offline', '');
     try { releaseStaleClaimedJobs(d.id); } catch (e) { /* non-critical */ }
-    createEvent('health_patrol', '__system__', null, 'Drone ' + d.id + ' marked offline + jobs released', JSON.stringify({ drone_id: d.id }));
+    emitEvent('health_patrol', '__system__', null, 'Drone ' + d.id + ' marked offline + jobs released', { drone_id: d.id });
     results.actions.push({ type: 'drone_offline', drone_id: d.id });
   }
   results.stale_drones = staleDrns.length;
 
   var staleSteps = getStalePlanSteps(stalePlanStepMins);
   for (var s of staleSteps) {
-    createEvent('health_patrol', '__system__', null, 'Plan step #' + s.id + ' in_progress for >' + stalePlanStepMins + ' min', JSON.stringify({ step_id: s.id, plan_id: s.plan_id, assignee: s.assignee }));
+    emitEvent('health_patrol', '__system__', null, 'Plan step #' + s.id + ' in_progress for >' + stalePlanStepMins + ' min', { step_id: s.id, plan_id: s.plan_id, assignee: s.assignee });
     results.actions.push({ type: 'stale_plan_step', step_id: s.id, plan_id: s.plan_id });
   }
   results.stale_plan_steps = staleSteps.length;
@@ -6660,7 +6679,7 @@ setInterval(function () {
     if (enabled === 'false') return; // defaults to enabled unless explicitly disabled
     runHealthPatrol();
   } catch (e) { console.error('[health_patrol] Error:', e.message); }
-}, PATROL_INTERVAL);
+}, PATROL_INTERVAL).unref();
 
 router.get('/admin/health', asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);

--- a/test/unit/liveness-debounce.test.js
+++ b/test/unit/liveness-debounce.test.js
@@ -1,0 +1,88 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// H2 — liveness-write debounce. getStudioUser() runs on (nearly) every
+// authenticated request and used to fire a `last_seen` UPDATE per request
+// (2-3/req under dashboard polling). touchStudioUserSeenDebounce() caps that
+// at ~one write per 30s per userId via an in-memory last-seen map.
+//
+// These tests exercise the debounce gating directly: the first call records a
+// timestamp, rapid re-calls within the 30s window are skipped, and once the
+// window elapses the cache refreshes again. Harness mirrors
+// test/unit/registry-commit-pin.test.js: fresh temp DB, env set before the
+// dynamic import; pool:'forks' isolates us.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const JWT_SECRET = 'test-jwt-secret'
+
+let tmpDataDir
+let mod
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-liveness-debounce-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+  process.env.JWT_SECRET = JWT_SECRET
+
+  const db = await import('../../server/db.js')
+  db.initDB()
+
+  mod = await import('../../server/routes/mycelium.js')
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+describe('studio liveness-write debounce (H2)', () => {
+  test('exports the debounce cache + wrapper for testability', () => {
+    expect(mod._studioSeenCache).toBeDefined()
+    expect(typeof mod.touchStudioUserSeenDebounce).toBe('function')
+  })
+
+  test('first call records a seen timestamp in the cache', () => {
+    const cache = mod._studioSeenCache
+    const uid = 'debounce-first-' + Date.now()
+    delete cache[uid]
+    mod.touchStudioUserSeenDebounce(uid)
+    expect(typeof cache[uid]).toBe('number')
+    expect(cache[uid]).toBeGreaterThan(0)
+  })
+
+  test('rapid re-calls within the 30s window are debounced (timestamp frozen)', () => {
+    const cache = mod._studioSeenCache
+    const uid = 'debounce-rapid-' + Date.now()
+    delete cache[uid]
+    mod.touchStudioUserSeenDebounce(uid)
+    const first = cache[uid]
+    // hammer it — none of these should advance the timestamp (window is 30s)
+    for (let i = 0; i < 25; i++) mod.touchStudioUserSeenDebounce(uid)
+    expect(cache[uid]).toBe(first)
+  })
+
+  test('after the 30s window elapses the cache refreshes again', () => {
+    const cache = mod._studioSeenCache
+    const uid = 'debounce-expired-' + Date.now()
+    delete cache[uid]
+    mod.touchStudioUserSeenDebounce(uid)
+    // simulate the 30s window having elapsed by back-dating the cached stamp
+    const backdated = cache[uid] - 31000
+    cache[uid] = backdated
+    mod.touchStudioUserSeenDebounce(uid)
+    // the wrapper wrote again → cache holds a fresh stamp, not the back-dated one
+    expect(cache[uid]).not.toBe(backdated)
+    expect(cache[uid]).toBeGreaterThan(backdated)
+  })
+
+  test('getStudioUser routes liveness through the debounced writer (source contract)', () => {
+    const src = readFileSync(join(process.cwd(), 'server/routes/mycelium.js'), 'utf8')
+    // the hot path must call the debounce wrapper, not the raw writer
+    expect(src).toContain('touchStudioUserSeenDebounce(decoded.userId)')
+    // the debounce wrapper must still call the raw writer underneath
+    expect(src).toMatch(/function touchStudioUserSeenDebounce[\s\S]*touchStudioUserSeen\(userId\)/)
+    // the raw immediate write must NOT be called directly from getStudioUser
+    expect(src).not.toContain('touchStudioUserSeen(decoded.userId)')
+  })
+})


### PR DESCRIPTION
Final code cycle of the 2026-07 core hardening drive + the audit-closure documentation. Squad workflow #170 (Ada plan → Lucy code → Echo verify), frontier byte-review, clean-worktree test run.

## The four fixes (server/routes/mycelium.js)
- **C2 — registry pin is now real**: `REGISTRY_COMMIT` null-SHA placeholder → `972a3b3` (verified upstream before landing: commit exists on SoftBacon-Software/mycelium-plugins, `registry.json` at that commit resolves 200). Load-time guard + pin tests unchanged.
- **H7 — graceful shutdown**: `.unref()` on the three module-level cleanup intervals (file TTL, drone sweep, health patrol) + the new debounce-prune interval. The per-connection SSE heartbeat is untouched (cleared on close, correctly ref'd).
- **M7 — health-patrol events reach subscribers**: `runHealthPatrol` now emits via `emitEvent` (5 sites) so patrol events broadcast to SSE instead of DB-only. Raw objects passed — `emitEvent` stringifies internally, so no double-encode. Behavioral note: patrol events now also reach plugin event hooks (previously bypassed; hooks are the intended observer seam).
- **H2 — liveness writes debounced**: `getStudioUser` fired a `last_seen` UPDATE on every authenticated request (2-3/req under dashboard polling). Now ≤1 write/30s per userId via a bounded in-memory map (5-min prune). Safe: every `last_seen` consumer (`getActiveStudioUsers`) works on ≥5-minute windows. +5 tests.

## Audit closure (docs commit)
`docs/audit-2026-07-core-hardening.md` — the code→PR map for the whole drive (#142–#150 + this) and the two deferred-by-design findings, documented instead of changed:
- **M2**: the SSE inner-stringify is the intentional wire contract (live broadcasts must match the DB-backed replay path — `data` is a JSON *string* on both). Inline guard note added at the `emitEvent` site.
- **M5**: bare `parseInt` vs the `parseIntParam` helper — convention drift, no exploitable path found; go-forward rule documented.

## Receipts
- 235/235 tests (34 files) green in a clean worktree off `master` — run independently, matching the squad's own run.
- Byte-review verified the stringify-removal at all 5 M7 sites, the H7 site count against a pre-edit snapshot (3 module-level timers — the audit brief's "four" was a miscount, the two drone sweeps share one interval), and H2 debounce invisibility to all consumers.

📊 frontier-ledger: stage=byte-review + one-way-door verify (upstream SHA existence, wire-format invariant) · squad=volume, frontier=judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K5RA1cTcsfFnvZDu9ZDYZ