### PR TITLE
fix(residency): unhang the mounted route + wire the policy engine (estate F3/F4)

### DIFF
--- a/server/plugins/residency/README.md
+++ b/server/plugins/residency/README.md
@@ -5,10 +5,12 @@ resident on which nodes, each node's RAM budget, and which backend each seat
 prefers. It is the foundation for a residency-aware router that keeps the right
 models warm on the right backends.
 
-**Status — P1 (foundation).** State model + read API + co-reside/swap policy.
-There is **no actuator and no actuation** in P1: this plugin describes residency
-and *decides* what should happen, it does not yet load or evict models. That
-comes in P2.
+**Status — P1 + decision endpoint.** State model, read API, and the
+co-reside/swap policy — **and the policy is now served over HTTP** via
+`POST /api/mycelium/residency/decide`. There is still **no actuator and no
+actuation**: this plugin describes residency, *decides* what should happen, and
+exposes that decision; it does not yet load or evict models. That actuator
+remains future work.
 
 ---
 
@@ -23,9 +25,10 @@ Three tables hold the live picture:
 - **seat_routes** — which backend + kind a given seat (e.g. an agent role)
   prefers, plus an optional mode preference.
 
-A single read endpoint, `GET /api/mycelium/residency`, returns the whole map as
-JSON. A pure policy function, `decideResidency()`, answers "can this model
-co-reside, or must we swap?".
+A read endpoint, `GET /api/mycelium/residency`, returns the whole map as JSON.
+A decision endpoint, `POST /api/mycelium/residency/decide`, runs the pure policy
+function `decideResidency()` to answer "can this model co-reside, or must we
+swap?" and returns the decision.
 
 ## Schema
 
