### PR TITLE
security(.fyi): harden the public site (Fable-cyber threat model)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -23,6 +23,7 @@ import jwt from 'jsonwebtoken';
 import { initDB, getDB, resolveStaleRequests, pruneWebhookDeliveries, purgeExpiredContextKeys, cleanupContextHistory, cleanupSavepoints } from './db.js';
 import myceliumRoutes, { initPlugins } from './routes/mycelium.js';
 import { initEmail } from './email.js';
+import { securityHeadersMiddleware } from './lib/security-headers.js';
 
 // Lightweight auth check for voice endpoints (reuses JWT_SECRET/ADMIN_KEY from env)
 function isAdminKey(key) {
@@ -135,15 +136,11 @@ app.use(cors({
   allowedHeaders: ['Content-Type', 'Authorization', 'X-Admin-Key', 'X-Agent-Key']
 }));
 
-// Security headers
-app.use(function (req, res, next) {
-  res.set('X-Content-Type-Options', 'nosniff');
-  res.set('X-Frame-Options', 'DENY');
-  res.set('X-XSS-Protection', '0');
-  res.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  res.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-  next();
-});
+// Security headers — policy centralised + unit-tested in lib/security-headers.js.
+// Adds Strict-Transport-Security and Content-Security-Policy (previously missing;
+// HSTS can only ever be an HTTP header, and the site shipped only a weak <meta>
+// CSP). Applied globally: CSP is inert on JSON responses and HSTS is wanted on all.
+app.use(securityHeadersMiddleware());
 
 app.use(express.json({
   limit: '1mb',

--- a/server/lib/security-headers.js
+++ b/server/lib/security-headers.js
@@ -1,0 +1,71 @@
+// Security-header policy — applied to every response the platform serves.
+//
+// This is the HTTP security-header contract for BOTH the mycelium.fyi public
+// static site (served from public/ via express.static) and the /api/mycelium
+// API. It is centralised here so the policy is a single source of truth and is
+// unit-tested (test/unit/security-headers.test.js); server/index.js mounts it
+// as global middleware.
+//
+// Why HSTS and CSP live HERE (not in the site repo):
+//   - mycelium.fyi is served by THIS platform's Express server (server: railway-
+//     hikari), not by the `serve` package. The site repo's serve.json / railway
+//     json only govern isolated local preview; production headers come from this
+//     middleware. Before this module existed the site shipped with no HSTS and
+//     only a weak <meta> CSP — see PR "security(.fyi): harden the public site".
+//   - Strict-Transport-Security can ONLY be enforced via an HTTP response header
+//     (a <meta> tag cannot set it), so this middleware is the sole HSTS origin.
+//   - The CSP is tuned for the static export: Next.js App Router hydrates via an
+//     inline <script> (the RSC payload), so script-src needs 'unsafe-inline';
+//     Tailwind v4 inline styles need style-src 'unsafe-inline'. The same policy
+//     is mirrored as a defense-in-depth <meta> tag in the site's layout.tsx.
+
+// max-age=2 years; includeSubDomains. `preload` intentionally omitted — it is a
+// one-way door (requires submitting to the HSTS preload list and guarantees that
+// every subdomain of mycelium.fyi is HTTPS forever); add it only with explicit
+// operator sign-off once all subdomains are confirmed HTTPS-only.
+export const HSTS_VALUE = 'max-age=63072000; includeSubDomains';
+
+// Locked down: no 'unsafe-eval', no wildcard hosts, no plugins, no external
+// framing. Mirrors the site repo's serve.json CSP exactly.
+export const CSP_VALUE = [
+  "default-src 'self'",
+  "img-src 'self' data:",
+  "style-src 'self' 'unsafe-inline'",
+  "script-src 'self' 'unsafe-inline'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'"
+].join('; ');
+
+/**
+ * The full policy as ordered [header, value] pairs. Order-stable so tests can
+ * assert the whole set in one pass. X-Frame-Options: DENY backs up the CSP
+ * frame-ancestors 'none' for legacy browsers; X-XSS-Protection: 0 disables the
+ * buggy, exploitable legacy IE XSS auditor (modern guidance).
+ */
+export const SECURITY_HEADERS = [
+  ['X-Content-Type-Options', 'nosniff'],
+  ['X-Frame-Options', 'DENY'],
+  ['X-XSS-Protection', '0'],
+  ['Referrer-Policy', 'strict-origin-when-cross-origin'],
+  ['Permissions-Policy', 'camera=(), microphone=(), geolocation=()'],
+  ['Strict-Transport-Security', HSTS_VALUE],
+  ['Content-Security-Policy', CSP_VALUE]
+];
+
+/**
+ * Express middleware: stamp the full security-header policy onto every response.
+ * CSP on JSON API responses is harmless (browsers apply CSP only to rendered
+ * documents), and HSTS is desirable on every response, so applying it globally
+ * is both safe and defense-in-depth.
+ */
+export function securityHeadersMiddleware() {
+  return function securityHeaders(req, res, next) {
+    for (const [key, value] of SECURITY_HEADERS) {
+      res.set(key, value);
+    }
+    next();
+  };
+}
+
+export default securityHeadersMiddleware;

--- a/test/unit/security-headers.test.js
+++ b/test/unit/security-headers.test.js
@@ -1,0 +1,77 @@
+import { describe, test, expect } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import {
+  SECURITY_HEADERS,
+  CSP_VALUE,
+  HSTS_VALUE,
+  securityHeadersMiddleware
+} from '../../server/lib/security-headers.js'
+
+// Minimal app: just the middleware + two representative routes (an HTML doc and
+// a JSON API response). The middleware is global in server/index.js; this proves
+// the policy it stamps onto res regardless of handler.
+function buildApp() {
+  const app = express()
+  app.use(securityHeadersMiddleware())
+  app.get('/', (req, res) => res.type('text/html').send('<!doctype html><p>ok</p>'))
+  app.get('/api/mycelium/ping', (req, res) => res.json({ ok: true }))
+  return app
+}
+
+describe('security-headers middleware (public-site + API origin policy)', () => {
+  const app = buildApp()
+
+  test('every declared header is present with its exact value on an HTML response', async () => {
+    const res = await request(app).get('/')
+    for (const [key, value] of SECURITY_HEADERS) {
+      expect(res.headers[key.toLowerCase()], `header ${key}`).toBe(value)
+    }
+  })
+
+  test('Strict-Transport-Security is set (HSTS cannot be a <meta> tag — header is the only origin)', async () => {
+    const res = await request(app).get('/')
+    expect(res.headers['strict-transport-security']).toBe(HSTS_VALUE)
+    // Real max-age, includes subdomains, no accidental preload (one-way door).
+    expect(HSTS_VALUE).toMatch(/^max-age=\d+; includeSubDomains$/)
+    expect(HSTS_VALUE).not.toContain('preload')
+  })
+
+  test('Content-Security-Policy locks the site down (no eval, no wildcards, no plugins, no framing)', async () => {
+    const res = await request(app).get('/')
+    expect(res.headers['content-security-policy']).toBe(CSP_VALUE)
+    expect(CSP_VALUE).toContain("default-src 'self'")
+    expect(CSP_VALUE).toContain("object-src 'none'")
+    expect(CSP_VALUE).toContain("base-uri 'self'")
+    expect(CSP_VALUE).toContain("frame-ancestors 'none'")
+    // 'unsafe-eval' is the one directive that would re-open real script injection /
+    // prototype-pollution-to-RCE — the policy must never carry it.
+    expect(CSP_VALUE).not.toContain("'unsafe-eval'")
+    // No wildcard hosts/sources anywhere.
+    expect(CSP_VALUE).not.toMatch(/\*/)
+  })
+
+  test('X-Frame-Options: DENY backs up CSP frame-ancestors none for legacy browsers', async () => {
+    const res = await request(app).get('/')
+    expect(res.headers['x-frame-options']).toBe('DENY')
+  })
+
+  test('the legacy XSS auditor is explicitly disabled (X-XSS-Protection: 0)', async () => {
+    const res = await request(app).get('/')
+    expect(res.headers['x-xss-protection']).toBe('0')
+  })
+
+  test('headers also apply to JSON API responses (defense in depth)', async () => {
+    const res = await request(app).get('/api/mycelium/ping')
+    expect(res.headers['strict-transport-security']).toBe(HSTS_VALUE)
+    expect(res.headers['content-security-policy']).toBe(CSP_VALUE)
+    expect(res.headers['x-content-type-options']).toBe('nosniff')
+    expect(res.headers['x-frame-options']).toBe('DENY')
+  })
+
+  test('OPTIONS (preflight) responses are also stamped', async () => {
+    const res = await request(app).options('/')
+    expect(res.headers['strict-transport-security']).toBe(HSTS_VALUE)
+    expect(res.headers['content-security-policy']).toBe(CSP_VALUE)
+  })
+})


### PR DESCRIPTION
Grey-box security review of **mycelium.fyi** against a frontier-cyber attacker, across four surfaces. The site is a Next.js static export (`mycelium-site`, no separate GitHub remote) overlaid into this platform's `public/` and **served by THIS repo's Express server** (`server: railway-hikari`, `app.use(express.static(publicPath))`). One finding needed code; the rest were verified solid.

## Findings

**1. Sanitization pipeline — ✅ solid, fail-closed.**
The substrate→site path (`mycelium-site/scripts/live-data/sanitize.mjs` + `publish-live-data.mjs`) is allowlist-first: published objects are constructed field-by-field from explicit safe fields, never spread. Unknown agent ids → `"agent"`, unknown requesters → `"operator"`, unknown projects → `null`, unknown statuses → `"unknown"`. Security-sensitive runs (name/briefs/error match `SECURITY_LEXICON`) are **held** unless a hand-written `release-list.json` label exists. `assertNoLeaks()` walks the entire output tree and **throws on any deny-pattern hit**, and it is called on every output object immediately before write. No change needed.

**2. XSS / HTML injection — ✅ no exploitable sink.**
`react-markdown` with `skipHtml`; run names are charset-stripped *and* React-escaped; the only `dangerouslySetInnerHTML` is a hardcoded console easter-egg; every `target="_blank"` carries `rel="noopener noreferrer"`. Substrate strings never reach an unescaped context.

**3. Secrets — ✅ clean.** `check:secrets` passes; only `.env.example` tracked; no keys/`.env`/private material in history.

**4. Response headers — ❌ the real gap (this PR).**
`server/index.js` set 5 headers but **omitted `Strict-Transport-Security` and `Content-Security-Policy`**. Live curl confirmed: no HSTS at all (it can *only* be an HTTP header — never a `<meta>` tag), and only a weak `<meta>` CSP shipped with no `frame-ancestors`. The site repo's `serve.json` defines both, but `serve.json` governs isolated local preview only — **production is served by this platform**, so those values never reached browsers.

## The fix

Centralize the policy in `server/lib/security-headers.js` (single source of truth, unit-tested) and add:

- **`Strict-Transport-Security: max-age=63072000; includeSubDomains`** — HSTS pinning (preload intentionally omitted: it's a one-way door worth an explicit operator sign-off once all subdomains are confirmed HTTPS-only).
- **`Content-Security-Policy`** — `default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'`. No `'unsafe-eval'`, no wildcard hosts, no plugins, no framing. Mirrors `serve.json` so preview and production agree.

On `'unsafe-inline'`: required for this Next.js App-Router static export, which hydrates via an inline `<script>` (the RSC payload) — a static export can't mint per-request nonces. Given there is no unescaped rendering sink (finding 2), this is an accepted, documented tradeoff, not an exposure.

`server/index.js` now mounts the centralised middleware; `X-Frame-Options: DENY` and `frame-ancestors 'none'` together cover clickjacking; `X-XSS-Protection: 0` keeps the legacy auditor disabled.

## Verification
- Real-boot curl (throwaway port): HSTS + CSP now present on **both** JSON (`/health`) and HTML (`/`) routes.
- `test/unit/security-headers.test.js`: 7 regression cases (full policy, HSTS-only-via-header, CSP invariants incl. no-eval/no-wildcard, frame-ancestors backup, auditor disabled, JSON + preflight coverage).
- Full vitest suite: **286/286 green**.

## Files
- `server/lib/security-headers.js` (new) — policy + middleware
- `server/index.js` — mount the centralised middleware
- `test/unit/security-headers.test.js` (new) — regression coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)