### PR TITLE
fix(auto-memory): robust extraction (force JSON) + surface LLM errors in /stats

### DIFF
--- a/server/plugins/auto-memory/llm.js
+++ b/server/plugins/auto-memory/llm.js
@@ -50,9 +50,13 @@ async function callOpenAI(baseUrl, model, apiKey, prompt) {
       model: model,
       messages: [{ role: 'user', content: prompt }],
       temperature: 0.3,
-      max_tokens: 2000
+      max_tokens: 2000,
+      // Constrained decoding: force valid JSON so small local models (nemotron-mini on
+      // the jetson) can't return markdown/prose the fact-parser then silently drops.
+      // Both auto-memory prompts (extraction + consolidation) request JSON. (2026-07-06)
+      response_format: { type: 'json_object' }
     }),
-    signal: AbortSignal.timeout(30000)
+    signal: AbortSignal.timeout(60000)  // jetson small model ~22s/call; 30s was too tight
   });
   if (!response.ok) throw new Error('OpenAI error: HTTP ' + response.status);
   var data = await response.json();

--- a/server/plugins/auto-memory/routes.js
+++ b/server/plugins/auto-memory/routes.js
@@ -128,6 +128,25 @@ export default function (core) {
 
 // ---- Extraction ----
 
+// Robustly pull a facts array from an LLM response (2026-07-06 parse-robustness).
+// Handles response_format=json_object -> {"facts":[...]}, a bare JSON array, and
+// JSON embedded in prose/code fences — so a small local model (nemotron-mini on the
+// jetson) that wraps or wobbles its output no longer yields silent 0-fact extractions.
+function parseFactArray(response) {
+  if (!response) return [];
+  var text = String(response);
+  try {
+    var whole = JSON.parse(text.trim());
+    if (Array.isArray(whole)) return whole;
+    if (whole && Array.isArray(whole.facts)) return whole.facts;
+  } catch (_) { /* fall through */ }
+  var objMatch = text.match(/\{[\s\S]*\}/);
+  if (objMatch) { try { var obj = JSON.parse(objMatch[0]); if (obj && Array.isArray(obj.facts)) return obj.facts; } catch (_) {} }
+  var arrMatch = text.match(/\[[\s\S]*\]/);
+  if (arrMatch) { try { var arr = JSON.parse(arrMatch[0]); if (Array.isArray(arr)) return arr; } catch (_) {} }
+  return [];
+}
+
 var EXTRACTION_PROMPT = `Given this agent activity, extract durable knowledge facts.
 Only extract facts useful across sessions — preferences, decisions, patterns, architecture choices, conventions.
 Do NOT extract: temporary status, in-progress work, timestamps, routine heartbeats.
@@ -137,7 +156,7 @@ Each fact's "category" MUST be exactly ONE word from this set: preference, decis
 Activity:
 {content}
 
-Return ONLY a JSON array (no markdown, no prose). Each item: {"category":"<one word>","fact_text":"...","confidence":0.0-1.0}`;
+Return a JSON object of the form {"facts":[{"category":"<one word>","fact_text":"...","confidence":0.5}]} (no markdown, no prose).`;
 
 export async function extractFacts(db, config, text, agentId, projectId) {
   if (!text || text.length < 20) return [];
@@ -148,12 +167,10 @@ export async function extractFacts(db, config, text, agentId, projectId) {
     var response = await callLLM(config, prompt);
     if (!response) return [];
 
-    // Parse JSON from response
-    var jsonMatch = response.match(/\[[\s\S]*\]/);
-    if (!jsonMatch) return [];
-    var facts = JSON.parse(jsonMatch[0]);
-
-    if (!Array.isArray(facts)) return [];
+    // Parse facts robustly (2026-07-06): response_format=json_object yields
+    // {"facts":[...]}; parseFactArray also handles bare arrays + prose-wrapped JSON.
+    var facts = parseFactArray(response);
+    if (!facts.length) return [];
 
     var created = [];
     for (var fact of facts) {

--- a/server/plugins/auto-memory/routes.js
+++ b/server/plugins/auto-memory/routes.js
@@ -120,6 +120,23 @@ export default function (core) {
         facts_decay_pruned: decayPruned
       };
     } catch (e) { /* non-critical */ }
+    // Surface extraction/consolidation LLM health so a SILENT failure — a configured
+    // LLM that went unreachable — becomes VISIBLE. This is exactly how the memory
+    // quietly broke 2026-07-06: errors were logged to am_extraction_errors the whole
+    // time, but nothing surfaced them. (mycelium house rule: no silent failures.)
+    try {
+      var es = db.getErrorStats();
+      var recent = db.getExtractionErrors(1);
+      stats.extraction_errors = {
+        total: es.total,
+        last_24h: es.last24h,
+        last_error: recent.length ? {
+          at: recent[0].created_at,
+          source: recent[0].source_event,
+          message: (recent[0].error_message || '').slice(0, 200)
+        } : null
+      };
+    } catch (e) { /* non-critical */ }
     res.json(stats);
   });
 


### PR DESCRIPTION
Two hardening fixes for the auto-memory plugin's extraction/consolidation:
- **Force JSON** via `response_format` and a resilient parse, so a chatty model reply no longer silently yields zero memories.
- **Surface extraction/consolidation LLM errors in `/stats`** instead of swallowing them (no silent failures — house rule).

Split out of #161; this is the auto-memory concern on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs9CULmcFF6XDk4s3E1y2q