### PR TITLE
chore: remove stray node_modules symlink from #154

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 mcp/node_modules/
 runner/node_modules/
 runner/config.json

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/grb/Projects/mycelium/node_modules


### PR DESCRIPTION
Removes the `node_modules` symlink (mode 120000, local absolute path) accidentally committed in #154, and tightens `.gitignore` (`node_modules/` → `node_modules`) so a symlink of that name can't be tracked again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)