@@ -72,9 +75,32 @@ Returns the live map. No request parameters.
 }
 ```
 
-P1 exposes this single read endpoint. State is seeded through the `db.js`
-helpers (`upsertNode`, `upsertModel`, `upsertRoute`, …) — today by tests,
-tomorrow by an ingestion/actuator step.
+### `POST /api/mycelium/residency/decide`
+
+Runs the residency policy for a candidate model against a node's current
+resident set, given a RAM budget. Authenticated (agent or admin).
+
+```json
+// request
+{ "resident_set": ["default-api"], "candidate": "default-local", "ram_budget_gb": 64 }
+
+// 200 response
+{
+  "ok": true,
+  "decision": {
+    "action": "co-reside",
+    "reason": "resident set 0GB + default-local 8GB = 8GB ≤ budget 64GB; co-reside",
+    "total_gb": 8
+  }
+}
+```
+
+`action` is `co-reside` (the candidate fits within the budget alongside the
+resident set) or `swap` (the resident set must be evicted first, or the budget
+is invalid). Missing or invalid fields return `400`.
+
+State is seeded through the `db.js` helpers (`upsertNode`, `upsertModel`,
+`upsertRoute`, …) — today by tests, tomorrow by an ingestion/actuator step.
 
 ## Policy
 
@@ -109,38 +135,52 @@ from the future actuator, the endpoint, or any caller.
 | --------------- | --------------------------------------------------------------------- |
 | `schema.sql`    | table DDL (applied by the platform loader)                            |
 | `db.js`         | `createResidencyDB(db)` — better-sqlite3 CRUD + `getMap()` (JS core)  |
-| `src/policy.ts` | `decideResidency()` + `modelRssLookup` + `estimateRss()` (pure, TS)   |
-| `src/index.ts`  | `createResidencyPlugin(dbPath)` factory — self-contained, testable (TS) |
+| `src/policy.js` | `decideResidency()` + `modelRssLookup` + `estimateRss()` (pure, JS)   |
+| `src/index.js`  | `createResidencyPlugin(dbPath)` factory — self-contained, testable (JS) |
 | `routes.js`     | Express adapter mounted by the platform loader under `/residency`     |
 | `plugin.json`   | manifest (`routePrefix: /residency`)                                  |
 
-> **Why the split?** The typed, testable surface (`src/index.ts`, `src/policy.ts`)
-> is TypeScript. The DB core (`db.js`) and the platform adapter (`routes.js`)
-> stay JavaScript because the platform loader (`server/plugins.js`) imports
-> `routes.js` in plain Node, which cannot load `.ts` directly. `src/index.ts`
-> imports `db.js`, so both the typed factory and the platform share one DB core.
+> **Why the split?** `routes.js` is the platform's mounted adapter: the loader
+> (`server/plugins.js`) imports it in plain Node and calls the default export
+> with the shared `core` (the live mycelium DB connection + `core.auth`). It is
+> what actually serves `/api/mycelium/residency`. `src/index.js`
+> (`createResidencyPlugin`) is a self-contained, testable factory that opens its
+> own DB connection and exposes a `{ routes }` array of `{ method, path, handler }`
+> — the unit suite exercises it without spinning up Express. Both share one DB
+> core (`db.js`) and one policy core (`src/policy.js`).
 
 Two entry points share the same core:
 
-- **`createResidencyPlugin(dbPath)`** (in `src/index.ts`) opens its own DB
+- **`createResidencyPlugin(dbPath)`** (in `src/index.js`) opens its own DB
   connection and returns `{ name, version, schema, init, routes, cleanup }`.
-  This is what the test suite uses.
+  This is what the unit suite uses to test the handler surface directly.
 - **`routes.js`** is the platform's directory-plugin adapter: the loader passes
-  it the shared `core.db` and mounts it at `/api/mycelium/residency`.
+  it the shared `core.db` and mounts it at `/api/mycelium/residency`. It serves
+  both `GET /` (the map) and `POST /decide` (the policy decision).
+
+### Auth
+
+`routes.js` uses **imperative** auth, not Express middleware. Each handler calls
+`core.auth.checkAgentOrAdmin(req, res)` inline: on success it returns the
+authenticated principal; on failure it sends a `401`/`403` itself and returns a
+falsy value (the handler then bails). It never calls `next()`, so it **must not**
+be used as `router.get('/', authMiddleware, handler)` — doing so hangs every
+authenticated request (the handler never runs). This mirrors the auth pattern
+used throughout `server/routes/mycelium.js`.
 
 ## How to extend
 
-### Add a node actuator (P2)
+### Add a node actuator (future)
 
 1. Populate `actuator_kind` / `actuator_url` on the node (via `upsertNode`).
 2. Add an actuator module that, given a `swap` decision, performs the
    load/evict against that backend and updates `residency_models.state`.
-3. Wire new actuation endpoints in `routes.js` (POST/PATCH). P1 intentionally
-   exposes none.
+3. Wire new actuation endpoints in `routes.js` (POST/PATCH). The decision
+   endpoint (`POST /decide`) is served; load/evict actuation endpoints are not.
 
 ### Add / tune a policy
 
-- **Tune weights:** edit `modelRssLookup` in `src/policy.ts`, or pass explicit
+- **Tune weights:** edit `modelRssLookup` in `src/policy.js`, or pass explicit
   `rss_gb` on resident/model entries (telemetry overrides the lookup).
 - **New policy:** add a function alongside `decideResidency` (e.g. one that
   prefers evicting the least-recently-used resident instead of the whole set)
@@ -166,4 +206,6 @@ npm test -- residency
 ```
 
 The suite (`test/unit/residency.test.js`) covers schema CRUD, the GET map
-shape, and the co-reside/swap policy decisions.
+shape, the co-reside/swap policy decisions, **and the mounted routes via
+supertest** (unauth → 401, agent/admin auth → 200, `POST /decide` → 200/400) —
+the regression class for the auth-hang bug.

--- a/server/plugins/residency/routes.js
+++ b/server/plugins/residency/routes.js
@@ -5,24 +5,68 @@
 // mycelium better-sqlite3 connection. Mounted under routePrefix "/residency",
 // so GET / here resolves to GET /api/mycelium/residency.
 //
-// P1 is read-only: only the map endpoint is exposed. State is seeded through
-// db.js helpers (by tests today; by a future ingestion/actuator step later).
+// Auth is IMPERATIVE, not middleware. core.auth.checkAgentOrAdmin(req, res)
+// sends a 401/403 itself and returns the authenticated principal (or falsy);
+// it never calls next(). Using it as Express middleware therefore hangs every
+// authenticated request (the handler never runs). We call it inline and bail
+// on a falsy return, matching the pattern used in routes/mycelium.js.
 
 import { Router } from 'express';
 import createResidencyDB from './db.js';
