### PR TITLE
security(assets): block DATA_DIR path traversal in asset download

### DIFF
--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -2631,6 +2631,9 @@ router.post('/assets', asyncHandler(function (req, res) {
   var status = req.body.status || 'requested';
   if (!validateEnum(res, req.body.status, ASSET_STATUSES, 'status')) return;
   var assetPath = req.body.path || '';
+  if (assetPath && (assetPath.indexOf('..') !== -1 || nodePath.isAbsolute(assetPath))) {
+    return res.status(400).json({ error: 'invalid asset path' });
+  }
   var metadata = req.body.metadata ? JSON.stringify(req.body.metadata) : '{}';
   var id = createAsset(name, type, projectId, status, assetPath, metadata, agentId);
   emitEvent('asset_registered', agentId, projectId, agentId + ' registered asset: ' + name, { asset_id: id });
@@ -2666,7 +2669,12 @@ router.put('/assets/:id', asyncHandler(function (req, res) {
   if (!validateEnum(res, req.body.status, ASSET_STATUSES, 'status')) return;
   var fields = {};
   if (req.body.status !== undefined) fields.status = req.body.status;
-  if (req.body.path !== undefined) fields.path = req.body.path;
+  if (req.body.path !== undefined) {
+    if (typeof req.body.path === 'string' && (req.body.path.indexOf('..') !== -1 || nodePath.isAbsolute(req.body.path))) {
+      return res.status(400).json({ error: 'invalid asset path' });
+    }
+    fields.path = req.body.path;
+  }
   if (req.body.metadata !== undefined) fields.metadata = JSON.stringify(req.body.metadata);
   if (req.body.drone_job_id !== undefined) fields.drone_job_id = req.body.drone_job_id;
   if (req.body.assigned_to !== undefined) fields.assigned_to = req.body.assigned_to;
@@ -2703,7 +2711,11 @@ router.get('/assets/:id/download', asyncHandler(function (req, res) {
 
   var filePath = asset.file_path || nodePath.join(FILES_DIR, asset.path);
   var resolved = nodePath.resolve(filePath);
-  if (!resolved.startsWith(nodePath.resolve(FILES_DIR)) && !resolved.startsWith(nodePath.resolve(ARTIFACTS_DIR)) && !resolved.startsWith(nodePath.resolve(DATA_DIR))) {
+  // Allow ONLY the two upload/artifact dirs — NOT their parent DATA_DIR, which
+  // holds mycelium.db (Stripe/webhook secrets, bcrypt password + agent-key
+  // hashes). A stored '../mycelium.db' path resolves into DATA_DIR and, with
+  // DATA_DIR allowlisted, streamed the whole DB to any agent key (audit 2026-07-02).
+  if (!resolved.startsWith(nodePath.resolve(FILES_DIR)) && !resolved.startsWith(nodePath.resolve(ARTIFACTS_DIR))) {
     return res.status(403).json({ error: 'File path outside allowed directory' });
   }
   if (!fs.existsSync(resolved)) return res.status(404).json({ error: 'File not found on disk' });

--- a/test/unit/asset-download-path-traversal.test.js
+++ b/test/unit/asset-download-path-traversal.test.js
@@ -1,0 +1,91 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+
+// Regression test for the CRITICAL asset-download path traversal (audit 2026-07-02):
+// any AGENT key could store an asset path of '../mycelium.db' and GET
+// /assets/:id/download to exfiltrate the entire SQLite DB (Stripe/webhook secrets,
+// bcrypt password + agent-key hashes) — because DATA_DIR (the DB's own dir) was in
+// the download allowlist alongside its children FILES_DIR + ARTIFACTS_DIR.
+// Fix: allowlist ONLY FILES_DIR + ARTIFACTS_DIR (the download containment gate),
+// and reject '..'/absolute paths at store time (defense in depth).
+// Harness mirrors directive-and-upload-auth.test.js.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const AGENT_KEY = 'dvk_' + 'b'.repeat(48)
+
+let tmpDataDir
+let db
+let app
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-asset-traversal-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  const routes = (await import('../../server/routes/mycelium.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routes)
+
+  const hash = crypto.createHash('sha256').update(AGENT_KEY).digest('hex')
+  db.createAgent('lucy-traversal', 'Lucy', 'trav-proj', hash, '["code"]')
+
+  // A canary "secret" living directly in DATA_DIR (mirrors mycelium.db's location).
+  writeFileSync(join(tmpDataDir, 'canary-secret.txt'), 'TOP-SECRET-DB-CONTENTS')
+  // A legit downloadable file in the allowed FILES_DIR.
+  const filesDir = join(tmpDataDir, 'files')
+  if (!existsSync(filesDir)) mkdirSync(filesDir, { recursive: true })
+  writeFileSync(join(filesDir, 'legit.txt'), 'hello')
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+describe('asset download — DATA_DIR path traversal is blocked', () => {
+  test('PUT /assets/:id rejects a ../ path at store time (400)', async () => {
+    const created = await request(app).post('/api/mycelium/assets')
+      .set('X-Agent-Key', AGENT_KEY).send({ name: 'a', status: 'ready' })
+    expect(created.status).toBe(200)
+    const res = await request(app).put(`/api/mycelium/assets/${created.body.id}`)
+      .set('X-Agent-Key', AGENT_KEY).send({ path: '../canary-secret.txt' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('invalid asset path')
+  })
+
+  test('POST /assets rejects a ../ path at creation (400)', async () => {
+    const res = await request(app).post('/api/mycelium/assets')
+      .set('X-Agent-Key', AGENT_KEY).send({ name: 'b', status: 'ready', path: '../canary-secret.txt' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('invalid asset path')
+  })
+
+  test('download gate blocks a malicious path stored directly, and leaks NO secret (403)', async () => {
+    // Simulate a pre-existing / store-guard-bypassed bad record by writing straight to the DB.
+    const id = db.createAsset('evil', 'sprite', 'trav-proj', 'ready', '../canary-secret.txt', '{}', 'lucy-traversal')
+    const res = await request(app).get(`/api/mycelium/assets/${id}/download`).set('X-Agent-Key', AGENT_KEY)
+    expect(res.status).toBe(403)
+    expect(res.text || '').not.toContain('TOP-SECRET')
+  })
+
+  test('the real DB (../mycelium.db) is NOT exfiltratable via download (403)', async () => {
+    const id = db.createAsset('evil2', 'sprite', 'trav-proj', 'ready', '../mycelium.db', '{}', 'lucy-traversal')
+    const res = await request(app).get(`/api/mycelium/assets/${id}/download`).set('X-Agent-Key', AGENT_KEY)
+    expect(res.status).toBe(403)
+  })
+
+  test('a legit file in FILES_DIR still downloads (200) — fix is not over-restrictive', async () => {
+    const id = db.createAsset('good', 'sprite', 'trav-proj', 'ready', 'legit.txt', '{}', 'lucy-traversal')
+    const res = await request(app).get(`/api/mycelium/assets/${id}/download`).set('X-Agent-Key', AGENT_KEY)
+    expect(res.status).toBe(200)
+    expect(res.text).toBe('hello')
+  })
+})


### PR DESCRIPTION
## Severity: CRITICAL — arbitrary DB/secret read from any agent key

`GET /assets/:id/download` allowlisted **`DATA_DIR`** — the SQLite database's own directory — alongside its legitimate children `FILES_DIR` and `ARTIFACTS_DIR`. Combined with an **unvalidated** asset `path`, any agent key could exfiltrate the entire database:

1. `PUT /assets/:id` with `{"path": "../mycelium.db"}` (or `POST /assets`) — stored verbatim, no `..` check.
2. `GET /assets/:id/download` → `nodePath.join(FILES_DIR, "../mycelium.db")` resolves to `DATA_DIR/mycelium.db`, which passes `startsWith(DATA_DIR)` → `res.download` streams the whole DB.

The DB holds plaintext `plugin_config` Stripe keys, webhook HMAC secrets, and bcrypt password + agent-key hashes. **Two requests, no admin.**

_Disclosure: no Mycelium instance has ever been publicly reachable (LAN-only), so there is no live breach and nothing to rotate — but the code is public, so the hole is patched._

## Fix
- **Download containment gate:** allowlist only `FILES_DIR` + `ARTIFACTS_DIR`, not their parent `DATA_DIR`. `DATA_DIR/mycelium.db` resolves under neither → `403`. This alone closes both the `../` and absolute-`file_path` vectors.
- **Store-time hardening (defense in depth):** reject `..`/absolute `path` on `POST /assets` and `PUT /assets/:id`.

## Tests
New `test/unit/asset-download-path-traversal.test.js` — 5 cases: both store guards (400), the download-gate containment incl. the real `mycelium.db` (403, no secret in body), and a positive legit `FILES_DIR` download (200) proving the fix isn't over-restrictive. **Full suite: 257/257 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYFckfMPRTUfm9amYoGgPv