### PR TITLE
security(plugins): propagate ssrf-guard to every DB-controlled outbound fetch (estate F1/F2)

### DIFF
--- a/server/plugins/a2a-gateway/routes.js
+++ b/server/plugins/a2a-gateway/routes.js
@@ -4,22 +4,7 @@
 import { Router } from 'express';
 import crypto from 'crypto';
 import createA2ADB from './db.js';
-
-// SSRF protection: validate URLs before fetching
-function validateExternalUrl(urlStr) {
-  try {
-    var parsed = new URL(urlStr);
-    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
-    var host = parsed.hostname.toLowerCase();
-    // Block private/internal IPs
-    if (host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '0.0.0.0') return false;
-    if (host.startsWith('10.') || host.startsWith('192.168.') || host.startsWith('169.254.')) return false;
-    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false;
-    // Block metadata endpoints
-    if (host === 'metadata.google.internal' || host === '169.254.169.254') return false;
-    return true;
-  } catch (e) { return false; }
-}
+import { assertPublicHost, SSRFBlockedError } from '../../lib/ssrf-guard.js';
 
 // A2A status mapping
 var A2A_TO_MYCELIUM = {
@@ -212,7 +197,11 @@ export default function (core) {
     if (!who) return;
     var url = req.body.url;
     if (!url) return apiError(res, 400, 'url is required');
-    if (!validateExternalUrl(url)) return apiError(res, 400, 'Invalid or blocked URL — must be public http(s)');
+    try {
+      await assertPublicHost(url);
+    } catch (ssrfErr) {
+      return apiError(res, 400, 'Invalid or blocked URL — must be public http(s)');
+    }
 
     // Normalize URL
     var agentCardUrl = url.replace(/\/$/, '') + '/.well-known/agent.json';
@@ -258,7 +247,11 @@ export default function (core) {
 
     var agent = db.getExternalAgent(parseInt(agent_id));
     if (!agent) return apiError(res, 404, 'External agent not found');
-    if (!validateExternalUrl(agent.agent_url)) return apiError(res, 400, 'Agent URL is blocked — private/internal addresses not allowed');
+    try {
+      await assertPublicHost(agent.agent_url);
+    } catch (ssrfErr) {
+      return apiError(res, 400, 'Agent URL is blocked — private/internal addresses not allowed');
+    }
 
     var taskId = db.createOutboundTask(agent.id, who, 'tasks/send', message);
 

--- a/server/plugins/daily-digest/routes.js
+++ b/server/plugins/daily-digest/routes.js
@@ -3,6 +3,7 @@
 
 import { Router } from 'express';
 import createDigestDB from './db.js';
+import { assertPublicHost } from '../../lib/ssrf-guard.js';
 
 function gatherDigestData(db, coreDb, periodStart, periodEnd) {
   // Query tasks for completed tasks in period
@@ -168,6 +169,7 @@ export default function (core) {
       var slackWebhook = core.db.prepare("SELECT value FROM plugin_config WHERE plugin_name = 'daily-digest' AND key = 'slack_webhook'").get();
       if (slackWebhook && slackWebhook.value) {
         try {
+          await assertPublicHost(slackWebhook.value);
           await fetch(slackWebhook.value, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -239,6 +241,7 @@ export default function (core) {
       var slackWebhook = core.db.prepare("SELECT value FROM plugin_config WHERE plugin_name = 'daily-digest' AND key = 'slack_webhook'").get();
       if (slackWebhook && slackWebhook.value) {
         try {
+          await assertPublicHost(slackWebhook.value);
           await fetch(slackWebhook.value, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/server/plugins/marketing/outreach/lib/researcher.js
+++ b/server/plugins/marketing/outreach/lib/researcher.js
@@ -2,6 +2,7 @@
 // Ported from Python worker scripts
 
 import { google } from 'googleapis';
+import { assertPublicHost, SSRFBlockedError } from '../../../../lib/ssrf-guard.js';
 
 var COUNTRY_TIMEZONE_MAP = {
   US: 'America/New_York', GB: 'Europe/London', AU: 'Australia/Sydney',
@@ -70,8 +71,21 @@ export async function researchPress(contact) {
   var domain = extractDomain(contact.notes || '');
   if (!domain) return {};
 
+  // SSRF guard: domain is parsed from contact.notes (DB-controlled). Resolve DNS
+  // and block private/link-local/metadata addresses before fetching.
+  var targetUrl = 'https://' + domain;
   try {
-    var resp = await fetch('https://' + domain, { signal: AbortSignal.timeout(10000) });
+    await assertPublicHost(targetUrl);
+  } catch (ssrfErr) {
+    if (ssrfErr instanceof SSRFBlockedError) {
+      console.warn('[outreach-researcher] SSRF blocked for domain:', domain, '—', ssrfErr.message);
+      return { last_content: '(research blocked)', error: 'SSRF blocked' };
+    }
+    throw ssrfErr;
+  }
+
+  try {
+    var resp = await fetch(targetUrl, { signal: AbortSignal.timeout(10000) });
     if (!resp.ok) return {};
     var html = await resp.text();
 

--- a/server/plugins/workflow-automations/handlers.js
+++ b/server/plugins/workflow-automations/handlers.js
@@ -2,6 +2,7 @@
 // Subscribes to all platform events and evaluates automation rules.
 
 import createAutomationDB from './db.js';
+import { assertPublicHost, SSRFBlockedError } from '../../lib/ssrf-guard.js';
 
 function evaluateConditions(conditions, eventData) {
   var data = eventData.data || {};
@@ -83,28 +84,28 @@ function executeAction(action, eventData, core) {
       return { type: 'assign_agent', skipped: true };
     }
     case 'send_webhook': {
-      // SSRF protection: block internal/private URLs
+      // SSRF protection: guard with the canonical ssrf-guard (DNS-aware).
+      // executeAction is synchronous and runs from a sync event hook
+      // (callEventHooks does not await handlers), so guard+fetch run inside a
+      // self-contained async IIFE whose .catch swallows any rejection.
       var webhookUrl = action.url || '';
-      try {
-        var parsed = new URL(webhookUrl);
-        var host = parsed.hostname.toLowerCase();
-        var blocked = host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0' ||
-          host === '::1' || host === '[::1]' || host === '169.254.169.254' ||
-          host.endsWith('.internal') || host.endsWith('.local') ||
-          host.startsWith('10.') || host.startsWith('192.168.') ||
-          /^172\.(1[6-9]|2\d|3[01])\./.test(host);
-        if (blocked || parsed.protocol === 'file:') {
-          console.warn('[workflow-automations] Blocked SSRF attempt to:', webhookUrl);
-          return { type: 'send_webhook', blocked: true, reason: 'Internal/private URL not allowed' };
+      (async function () {
+        try {
+          await assertPublicHost(webhookUrl);
+        } catch (ssrfErr) {
+          if (ssrfErr instanceof SSRFBlockedError) {
+            console.warn('[workflow-automations] Blocked SSRF attempt to:', webhookUrl, '—', ssrfErr.message);
+          } else {
+            console.error('[workflow-automations] Webhook URL validation failed:', ssrfErr.message);
+          }
+          return;
         }
-      } catch (e) {
-        return { type: 'send_webhook', blocked: true, reason: 'Invalid URL' };
-      }
-      fetch(webhookUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ event: eventData.type, agent: agent, data: data, summary: eventData.summary })
-      }).catch(function (e) { console.error('[workflow-automations] Webhook failed:', e.message); });
+        fetch(webhookUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ event: eventData.type, agent: agent, data: data, summary: eventData.summary })
+        }).catch(function (e) { console.error('[workflow-automations] Webhook failed:', e.message); });
+      })().catch(function (e) { console.error('[workflow-automations] Webhook guard failed:', e.message); });
       return { type: 'send_webhook', url: webhookUrl };
     }
     case 'inbox_notify': {

--- a/test/unit/researcher-ssrf.test.js
+++ b/test/unit/researcher-ssrf.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { researchPress } from '../../server/plugins/marketing/outreach/lib/researcher.js';
+
+// The outreach researcher extracts a `domain:` token from contact.notes
+// (DB-controlled, user-settable) and fetches `https://<domain>`. These tests
+// prove the ssrf-guard refuses private / link-local / metadata addresses at
+// that call site and that NO outbound fetch is attempted for them.
+//
+// We use literal IP addresses (the guard's own seam — literal IPs are checked
+// directly without DNS), mirroring how test/unit/ssrf-guard.test.js exercises
+// the guard, so the suite is deterministic and network-free.
+
+describe('outreach researcher SSRF guard (researchPress)', () => {
+  let fetchSpy;
+
+  beforeEach(() => {
+    // researchPress calls the global fetch; spy so we can assert it is never
+    // reached for blocked hosts (and so no real network call ever happens).
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('blocks the cloud metadata / link-local address 169.254.169.254', async () => {
+    var result = await researchPress({ id: 1, type: 'press', notes: 'domain:169.254.169.254' });
+    expect(result.error).toBe('SSRF blocked');
+    expect(result.last_content).toBe('(research blocked)');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('blocks a private RFC1918 address 192.168.1.1', async () => {
+    var result = await researchPress({ id: 2, type: 'press', notes: 'domain:192.168.1.1' });
+    expect(result.error).toBe('SSRF blocked');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('blocks loopback 127.0.0.1', async () => {
+    var result = await researchPress({ id: 3, type: 'press', notes: 'domain:127.0.0.1' });
+    expect(result.error).toBe('SSRF blocked');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns {} (no crash, no fetch) when notes carry no domain token', async () => {
+    var result = await researchPress({ id: 4, type: 'press', notes: 'just some notes' });
+    expect(result).toEqual({});
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The repo's correct SSRF guard (`server/lib/ssrf-guard.js` — DNS-resolving, v4-mapped-v6 aware, fail-closed) was wired only into `db.js` webhook dispatch. The 2026-07-01 estate audit found four plugins with unguarded or weakly-guarded outbound fetches to user/DB-controlled targets. Squad workflow #171 (Ada → Lucy → Echo), m5Max byte-review + clean-worktree tests.

## Sites guarded
- **`marketing/outreach/researcher.js` — THE LIVE hole.** `researchPress` fetches `https://<domain>` where `domain` is parsed from `contact.notes` (DB-controlled via outreach routes). Now `assertPublicHost` first; `SSRFBlockedError` → fail-closed early return.
- **`a2a-gateway/routes.js`** (ships `enabled:false` — latent). Deleted the weak string-prefix `validateExternalUrl` (missed DNS rebinding, `::ffff:` v4-mapped-v6, metadata endpoints outside its short blocklist); `/discover` + `/send` now use `assertPublicHost` → 400 on block.
- **`workflow-automations/handlers.js`.** Replaced the same weak inline validator. `executeAction` is synchronous (`callEventHooks` doesn't await handlers), so guard+fetch run in a self-contained async IIFE with its own `.catch` — guard adoption, not a dispatch refactor.
- **`daily-digest/routes.js`.** Both Slack-webhook deliveries guarded (`slack_webhook` is admin-settable `plugin_config`).

## Left alone (correctly — constant/hardcoded targets)
`discoverer.js` (api.hunter.io), `twitter.js` (api.twitter.com), `auto-memory`/`semantic-memory` (admin-config embedding URLs / local Ollama).

## Receipts
- **+4 tests** (`researcher-ssrf.test.js`): refuses AWS metadata (169.254.169.254), private (192.168.1.1), loopback (127.0.0.1) and asserts **no outbound fetch is attempted** for blocked hosts (spies on `globalThis.fetch`), using literal IPs (the guard's own seam — no DNS mock).
- **239/239 tests (35 files) green** in a clean worktree off `master`, run independently.
- Byte-review verified the guard signature (`assertPublicHost(url)` async, `SSRFBlockedError` class) at all four sites, the deleted validator has zero remaining references, and the async-IIFE case returns cleanly.

Notable: **Lucy corrected three factual errors in Ada's plan by grounding in the actual code** — the vulnerable fetch is in `researchPress` (not `researchCreator`, which uses the YouTube API), the real import depths differ from the plan's, and `executeAction` is synchronous. The gate caught what the plan got wrong.

📊 frontier-ledger #171: stage=byte-review + guard-signature/reachability verify · squad=plan+code+verify volume, frontier=judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K5RA1cTcsfFnvZDu9ZDYZ