+import { decideResidency } from './src/policy.js';
 
 export default function residencyRoutes(core) {
   var router = Router();
   var store = createResidencyDB(core.db);
-  var auth = core && core.auth ? core.auth.checkAgentOrAdmin : function (_req, _res, next) { next(); };
+
+  // Imperative auth: returns the principal on success, or falsy after it has
+  // already sent a 401/403. When no auth is wired (factory/test path), allow.
+  function authenticate(req, res) {
+    if (core && core.auth && core.auth.checkAgentOrAdmin) {
+      return core.auth.checkAgentOrAdmin(req, res);
+    }
+    return true;
+  }
 
   // GET /api/mycelium/residency — live map: nodes + budgets, resident set per
   // node, and seat routes.
-  router.get('/', auth, function (_req, res) {
+  router.get('/', function (req, res) {
+    var who = authenticate(req, res);
+    if (!who) return; // 401/403 already sent
     try {
       res.json({ ok: true, residency: store.getMap() });
     } catch (err) {
       core.apiError(res, 500, 'failed to read residency map: ' + err.message);
+    }
+  });
+
+  // POST /api/mycelium/residency/decide — run the residency policy engine on a
+  // candidate model against the current resident set, given a RAM budget.
+  // Body: { resident_set: string[], candidate: string, ram_budget_gb: number }
+  // Response: { ok: true, decision: { action: 'co-reside'|'swap', reason, total_gb } }
+  router.post('/decide', function (req, res) {
+    var who = authenticate(req, res);
+    if (!who) return; // 401/403 already sent
+    var body = req.body || {};
+    var residentSet = body.resident_set;
+    var candidate = body.candidate;
+    var ramBudgetGb = body.ram_budget_gb;
+    if (
+      !Array.isArray(residentSet) ||
+      typeof candidate !== 'string' || candidate.length === 0 ||
+      typeof ramBudgetGb !== 'number'
+    ) {
+      return core.apiError(
+        res,
+        400,
+        'missing or invalid fields: resident_set (string[]), candidate (string), ram_budget_gb (number)'
+      );
+    }
+    try {
+      var decision = decideResidency(residentSet, candidate, ramBudgetGb);
+      res.json({ ok: true, decision: decision });
+    } catch (err) {
+      core.apiError(res, 500, 'failed to decide residency: ' + err.message);
     }
   });
 

--- a/test/unit/residency.test.js
+++ b/test/unit/residency.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import Database from 'better-sqlite3';
 import os from 'os';
 import fs from 'fs';
@@ -209,5 +209,107 @@ describe('residency policy — decideResidency', () => {
     expect(modelRssLookup).toMatchObject({
       ds4: 80, 'squad-glm': 27, 'oMLX-Lucy-30B': 30, 'default-local': 8, 'default-api': 0
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mounted routes (supertest) — the regression class for the auth-hang bug.
+//
+// routes.js is the Express adapter the platform loader mounts at
+// /api/mycelium/residency. It used core.auth.checkAgentOrAdmin as Express
+// MIDDLEWARE, but that helper is imperative (sends 401/403 itself, returns the
+// principal, never calls next()) — so every AUTHENTICATED request hung. These
+// tests exercise the real mounted adapter with the shared mycelium core
+// (auth + db) and prove: unauth → 401 (responds, no hang), auth → 200 + map,
+// POST /decide runs the policy engine. Harness mirrors auth-roles.test.js.
+// ---------------------------------------------------------------------------
+describe('residency mounted routes (supertest)', () => {
+  let app;
+  let request;
+  let tmpDir;
+  const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef';
+  const AGENT_KEY = 'dvk_' + 'a'.repeat(48);
+
+  beforeAll(async () => {
+    const crypto = await import('node:crypto');
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'residency-mount-'));
+    process.env.DATA_DIR = tmpDir;
+    process.env.ADMIN_KEY = ADMIN_KEY;
+    process.env.JWT_SECRET = 'test-jwt-secret';
+
+    // Shared mycelium DB connection (initDB opens it from DATA_DIR).
+    const db = await import('../../server/db.js');
+    db.initDB();
+
+    // Seed an agent whose key authenticates via the X-Agent-Key header.
+    const hash = crypto.createHash('sha256').update(AGENT_KEY).digest('hex');
+    db.createAgent('residency-agent', 'Residency Agent', 'residency-proj', hash, '["code"]');
+
+    // Seed residency data on the SAME connection the mounted route reads.
+    const store = createResidencyDB(db.getDB());
+    store.upsertNode({ node_id: 'mac', ram_total_gb: 128, ram_budget_gb: 96 });
+    store.upsertRoute({ seat: 'seat-1', backend: 'mac', kind: 'local', mode_pref: 'ollama' });
+
+    // Import the mycelium router AFTER env is set, mount it, then initPlugins()
+    // so the platform loader mounts residency at /residency on that router.
+    const express = (await import('express')).default;
+    const mycelium = await import('../../server/routes/mycelium.js');
+    app = express();
+    app.use(express.json());
+    app.use('/api/mycelium', mycelium.default);
+    await mycelium.initPlugins();
+
+    request = (await import('supertest')).default;
+  });
+
+  afterAll(() => {
+    if (tmpDir) {
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (e) { /* ignore */ }
+    }
+  });
+
+  test('GET /residency without auth → 401 (responds, does not hang)', async () => {
+    const res = await request(app).get('/api/mycelium/residency');
+    expect(res.status).toBe(401);
+  });
+
+  test('GET /residency with agent key → 200 + residency map shape', async () => {
+    const res = await request(app)
+      .get('/api/mycelium/residency')
+      .set('X-Agent-Key', AGENT_KEY);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(Array.isArray(res.body.residency.nodes)).toBe(true);
+    expect(Array.isArray(res.body.residency.seat_routes)).toBe(true);
+    expect(res.body.residency.nodes.length).toBeGreaterThan(0);
+  });
+
+  test('GET /residency with admin key → 200', async () => {
+    const res = await request(app)
+      .get('/api/mycelium/residency')
+      .set('X-Admin-Key', ADMIN_KEY);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  test('POST /residency/decide with valid body → 200 + decision shape', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/residency/decide')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ resident_set: ['default-api'], candidate: 'default-local', ram_budget_gb: 64 });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(['co-reside', 'swap']).toContain(res.body.decision.action);
+    expect(typeof res.body.decision.total_gb).toBe('number');
+    expect(typeof res.body.decision.reason).toBe('string');
+  });
+
+  test('POST /residency/decide with missing fields → 400', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/residency/decide')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ resident_set: ['default-api'] }); // missing candidate + ram_budget_gb
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeTruthy();
   });
 });


### PR DESCRIPTION
The residency plugin was broken at the socket and split-brained (2026-07-01 estate audit). Squad workflow #172 (Ada → Lucy → Echo), m5Max byte-review + clean-worktree tests.

## The hang (F3)
`routes.js` mounted `GET /` with `core.auth.checkAgentOrAdmin` **as Express middleware**. That helper is *imperative* — it sends the 401/403 itself and returns the principal; it **never calls `next()`**. So an *authenticated* request hung forever (the handler never ran); only the unauth 401 path responded. The served endpoint could never 200.

**Fix:** call auth inline and bail on a falsy return — the pattern every route in `mycelium.js` uses. Authed `GET /residency` now returns 200 with the residency map.

## The split-brain (F4)
`src/policy.js` (`decideResidency`) — the plugin's advertised policy engine — was imported **only by the test**; nothing served reached it. **Converged by wiring it in:** a new `POST /residency/decide` (validated body → decision) makes the engine reachable from the mounted route. The `src/index.js` factory is left intact so its tests stay green (a legitimate dual-surface, now documented).

## Receipts
- **+5 supertests on the MOUNTED route** via the real plugin loader (`initPlugins`): the authed-**200** regression that would have caught the hang, admin-200, `POST /decide` 200 + shape, and a missing-fields **400**. Plus a no-auth **401** (responds, doesn't hang).
- **244/244 tests (35 files) green** in a clean worktree off `master`, run independently.
- README reconciled to the bytes (`.js` not `.ts`; the real dual-surface; the new `/decide`; an imperative-auth warning so nobody re-mounts it as middleware).

Byte-review confirmed the auth fix at both handlers, the policy engine genuinely reachable (not orphaned), scope limited to the 3 residency files. Notable: **Lucy corrected the plan's auth-header mistake by grounding in the code** — `checkAgentOrAdmin` reads `X-Agent-Key`/`X-Admin-Key`, not `Authorization: Bearer` (that's the studio-JWT path).

📊 frontier-ledger #172: stage=byte-review + auth-path trace + reachability verify · squad=plan+code+verify, frontier=judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K5RA1cTcsfFnvZDu9ZDYZ