### PR TITLE
security(ssrf): re-validate host on every redirect hop (F2 red-team)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import migrateTableNames from './migrate-table-names.js';
-import { assertPublicHost, SSRFBlockedError } from './lib/ssrf-guard.js';
+import { assertPublicHost, guardedFetch, SSRFBlockedError } from './lib/ssrf-guard.js';
 
 var __dirname = path.dirname(fileURLToPath(import.meta.url));
 var DATA_DIR = process.env.DATA_DIR || path.join(__dirname, 'data');
@@ -2287,10 +2287,13 @@ export async function dispatchWebhook(event, agentId, data) {
     try { events = JSON.parse(wh.events); } catch (e) { console.warn('[mycelium] JSON parse failed for webhook.events (webhook: ' + wh.id + '):', e.message); continue; }
     if (events.indexOf(event) === -1 && events.indexOf('*') === -1) continue;
 
+    // Allow loopback if MYCELIUM_WEBHOOK_ALLOW_LOOPBACK is set to '1'. Declared at
+    // loop-body scope so the redirect-guarded delivery below reuses the same flag
+    // (the guardedFetch call sits outside the try, so a try-scoped const is undefined there).
+    const allowLoopback = process.env.MYCELIUM_WEBHOOK_ALLOW_LOOPBACK === '1';
+
     // SSRF Guard: validate the webhook URL before making the request
     try {
-      // Allow loopback if MYCELIUM_WEBHOOK_ALLOW_LOOPBACK is set to '1'
-      const allowLoopback = process.env.MYCELIUM_WEBHOOK_ALLOW_LOOPBACK === '1';
       await assertPublicHost(wh.url, { allowLoopback });
     } catch (ssrfError) {
       if (ssrfError instanceof SSRFBlockedError) {
@@ -2331,9 +2334,11 @@ export async function dispatchWebhook(event, agentId, data) {
     var whId = wh.id;
     var startTime = Date.now();
 
-    // Non-blocking fetch with 5s timeout and retry (up to 3 attempts)
+    // Non-blocking fetch with 5s timeout and retry (up to 3 attempts).
+    // guardedFetch re-runs the SSRF guard on every redirect hop so a public
+    // first-hop can't 302 into an internal address.
     (function deliverWithRetry(url, opts, attempt) {
-      fetch(url, Object.assign({}, opts, { signal: AbortSignal.timeout(5000) }))
+      guardedFetch(url, Object.assign({}, opts, { signal: AbortSignal.timeout(5000) }), { allowLoopback })
         .then(function (resp) {
           var duration = Date.now() - startTime;
           return resp.text().then(function (body) {
@@ -2341,6 +2346,12 @@ export async function dispatchWebhook(event, agentId, data) {
           });
         }).catch(function (err) {
           var duration = Date.now() - startTime;
+          // SSRF blocks (incl. a redirect to a private host) must NOT be retried.
+          if (err instanceof SSRFBlockedError) {
+            logWebhookDelivery(whId, event, agentId, payload, null, null, 'SSRF blocked: ' + err.message, duration);
+            console.warn('[webhook] SSRF blocked for webhook ' + whId + ':', err.message);
+            return;
+          }
           if (attempt < 3) {
             var delay = Math.pow(2, attempt) * 1000; // 2s, 4s backoff
             setTimeout(function () { deliverWithRetry(url, opts, attempt + 1); }, delay);

--- a/server/lib/ssrf-guard.js
+++ b/server/lib/ssrf-guard.js
@@ -113,3 +113,72 @@ export async function assertPublicHost(url, { allowLoopback = false } = {}) {
   for (const r of records) check(r.address);
   return { hostname: host, ip: records[0].address };
 }
+
+// HTTP statuses that constitute a redirect the guard must follow manually so it
+// can re-validate the target. Matches fetch's own redirect set.
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+// Upper bound on manual redirect following. Tighter than fetch's built-in 20 —
+// these are server-to-server webhook/discover calls, not a browser.
+const DEFAULT_MAX_REDIRECTS = 5;
+
+/**
+ * fetch() that re-runs `assertPublicHost` on the initial URL **and on the
+ * resolved target of every redirect hop**, then bounds the hop count.
+ *
+ * `assertPublicHost` alone only vetoes the *first* hop. With Node's default
+ * `redirect: 'follow'`, a public host can answer `302 → http://127.0.0.1/…`
+ * (or any internal/metadata address) and `fetch` will silently follow it — an
+ * SSRF bypass. By forcing `redirect: 'manual'` and re-validating each
+ * `Location` before following, every hop is gated. Re-resolving DNS at each hop
+ * also narrows (does not eliminate) the DNS-rebinding TOCTOU window between
+ * validation and connect.
+ *
+ * Note: Node's global `fetch` (undici), unlike the browser WHATWG fetch, exposes
+ * the real 3xx status and a readable `Location` header under `redirect:
+ * 'manual'` — so no extra dependency is needed to follow hops manually.
+ *
+ * @param {string} url
+ * @param {object} [options] - standard fetch options; `redirect` is forced to 'manual'
+ * @param {{ allowLoopback?: boolean, maxRedirects?: number }} [guardOptions]
+ * @returns {Promise<Response>} the final (non-redirect) response
+ * @throws {SSRFBlockedError} if any hop targets a private/internal host, on a
+ *   malformed `Location`, or when the hop count is exceeded
+ */
+export async function guardedFetch(url, options = {}, { allowLoopback = false, maxRedirects = DEFAULT_MAX_REDIRECTS } = {}) {
+  let fetchOpts = { ...options, redirect: 'manual' };
+  let currentUrl = url;
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    // Re-validate the host on EVERY hop — first hop and each redirect target.
+    await assertPublicHost(currentUrl, { allowLoopback });
+
+    const response = await fetch(currentUrl, fetchOpts);
+    const status = response.status;
+    const location = response.headers.get('location');
+    if (!REDIRECT_STATUSES.has(status) || !location) {
+      return response;
+    }
+    if (hop === maxRedirects) {
+      throw new SSRFBlockedError(`Too many redirects (>${maxRedirects}) following ${url}`);
+    }
+    let nextUrl;
+    try {
+      nextUrl = new URL(location, currentUrl).href;
+    } catch (e) {
+      throw new SSRFBlockedError(`Malformed redirect Location: ${location}`);
+    }
+    currentUrl = nextUrl;
+    // Match fetch redirect semantics: 301/302/303 downgrade the method to GET
+    // and drop the body; 307/308 preserve method and body. (A body on a GET
+    // would make undici throw, so it must be cleared.)
+    if (status === 301 || status === 302 || status === 303) {
+      const method = (fetchOpts.method || 'GET').toUpperCase();
+      if (method !== 'GET' && method !== 'HEAD') {
+        fetchOpts = { ...fetchOpts, method: 'GET', body: undefined };
+      }
+    }
+  }
+  // Unreachable when maxRedirects >= 0, but fail CLOSED rather than returning
+  // undefined if the loop ever exits without resolving.
+  throw new SSRFBlockedError(`Too many redirects following ${url}`);
+}

--- a/server/plugins/a2a-gateway/routes.js
+++ b/server/plugins/a2a-gateway/routes.js
@@ -4,7 +4,7 @@
 import { Router } from 'express';
 import crypto from 'crypto';
 import createA2ADB from './db.js';
-import { assertPublicHost, SSRFBlockedError } from '../../lib/ssrf-guard.js';
+import { assertPublicHost, guardedFetch, SSRFBlockedError } from '../../lib/ssrf-guard.js';
 
 // A2A status mapping
 var A2A_TO_MYCELIUM = {
@@ -207,7 +207,7 @@ export default function (core) {
     var agentCardUrl = url.replace(/\/$/, '') + '/.well-known/agent.json';
 
     try {
-      var response = await fetch(agentCardUrl, {
+      var response = await guardedFetch(agentCardUrl, {
         headers: { 'Accept': 'application/json' },
         signal: AbortSignal.timeout(10000)
       });
@@ -219,6 +219,9 @@ export default function (core) {
       core.emitEvent('a2a_agent_discovered', who, null, who + ' discovered A2A agent: ' + (card.name || url), { agent_url: url, agent_id: id });
       res.json({ ok: true, id: id, agent: db.getExternalAgent(id) });
     } catch (e) {
+      if (e instanceof SSRFBlockedError) {
+        return apiError(res, 400, 'Invalid or blocked URL — must be public http(s)');
+      }
       return apiError(res, 502, 'Failed to discover agent: ' + e.message);
     }
   });
@@ -269,7 +272,7 @@ export default function (core) {
         }
       };
 
-      var response = await fetch(a2aUrl, {
+      var response = await guardedFetch(a2aUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(rpcBody),
@@ -292,6 +295,9 @@ export default function (core) {
       res.json({ ok: true, task_id: taskId, result: a2aResult });
     } catch (e) {
       db.updateOutboundTask(taskId, { status: 'failed', result: { error: e.message } });
+      if (e instanceof SSRFBlockedError) {
+        return apiError(res, 400, 'Agent URL is blocked — private/internal addresses not allowed');
+      }
       return apiError(res, 502, 'Failed to send A2A task: ' + e.message);
     }
   });

--- a/server/plugins/daily-digest/routes.js
+++ b/server/plugins/daily-digest/routes.js
@@ -3,7 +3,7 @@
 
 import { Router } from 'express';
 import createDigestDB from './db.js';
-import { assertPublicHost } from '../../lib/ssrf-guard.js';
+import { assertPublicHost, guardedFetch } from '../../lib/ssrf-guard.js';
 
 function gatherDigestData(db, coreDb, periodStart, periodEnd) {
   // Query tasks for completed tasks in period
@@ -170,7 +170,7 @@ export default function (core) {
       if (slackWebhook && slackWebhook.value) {
         try {
           await assertPublicHost(slackWebhook.value);
-          await fetch(slackWebhook.value, {
+          await guardedFetch(slackWebhook.value, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ text: '*' + digestType + ' Digest*\n' + summary })
@@ -242,7 +242,7 @@ export default function (core) {
       if (slackWebhook && slackWebhook.value) {
         try {
           await assertPublicHost(slackWebhook.value);
-          await fetch(slackWebhook.value, {
+          await guardedFetch(slackWebhook.value, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ text: '*' + report.digest_type + ' Digest (re-sent)*\n' + report.summary })

--- a/server/plugins/marketing/outreach/lib/researcher.js
+++ b/server/plugins/marketing/outreach/lib/researcher.js
@@ -2,7 +2,7 @@
 // Ported from Python worker scripts
 
 import { google } from 'googleapis';
-import { assertPublicHost, SSRFBlockedError } from '../../../../lib/ssrf-guard.js';
+import { assertPublicHost, guardedFetch, SSRFBlockedError } from '../../../../lib/ssrf-guard.js';
 
 var COUNTRY_TIMEZONE_MAP = {
   US: 'America/New_York', GB: 'Europe/London', AU: 'Australia/Sydney',
@@ -85,7 +85,7 @@ export async function researchPress(contact) {
   }
 
   try {
-    var resp = await fetch(targetUrl, { signal: AbortSignal.timeout(10000) });
+    var resp = await guardedFetch(targetUrl, { signal: AbortSignal.timeout(10000) });
     if (!resp.ok) return {};
     var html = await resp.text();
 

--- a/server/plugins/workflow-automations/handlers.js
+++ b/server/plugins/workflow-automations/handlers.js
@@ -2,7 +2,7 @@
 // Subscribes to all platform events and evaluates automation rules.
 
 import createAutomationDB from './db.js';
-import { assertPublicHost, SSRFBlockedError } from '../../lib/ssrf-guard.js';
+import { assertPublicHost, guardedFetch, SSRFBlockedError } from '../../lib/ssrf-guard.js';
 
 function evaluateConditions(conditions, eventData) {
   var data = eventData.data || {};
@@ -100,7 +100,7 @@ function executeAction(action, eventData, core) {
           }
           return;
         }
-        fetch(webhookUrl, {
+        guardedFetch(webhookUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ event: eventData.type, agent: agent, data: data, summary: eventData.summary })

--- a/test/unit/ssrf-guard.test.js
+++ b/test/unit/ssrf-guard.test.js
@@ -1,6 +1,6 @@
 // Test suite for SSRF Guard functionality
-import { assertPublicHost, SSRFBlockedError } from '../../server/lib/ssrf-guard.js';
-import { test, expect } from 'vitest';
+import { assertPublicHost, guardedFetch, SSRFBlockedError } from '../../server/lib/ssrf-guard.js';
+import { test, expect, vi } from 'vitest';
 
 test('assertPublicHost allows valid public URLs', async () => {
   // Test a valid public URL - note: DNS resolution is not guaranteed in test environment
@@ -130,4 +130,74 @@ test('assertPublicHost blocks IPv4-mapped IPv6 private addresses', async () => {
   // ::ffff:10.0.0.1 maps to a private v4 — must be blocked
   await expect(assertPublicHost('http://[::ffff:10.0.0.1]/test', { allowLoopback: false }))
     .rejects.toThrow(SSRFBlockedError);
+});
+
+// --- guardedFetch: re-validate the host on EVERY redirect hop (F2 red-team) ---
+//
+// assertPublicHost only vets the first hop. The default `fetch` follows 3xx
+// redirects without re-checking, so a public host can answer 302 → an internal
+// address and reach it. guardedFetch forces redirect:'manual' and re-runs the
+// guard on each Location. These use literal public IPs as the first hop (the
+// guard checks literals directly, no DNS) and a mocked fetch, so the suite is
+// deterministic and network-free — mirroring researcher-ssrf.test.js.
+
+function redirectResponse(location) {
+  return new Response(null, { status: 302, headers: { location } });
+}
+
+test('guardedFetch blocks a redirect to a loopback host (F2 bypass)', async () => {
+  // First hop is a public IP (passes the guard); the server 302s to loopback.
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    .mockResolvedValue(redirectResponse('http://127.0.0.1:3009/internal'));
+  try {
+    await expect(guardedFetch('https://1.1.1.1/', { method: 'GET' }))
+      .rejects.toThrow(SSRFBlockedError);
+    // Exactly one request: the redirect target must never be fetched.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  } finally {
+    fetchSpy.mockRestore();
+  }
+});
+
+test('guardedFetch blocks a redirect to the cloud metadata address', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    .mockResolvedValue(redirectResponse('http://169.254.169.254/latest/meta-data/'));
+  try {
+    await expect(guardedFetch('https://1.1.1.1/', { method: 'GET' }))
+      .rejects.toThrow(SSRFBlockedError);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  } finally {
+    fetchSpy.mockRestore();
+  }
+});
+
+test('guardedFetch follows a redirect to another PUBLIC host and returns the final response', async () => {
+  let calls = 0;
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+    calls++;
+    if (calls === 1) return redirectResponse('https://1.0.0.1/');
+    return new Response('ok', { status: 200 });
+  });
+  try {
+    const res = await guardedFetch('https://1.1.1.1/', { method: 'GET' });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  } finally {
+    fetchSpy.mockRestore();
+  }
+});
+
+test('guardedFetch bounds the redirect hop count', async () => {
+  // Every response redirects to another public IP — never resolves, so the hop
+  // cap (not the guard) must terminate it, as an SSRFBlockedError.
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    .mockResolvedValue(redirectResponse('https://1.1.1.1/'));
+  try {
+    await expect(guardedFetch('https://1.1.1.1/', { method: 'GET' }, { maxRedirects: 2 }))
+      .rejects.toThrow(/redirects/);
+    expect(fetchSpy.mock.calls.length).toBeLessThanOrEqual(3);
+  } finally {
+    fetchSpy.mockRestore();
+  }
 });


### PR DESCRIPTION
## What

Fixes red-team finding **F2 (Medium, code-confirmed)** from `redteam-2026-07-09.md`: the `assertPublicHost()` SSRF guard validated only the **first hop**, while the guarded `fetch()` call sites used Node's default `redirect: 'follow'`. A public first-hop host could answer `302 → http://127.0.0.1:3009/…` (or any internal/metadata address) and `fetch` would silently follow it — an **SSRF bypass via redirect-following** (and the related **DNS-rebinding TOCTOU**, since `fetch` re-resolves at connect time).

Affected sites (all guarded-fetch sites, per `grep assertPublicHost`):
- `server/db.js` — webhook delivery
- `server/plugins/a2a-gateway/routes.js` — `POST /a2a/discover` (any-agent-reachable) + `/a2a/send`
- `server/plugins/daily-digest/routes.js` — Slack delivery ×2
- `server/plugins/workflow-automations/handlers.js` — `send_webhook`
- `server/plugins/marketing/outreach/lib/researcher.js` — `researchPress`

## Fix

Add **`guardedFetch()`** to `server/lib/ssrf-guard.js` and route every guarded-fetch site through it. It:
- forces `redirect: 'manual'` and re-runs `assertPublicHost` on the initial URL **and on the resolved target of every redirect hop**,
- bounds the hop count (`DEFAULT_MAX_REDIRECTS = 5`, tighter than fetch's built-in 20),
- applies fetch-spec redirect method semantics (301/302/303 → GET + drop body; 307/308 preserve),
- **fails CLOSED** — a private/loopback/metadata redirect target, a malformed `Location`, or an exceeded hop count all throw `SSRFBlockedError`.

Implementation note: Node's global `fetch` (undici), unlike browser WHATWG fetch, exposes the **real 3xx status and a readable `Location` header** under `redirect: 'manual'` (verified against a live local redirector on Node 25) — so manual hop-following needs no extra dependency.

The per-site upfront `assertPublicHost` checks are kept as a fail-fast/logging layer; `guardedFetch` adds redirect re-validation on top. Webhook delivery now **skips retry on `SSRFBlockedError`** (previously it would have retried an SSRF block 3×).

## Gate

- ✅ **New test: redirect-to-internal is BLOCKED** — `guardedFetch` rejects a `302 → http://127.0.0.1:3009/…` and a `302 → http://169.254.169.254/…` (no request made to the internal target). Plus a safe-redirect-followed positive test and a hop-count-bound test.
- ✅ **Full suite green** — `npm test` → 261 passed across 37 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)