### PR TITLE
security(widgets): scope PUT/DELETE /widgets/:id to caller's project (audit S5)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1223,6 +1223,10 @@ export function getAgentSkills(agentId) {
 
 // -- Widgets --
 
+export function getWidget(id) {
+  return db.prepare('SELECT * FROM widgets WHERE id = ?').get(id);
+}
+
 export function createWidget(agentId, projectId, title, widgetType, data) {
   var result = db.prepare(
     "INSERT INTO widgets (agent_id, project_id, title, widget_type, data) VALUES (?, ?, ?, ?, ?)"

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -111,7 +111,7 @@ import {
   getContextHistory, rollbackContextKey,
   logAgentSpend, getAgentSpend, getSpendSummary,
   createRun, updateRun, getRun, listRuns, claimRun, releaseStaleClaimedRuns,
-  createWidget, updateWidget, listWidgets, deleteWidget,
+  createWidget, getWidget, updateWidget, listWidgets, deleteWidget,
   createSkill, getSkill, listSkills, updateSkill, installSkill, uninstallSkill, getAgentSkills,
   createAsset, getAsset, listAssets, updateAsset, deleteAsset,
   autoTaskFromAsset,
@@ -2194,6 +2194,9 @@ router.post('/widgets', asyncHandler(function (req, res) {
 router.put('/widgets/:id', asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
+  var widget = getWidget(req.params.id);
+  if (!widget) return res.status(404).json({ error: 'widget not found' });
+  if (!checkProjectScope(req, res, widget.project_id)) return;
   var updated = updateWidget(req.params.id, req.body);
   if (!updated) return res.status(404).json({ error: 'widget not found' });
   res.json(updated);
@@ -2202,6 +2205,9 @@ router.put('/widgets/:id', asyncHandler(function (req, res) {
 router.delete('/widgets/:id', asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
+  var widget = getWidget(req.params.id);
+  if (!widget) return res.status(404).json({ error: 'widget not found' });
+  if (!checkProjectScope(req, res, widget.project_id)) return;
   deleteWidget(req.params.id);
   res.json({ ok: true });
 }));

--- a/test/unit/widget-scope-auth.test.js
+++ b/test/unit/widget-scope-auth.test.js
@@ -1,0 +1,107 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+
+// Regression test for audit finding S5: widget mutation endpoints
+// (PUT/DELETE /widgets/:id) must scope the mutation to the caller's project.
+//
+// Before the fix they called checkAgentOrAdmin (auth only) and then mutated
+// the widget with NO project-scope check — so ANY authenticated agent could
+// modify or delete ANY widget on the platform, including widgets owned by
+// other projects/agents. The fix loads the widget, runs checkProjectScope on
+// its project_id (the same pattern tasks/plans already use), then mutates.
+//
+// Harness mirrors directive-and-upload-auth.test.js: real router, fresh temp
+// DB, env set before the dynamic import so db.js / routes pick up DATA_DIR +
+// ADMIN_KEY.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const OWNER_KEY = 'dvk_' + 'b'.repeat(48)
+const OTHER_KEY = 'dvk_' + 'c'.repeat(48)
+
+const OWNER_PROJECT = 'owner-proj'
+const OTHER_PROJECT = 'other-proj'
+
+let tmpDataDir
+let db
+let app
+let widgetId
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-widget-scope-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  const routes = (await import('../../server/routes/mycelium.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routes)
+
+  // Owner agent scoped to OWNER_PROJECT.
+  const ownerHash = crypto.createHash('sha256').update(OWNER_KEY).digest('hex')
+  db.createAgent('owner-agent', 'Owner Agent', OWNER_PROJECT, ownerHash, '["code"]')
+
+  // Cross-project agent scoped to a DIFFERENT project.
+  const otherHash = crypto.createHash('sha256').update(OTHER_KEY).digest('hex')
+  db.createAgent('other-agent', 'Other Agent', OTHER_PROJECT, otherHash, '["code"]')
+
+  // A widget owned by OWNER_PROJECT.
+  const created = db.createWidget('owner-agent', OWNER_PROJECT, 'Status Widget', 'status', { hello: 'world' })
+  widgetId = created.id
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+describe('PUT/DELETE /widgets/:id — audit S5 project-scope gate', () => {
+  test('a cross-project agent is 403 on PUT', async () => {
+    const res = await request(app)
+      .put('/api/mycelium/widgets/' + widgetId)
+      .set('X-Agent-Key', OTHER_KEY)
+      .send({ title: 'hacked' })
+    expect(res.status).toBe(403)
+  })
+
+  test('a cross-project agent is 403 on DELETE', async () => {
+    const res = await request(app)
+      .delete('/api/mycelium/widgets/' + widgetId)
+      .set('X-Agent-Key', OTHER_KEY)
+    expect(res.status).toBe(403)
+  })
+
+  test('the owning agent can PUT its own widget (200)', async () => {
+    const res = await request(app)
+      .put('/api/mycelium/widgets/' + widgetId)
+      .set('X-Agent-Key', OWNER_KEY)
+      .send({ title: 'updated by owner' })
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('updated by owner')
+  })
+
+  test('admin can PUT any widget (200)', async () => {
+    const res = await request(app)
+      .put('/api/mycelium/widgets/' + widgetId)
+      .set('X-Admin-Key', ADMIN_KEY)
+      .set('X-Acting-As', 'greatness')
+      .send({ title: 'updated by admin' })
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('updated by admin')
+  })
+
+  test('admin can DELETE any widget (200)', async () => {
+    const res = await request(app)
+      .delete('/api/mycelium/widgets/' + widgetId)
+      .set('X-Admin-Key', ADMIN_KEY)
+      .set('X-Acting-As', 'greatness')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+})


### PR DESCRIPTION
## Finding S5 (MEDIUM) — missing authorization scope on widget mutations

`PUT`/`DELETE /widgets/:id` authenticated the caller with `checkAgentOrAdmin` but mutated with **no project scope**, so any authenticated agent could modify or delete any widget on the platform, including other projects'.

## Fix
Load the widget (404 if missing), run the **existing** `checkProjectScope` helper on its `project_id` before mutating — the exact pattern the task/plan handlers already use. Admin still passes. Adds a minimal `getWidget(id)` (parameterized). Purely additive; nothing weakened.

## Tests
New `test/unit/widget-scope-auth.test.js`: cross-project agent → 403 on PUT and DELETE; owner/admin → 200. **Full suite 262/262.**

---
🤖 This is the lab's **first squad-authored PR**: specced by m5Max, **coded by the local squad (GLM-5.2 in Lucy's chair)**, verified by Echo (Qwen3.6-27B) + the efficacy gate, then byte-reviewed and suite-run by m5Max before filing.

https://claude.ai/code/session_01SYFckfMPRTUfm9amYoGgPv