### PR TITLE
security(context): scope context keys to project (F1 red-team — cross-project IDOR)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -93,6 +93,11 @@ export function initDB() {
     // Smart Memory — access tracking for context keys
     ["context_keys", "access_count", "INTEGER NOT NULL DEFAULT 0"],
     ["context_keys", "last_accessed_at", "TEXT"],
+    // F1 (red-team) — project-scope context keys. Nullable: NULL = shared/global
+    // (legacy behavior preserved by checkProjectScope's no-project bypass).
+    // Existing rows backfill to NULL (shared); new agent writes stamp their project.
+    ["context_keys", "project_id", "TEXT"],
+    ["context_history", "project_id", "TEXT"],
     // Squad-loop repo resolution — a project's local checkout root so agents
     // working its tasks resolve relative paths in the right repo (not the
     // agent's CWD). Any squad sets this per project.
@@ -855,6 +860,11 @@ var CONTEXT_MAX_KEYS_PER_NAMESPACE = 200;
 
 export function upsertContextKey(namespace, key, data, agentId, opts) {
   var category = (opts && opts.category) || 'durable';
+  // project_id scopes a key to its owning project (F1). NULL = shared/global.
+  // Only stamped on NEW rows; an existing key keeps its project (ON CONFLICT
+  // below deliberately omits project_id from the UPDATE) so a shared key stays
+  // shared and an owned key can't be re-homed by an overwrite.
+  var projectId = (opts && opts.projectId) || null;
   var ttl = (opts && opts.ttl) || null; // seconds
   var expiresAt = null;
   if (ttl) {
@@ -863,12 +873,14 @@ export function upsertContextKey(namespace, key, data, agentId, opts) {
     expiresAt = opts.expires_at;
   }
 
-  var existing = db.prepare("SELECT data FROM context_keys WHERE namespace = ? AND key = ?").get(namespace, key);
+  var existing = db.prepare("SELECT data, project_id FROM context_keys WHERE namespace = ? AND key = ?").get(namespace, key);
   var merged = data;
   if (existing) {
-    // Save previous value to history before overwriting
+    // Save previous value to history before overwriting. Stamp the history row
+    // with the key's CURRENT project (preserved for existing keys) so history
+    // reads + rollbacks can be project-scoped (F1).
     try {
-      db.prepare("INSERT INTO context_history (namespace, key, data, changed_by) VALUES (?, ?, ?, ?)").run(namespace, key, existing.data, agentId || '');
+      db.prepare("INSERT INTO context_history (namespace, key, data, changed_by, project_id) VALUES (?, ?, ?, ?, ?)").run(namespace, key, existing.data, agentId || '', existing.project_id || null);
       // Keep only last 50 versions per key
       db.prepare("DELETE FROM context_history WHERE namespace = ? AND key = ? AND id NOT IN (SELECT id FROM context_history WHERE namespace = ? AND key = ? ORDER BY id DESC LIMIT 50)").run(namespace, key, namespace, key);
     } catch (e) { /* non-critical — history table may not exist yet */ }
@@ -889,8 +901,8 @@ export function upsertContextKey(namespace, key, data, agentId, opts) {
     merged = typeof data === 'string' ? data : JSON.stringify(data);
   }
   db.prepare(
-    "INSERT INTO context_keys (namespace, key, data, category, expires_at, updated_by, updated_at) VALUES (?, ?, ?, ?, ?, ?, datetime('now')) ON CONFLICT(namespace, key) DO UPDATE SET data = excluded.data, category = excluded.category, expires_at = excluded.expires_at, updated_by = excluded.updated_by, updated_at = excluded.updated_at"
-  ).run(namespace, key, merged, category, expiresAt, agentId);
+    "INSERT INTO context_keys (namespace, key, data, category, project_id, expires_at, updated_by, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now')) ON CONFLICT(namespace, key) DO UPDATE SET data = excluded.data, category = excluded.category, expires_at = excluded.expires_at, updated_by = excluded.updated_by, updated_at = excluded.updated_at"
+  ).run(namespace, key, merged, category, projectId, expiresAt, agentId);
 
   // Enforce size cap per namespace
   enforceNamespaceCap(namespace);
@@ -950,13 +962,24 @@ export function getContextKey(namespace, key) {
   return row;
 }
 
-export function listContextKeys(namespace) {
+export function listContextKeys(namespace, projectId) {
   // Filter out expired keys on read
   var now = new Date().toISOString();
+  var conditions = ["(expires_at IS NULL OR expires_at > ?)"];
+  var params = [now];
   if (namespace) {
-    return db.prepare("SELECT * FROM context_keys WHERE namespace = ? AND (expires_at IS NULL OR expires_at > ?) ORDER BY key").all(namespace, now);
+    conditions.push("namespace = ?");
+    params.push(namespace);
   }
-  return db.prepare("SELECT * FROM context_keys WHERE expires_at IS NULL OR expires_at > ? ORDER BY namespace, key").all(now);
+  // F1: scope listings to shared (NULL) + the caller's project. projectId is
+  // left undefined for admins/studio (no filter, see all) and set (possibly
+  // null → shared-only) for agents.
+  if (projectId !== undefined) {
+    conditions.push("(project_id IS NULL OR project_id = ?)");
+    params.push(projectId);
+  }
+  var order = namespace ? "key" : "namespace, key";
+  return db.prepare("SELECT * FROM context_keys WHERE " + conditions.join(" AND ") + " ORDER BY " + order).all(...params);
 }
 
 export function deleteContextKey(namespace, key) {
@@ -994,6 +1017,11 @@ export function searchContextKeys(opts) {
     var pattern = "%" + opts.search + "%";
     params.push(pattern, pattern);
   }
+  // F1: scope search results to shared (NULL) + the caller's project.
+  if (opts.projectId !== undefined) {
+    conditions.push("(project_id IS NULL OR project_id = ?)");
+    params.push(opts.projectId);
+  }
 
   var sql = "SELECT * FROM context_keys WHERE " + conditions.join(" AND ") + " ORDER BY namespace, key";
   return db.prepare(sql).all(...params);
@@ -1004,6 +1032,13 @@ export function getContextHistory(namespace, key, limit) {
   return db.prepare(
     "SELECT * FROM context_history WHERE namespace = ? AND key = ? ORDER BY id DESC LIMIT ?"
   ).all(namespace, key, limit || 20);
+}
+
+// Single history entry by id — used by the rollback route to scope-check the
+// caller against the entry's project BEFORE restoring (F1). Returns the row
+// (now carrying project_id) without mutating anything.
+export function getContextHistoryEntry(historyId) {
+  return db.prepare("SELECT * FROM context_history WHERE id = ?").get(historyId);
 }
 
 // Rollback — restore a previous version by history ID

--- a/server/routes/context.js
+++ b/server/routes/context.js
@@ -6,7 +6,7 @@
 // to before extraction — enforced by test/refactor/route-manifest.mjs.
 import {
   searchContextKeys, listContextKeys, getContextKey, upsertContextKey,
-  deleteContextKey, bulkDeleteContextKeys, getContextHistory,
+  deleteContextKey, bulkDeleteContextKeys, getContextHistory, getContextHistoryEntry,
   rollbackContextKey, contextKeyStats, getAllContext, getContext,
   upsertContext,
 } from '../db.js';
@@ -14,31 +14,49 @@ import {
 export function registerContextRoutes(router, deps) {
   const {
     asyncHandler, checkAgentOrAdmin, checkAdmin, emitEvent,
+    checkProjectScope, agentCanAccessProject,
   } = deps;
 
   // ======== CONTEXT ========
+  //
+  // F1 (red-team): context keys are now project-scoped. NULL project_id = shared/
+  // global (legacy swarm-readable state — enforcement rules, api limits, standups,
+  // anything written without a project). A key written through the agent HTTP path
+  // is stamped with the writer's project, after which a cross-project agent can no
+  // longer read, overwrite, dump history, or roll it back — the same 403 a
+  // cross-project task write already gets. Reads are strict-scoped too because
+  // context keys can hold secrets (unlike tasks/plans, which stay read-shared).
+
+  // Project filter for context list/search: undefined (no filter → see all) for
+  // admins/studio; the agent's own project (possibly null → shared-only) for agents.
+  function contextListProjectFilter(req) {
+    if (req._authIsAdmin || !req._authAgentId) return undefined;
+    return (req._authProjectId !== undefined) ? req._authProjectId : null;
+  }
 
   // Namespaced context (must be before :projectId param route)
   router.get('/context/keys', asyncHandler(function (req, res) {
     var who = checkAgentOrAdmin(req, res);
     if (!who) return;
     var namespace = req.query.namespace;
+    var projectId = contextListProjectFilter(req);
     // If search/filter params present, use searchContextKeys
     if (req.query.search || req.query.category || req.query.updated_by) {
       return res.json(searchContextKeys({
         namespace: namespace || undefined,
         search: req.query.search || undefined,
         category: req.query.category || undefined,
-        updated_by: req.query.updated_by || undefined
+        updated_by: req.query.updated_by || undefined,
+        projectId: projectId
       }));
     }
-    res.json(listContextKeys(namespace));
+    res.json(listContextKeys(namespace, projectId));
   }));
 
   router.get('/context/keys/:namespace', asyncHandler(function (req, res) {
     var who = checkAgentOrAdmin(req, res);
     if (!who) return;
-    res.json(listContextKeys(req.params.namespace));
+    res.json(listContextKeys(req.params.namespace, contextListProjectFilter(req)));
   }));
 
   router.get('/context/keys/:namespace/:key', asyncHandler(function (req, res) {
@@ -46,6 +64,8 @@ export function registerContextRoutes(router, deps) {
     if (!who) return;
     var ctx = getContextKey(req.params.namespace, req.params.key);
     if (!ctx) return res.status(404).json({ error: 'Context key not found' });
+    // F1: context keys can hold secrets — scope reads like writes (strictRead).
+    if (!checkProjectScope(req, res, ctx.project_id, null, { strictRead: true })) return;
     res.json(ctx);
   }));
 
@@ -54,8 +74,13 @@ export function registerContextRoutes(router, deps) {
     if (!agentId) return;
     var data = req.body.data;
     if (data === undefined) return res.status(400).json({ error: 'data field is required' });
+    // F1: if the key already exists, only its owning project (or admin) may
+    // overwrite it — same 403 a cross-project task write already gets. A new key
+    // is stamped with the writer's project (opts.projectId) below.
+    var existing = getContextKey(req.params.namespace, req.params.key);
+    if (existing && !checkProjectScope(req, res, existing.project_id)) return;
     var dataStr = typeof data === 'string' ? data : JSON.stringify(data);
-    var opts = {};
+    var opts = { projectId: req._authProjectId || null };
     if (req.body.category) opts.category = req.body.category;
     if (req.body.ttl) opts.ttl = parseInt(req.body.ttl, 10);
     if (req.body.expires_at) opts.expires_at = req.body.expires_at;
@@ -64,13 +89,15 @@ export function registerContextRoutes(router, deps) {
     res.json({ ok: true, namespace: req.params.namespace, key: req.params.key });
   }));
 
+  // Admin-only — checkAdmin is a stricter gate than project scope (admins bypass
+  // scope anyway), so no agent can reach this path cross-project. Left as-is.
   router.delete('/context/keys/:namespace/:key', asyncHandler(function (req, res) {
     if (!checkAdmin(req, res)) return;
     deleteContextKey(req.params.namespace, req.params.key);
     res.json({ ok: true, deleted: req.params.namespace + ':' + req.params.key });
   }));
 
-  // Bulk delete context keys by IDs (admin only)
+  // Bulk delete context keys by IDs (admin only — see DELETE note above)
   router.post('/context/keys/bulk-delete', asyncHandler(function (req, res) {
     if (!checkAdmin(req, res)) return;
     var ids = req.body.ids;
@@ -92,6 +119,10 @@ export function registerContextRoutes(router, deps) {
     var limit = parseInt(req.query.limit) || 20;
     if (limit > 100) limit = 100;
     var history = getContextHistory(req.params.namespace, req.params.key, limit);
+    // F1: history leaks overwritten secrets — scope it like a read. The latest
+    // entry carries the key's project (stamped on every write); empty history is
+    // returned as-is. Data is fetched server-side but only sent once scope passes.
+    if (history.length > 0 && !checkProjectScope(req, res, history[0].project_id, null, { strictRead: true })) return;
     res.json(history);
   }));
 
@@ -101,6 +132,11 @@ export function registerContextRoutes(router, deps) {
     if (!agentId) return;
     var historyId = parseInt(req.params.historyId);
     if (!historyId) return res.status(400).json({ error: 'Invalid history ID' });
+    // F1: scope the rollback (a write) against the target's project BEFORE
+    // restoring — fetch the history entry (carries project_id) and check scope.
+    var entry = getContextHistoryEntry(historyId);
+    if (!entry) return res.status(404).json({ error: 'History entry not found' });
+    if (!checkProjectScope(req, res, entry.project_id)) return;
     var restored = rollbackContextKey(historyId, agentId);
     if (!restored) return res.status(404).json({ error: 'History entry not found' });
     emitEvent('context_key_rollback', agentId, restored.namespace, agentId + ' rolled back ' + restored.namespace + ':' + restored.key + ' to version #' + historyId);
@@ -124,8 +160,15 @@ export function registerContextRoutes(router, deps) {
         results.push({ namespace: entry.namespace, key: entry.key, error: 'namespace, key, and data are required' });
         continue;
       }
+      // F1: per-key scope — a cross-project overwrite is rejected for that entry
+      // only (pure check; we record a per-entry error rather than 403 the batch).
+      var existing = getContextKey(entry.namespace, entry.key);
+      if (existing && !agentCanAccessProject(req, existing.project_id)) {
+        results.push({ namespace: entry.namespace, key: entry.key, error: 'forbidden: cross-project' });
+        continue;
+      }
       var dataStr = typeof entry.data === 'string' ? entry.data : JSON.stringify(entry.data);
-      var opts = {};
+      var opts = { projectId: req._authProjectId || null };
       if (entry.category) opts.category = entry.category;
       if (entry.ttl) opts.ttl = parseInt(entry.ttl, 10);
       if (entry.expires_at) opts.expires_at = entry.expires_at;

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -532,11 +532,16 @@ function invalidateAgentKeyCache(agentId) {
 // Check if the authenticated caller has access to a resource's project.
 // Admins and studio users bypass. Agents can READ any project but can only
 // WRITE to their own project (or resources assigned to them).
-function checkProjectScope(req, res, resourceProjectId, assignee) {
+//
+// opts.strictRead (F1): context keys can hold secrets, so unlike tasks/plans
+// their READS are also project-scoped — strictRead defeats the GET bypass below
+// so a cross-project agent read is denied. Writes are always scoped regardless.
+function agentCanAccessProject(req, resourceProjectId, assignee, opts) {
   if (req._authIsAdmin) return true;
   if (!req._authAgentId) return true; // studio user or admin — no scope restriction
-  if (!resourceProjectId) return true; // resource has no project — allow
-  if (req.method === 'GET') return true; // agents can read across projects (shared swarm context)
+  if (!resourceProjectId) return true; // resource has no project — allow (shared/global)
+  var strictRead = opts && opts.strictRead;
+  if (req.method === 'GET' && !strictRead) return true; // agents can read across projects (shared swarm context)
   if (req._authProjectId === resourceProjectId) return true;
   if (assignee && assignee === req._authAgentId) return true; // assigned agent can update their own work across projects
   // Team-scope (durable): an agent may write to any project owned by a team it
@@ -546,7 +551,12 @@ function checkProjectScope(req, res, resourceProjectId, assignee) {
   // result or creating a plan there.
   try {
     if (getTeamProjectIdsForAgent(req._authAgentId).indexOf(resourceProjectId) !== -1) return true;
-  } catch (e) { /* fall through to 403 */ }
+  } catch (e) { /* fall through to deny */ }
+  return false;
+}
+
+function checkProjectScope(req, res, resourceProjectId, assignee, opts) {
+  if (agentCanAccessProject(req, resourceProjectId, assignee, opts)) return true;
   res.status(403).json({ error: 'Agent ' + req._authAgentId + ' cannot access resources in project ' + resourceProjectId });
   return false;
 }
@@ -1375,7 +1385,7 @@ registerAgentRoutes(router, {
 
 // ======== CONTEXT ========
 
-registerContextRoutes(router, { asyncHandler, checkAgentOrAdmin, checkAdmin, emitEvent });
+registerContextRoutes(router, { asyncHandler, checkAgentOrAdmin, checkAdmin, emitEvent, checkProjectScope, agentCanAccessProject });
 
 // ======== SPEND TRACKING (extracted to spend.js) ========
 

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -133,12 +133,17 @@ CREATE TABLE IF NOT EXISTS messages (
 );
 
 -- Namespaced context storage
+-- project_id: NULL = shared/global (readable + writable swarm-wide, the legacy
+-- model); otherwise the owning project — cross-project agent access is denied
+-- by checkProjectScope (see F1 red-team fix). System-written keys (enforcement
+-- rules, api limits, standups) carry no project and stay shared.
 CREATE TABLE IF NOT EXISTS context_keys (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   namespace   TEXT NOT NULL,
   key         TEXT NOT NULL,
   data        TEXT NOT NULL DEFAULT '{}',
   category    TEXT NOT NULL DEFAULT 'durable',
+  project_id  TEXT,
   expires_at  TEXT,
   updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
   updated_by  TEXT NOT NULL DEFAULT '',
@@ -148,11 +153,14 @@ CREATE TABLE IF NOT EXISTS context_keys (
 );
 
 -- Context version history (for rollback)
+-- project_id mirrors the key's owning project at change time so history reads +
+-- rollbacks can be project-scoped (history leaks overwritten secrets — F1).
 CREATE TABLE IF NOT EXISTS context_history (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   namespace   TEXT NOT NULL,
   key         TEXT NOT NULL,
   data        TEXT NOT NULL,
+  project_id  TEXT,
   changed_by  TEXT NOT NULL DEFAULT '',
   changed_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/test/unit/context-project-scope.test.js
+++ b/test/unit/context-project-scope.test.js
@@ -1,0 +1,187 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+
+// F1 (red-team) — context keys must be project-scoped.
+//
+// Reproduces the red-team scenario: two agents in two different projects
+// (rt-alpha/project alpha, rt-bravo/project bravo). Before the fix a bravo key
+// could READ, OVERWRITE (poison), dump plaintext HISTORY, and ROLL BACK alpha's
+// secret context key. After the fix every one of those is a 403, while the
+// owning agent (alpha) and admins still have full access and shared/global keys
+// (NULL project_id) remain readable swarm-wide.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const JWT_SECRET = 'test-jwt-secret'
+const AGENT_KEY_ALPHA = 'dvk_test_ctx_alpha_key_0123456789abcdef0123456'
+const AGENT_KEY_BRAVO = 'dvk_test_ctx_bravo_key_0123456789abcdef01234567'
+const AGENT_HASH_ALPHA = crypto.createHash('sha256').update(AGENT_KEY_ALPHA).digest('hex')
+const AGENT_HASH_BRAVO = crypto.createHash('sha256').update(AGENT_KEY_BRAVO).digest('hex')
+
+const NS = 'alpha_secrets'
+const KEY = 'prod'
+
+let tmpDataDir
+let db
+let app
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-ctx-scope-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+  process.env.JWT_SECRET = JWT_SECRET
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  db.createProject('alpha', 'Alpha', '', '', null, 'product')
+  db.createProject('bravo', 'Bravo', '', '', null, 'product')
+  db.createAgent('rt-alpha', 'RT Alpha', 'alpha', AGENT_HASH_ALPHA, '["code"]')
+  db.createAgent('rt-bravo', 'RT Bravo', 'bravo', AGENT_HASH_BRAVO, '["code"]')
+
+  const routes = (await import('../../server/routes/mycelium.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routes)
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+function adminHeaders() {
+  return { 'X-Admin-Key': ADMIN_KEY, 'X-Acting-As': 'tester' }
+}
+
+const BASE = '/api/mycelium/context/keys'
+
+describe('F1: cross-project context access is DENIED', () => {
+  test('alpha writes a project-scoped secret; bravo cannot READ it (403)', async () => {
+    // alpha (project alpha) writes a secret — stamped with alpha's project
+    const write = await request(app)
+      .put(`${BASE}/${NS}/${KEY}`)
+      .set('X-Agent-Key', AGENT_KEY_ALPHA)
+      .send({ data: { stripe_key: 'sk_live_ALPHA_PRIVATE_1234' } })
+    expect(write.status).toBe(200)
+    expect(write.body.ok).toBe(true)
+
+    // owner can read it back
+    const own = await request(app).get(`${BASE}/${NS}/${KEY}`).set('X-Agent-Key', AGENT_KEY_ALPHA)
+    expect(own.status).toBe(200)
+    expect(own.body.project_id).toBe('alpha')
+    expect(own.body.data).toContain('sk_live_ALPHA_PRIVATE_1234')
+
+    // bravo (DIFFERENT project) is denied — this is the F1 reproduction
+    const cross = await request(app).get(`${BASE}/${NS}/${KEY}`).set('X-Agent-Key', AGENT_KEY_BRAVO)
+    expect(cross.status).toBe(403)
+    expect(String(cross.body.error)).toMatch(/project/i)
+
+    // admin bypasses scope
+    const adm = await request(app).get(`${BASE}/${NS}/${KEY}`).set(adminHeaders())
+    expect(adm.status).toBe(200)
+  })
+
+  test('bravo cannot OVERWRITE (poison) alpha\'s key (403) — value unchanged', async () => {
+    const poison = await request(app)
+      .put(`${BASE}/${NS}/${KEY}`)
+      .set('X-Agent-Key', AGENT_KEY_BRAVO)
+      .send({ data: { stripe_key: 'POISONED_BY_BRAVO' } })
+    expect(poison.status).toBe(403)
+
+    // alpha still sees the original secret — not poisoned
+    const own = await request(app).get(`${BASE}/${NS}/${KEY}`).set('X-Agent-Key', AGENT_KEY_ALPHA)
+    expect(own.body.data).toContain('sk_live_ALPHA_PRIVATE_1234')
+    expect(own.body.data).not.toContain('POISONED')
+  })
+
+  test('bravo cannot dump alpha\'s version HISTORY (403)', async () => {
+    // alpha overwrites once -> creates a history entry (carries project_id=alpha)
+    const overwrite = await request(app)
+      .put(`${BASE}/${NS}/${KEY}`)
+      .set('X-Agent-Key', AGENT_KEY_ALPHA)
+      .send({ data: { stripe_key: 'sk_live_ALPHA_ROTATED_5678' } })
+    expect(overwrite.status).toBe(200)
+
+    const cross = await request(app)
+      .get(`${BASE}/${NS}/${KEY}/history`)
+      .set('X-Agent-Key', AGENT_KEY_BRAVO)
+    expect(cross.status).toBe(403)
+
+    // owner can read history (the overwritten secret is visible to alpha only)
+    const own = await request(app)
+      .get(`${BASE}/${NS}/${KEY}/history`)
+      .set('X-Agent-Key', AGENT_KEY_ALPHA)
+    expect(own.status).toBe(200)
+    expect(Array.isArray(own.body)).toBe(true)
+    expect(own.body.length).toBeGreaterThan(0)
+  })
+
+  test('bravo cannot ROLL BACK alpha\'s key (403)', async () => {
+    // find alpha's history entry id via the owner (bravo can't list it)
+    const ownHist = await request(app)
+      .get(`${BASE}/${NS}/${KEY}/history`)
+      .set('X-Agent-Key', AGENT_KEY_ALPHA)
+    const historyId = ownHist.body[0].id
+    expect(historyId).toBeTruthy()
+
+    const cross = await request(app)
+      .post(`${BASE}/rollback/${historyId}`)
+      .set('X-Agent-Key', AGENT_KEY_BRAVO)
+    expect(cross.status).toBe(403)
+
+    // owner can roll back
+    const own = await request(app)
+      .post(`${BASE}/rollback/${historyId}`)
+      .set('X-Agent-Key', AGENT_KEY_ALPHA)
+    expect(own.status).toBe(200)
+    expect(own.body.ok).toBe(true)
+  })
+
+  test('bravo cannot bulk-overwrite alpha\'s key — that entry is rejected', async () => {
+    const res = await request(app)
+      .post(`${BASE}/bulk`)
+      .set('X-Agent-Key', AGENT_KEY_BRAVO)
+      .send({
+        keys: [
+          { namespace: NS, key: KEY, data: { poison: true } },                 // alpha's — denied
+          { namespace: 'bravo_ns', key: 'own', data: { ok: true } }            // bravo's — allowed
+        ]
+      })
+    expect(res.status).toBe(200)
+    const alphaResult = res.body.results.find(r => r.namespace === NS && r.key === KEY)
+    const bravoResult = res.body.results.find(r => r.namespace === 'bravo_ns' && r.key === 'own')
+    expect(alphaResult.error).toMatch(/forbidden|cross-project/i)
+    expect(bravoResult.ok).toBe(true)
+
+    // alpha's key still not poisoned by the bulk attempt
+    const own = await request(app).get(`${BASE}/${NS}/${KEY}`).set('X-Agent-Key', AGENT_KEY_ALPHA)
+    expect(own.body.data).not.toContain('poison')
+  })
+
+  test('bravo cannot discover alpha\'s key via namespace LIST', async () => {
+    const res = await request(app).get(`${BASE}/${NS}`).set('X-Agent-Key', AGENT_KEY_BRAVO)
+    expect(res.status).toBe(200)
+    // alpha's prod key must NOT appear in bravo's view of the alpha_secrets ns
+    const found = (res.body || []).some(k => k.key === KEY)
+    expect(found).toBe(false)
+  })
+})
+
+describe('F1: no regression — shared/global keys stay swarm-readable', () => {
+  test('a NULL-project (shared) key is readable by agents in any project', async () => {
+    // system-written key carries no project -> shared/global (the legacy model)
+    db.upsertContextKey('shared_ns', 'pub', JSON.stringify({ v: 'shared_config' }), 'system')
+
+    const alpha = await request(app).get(`${BASE}/shared_ns/pub`).set('X-Agent-Key', AGENT_KEY_ALPHA)
+    expect(alpha.status).toBe(200)
+    expect(alpha.body.data).toContain('shared_config')
+
+    const bravo = await request(app).get(`${BASE}/shared_ns/pub`).set('X-Agent-Key', AGENT_KEY_BRAVO)
+    expect(bravo.status).toBe(200)
+    expect(bravo.body.data).toContain('shared_config')
+  })
+})

--- a/test/unit/schema-drift.test.js
+++ b/test/unit/schema-drift.test.js
@@ -71,6 +71,9 @@ function extractMigrations() {
     // Smart Memory — access tracking for context keys
     ["context_keys", "access_count", "INTEGER NOT NULL DEFAULT 0"],
     ["context_keys", "last_accessed_at", "TEXT"],
+    // F1 (red-team) — project-scope context keys (NULL = shared/global)
+    ["context_keys", "project_id", "TEXT"],
+    ["context_history", "project_id", "TEXT"],
   ];
 
   // Lines 109-129 in db.js


### PR DESCRIPTION
## F1 — Broken project-scoping on context keys (Medium, REPRODUCED)

Fixes red-team finding **F1** from the 2026-07-09 dynamic red-team report (`redteam-2026-07-09.md`).

### The bug
`context_keys` had **no `project_id` column** and the context write/read/history/rollback paths **never called `checkProjectScope`**. The platform scopes *writes* for tasks/plans/bugs/approvals via `checkProjectScope()` (read-shared, write-owned), but context keys were exempt. Result: **any** valid `X-Agent-Key`, regardless of its project, could:

1. **read** any namespace/key,
2. **overwrite (poison)** any namespace/key,
3. dump the full plaintext version **history** — including secret values that were later overwritten,
4. **roll back** any key to any prior version by sequential `historyId`.

Reproduced cross-project in the red-team run — a `bravo` key read `alpha`'s secret (`sk_live_ALPHA_PRIVATE_1234`), overwrote it with `POISONED_BY_BRAVO`, and dumped the history exposing the original.

**Root cause:** `server/routes/mycelium.js` `PUT/GET/GET-history/POST-rollback /context/keys/*` used `checkAgentOrAdmin` only; `server/schema.sql` `context_keys`/`context_history` had no `project_id`, so scope couldn't be enforced downstream.

### The fix (narrowly scoped to context keys)
- **Schema** (`schema.sql` + `db.js` migration): add nullable `project_id` to `context_keys` and `context_history`. `NULL = shared/global` (the legacy swarm-readable model — enforcement rules, api limits, standups, anything written without a project). Idempotent `ALTER TABLE` migration backfills existing rows to `NULL` → **non-breaking**. Verified on a simulated pre-migration DB: column added to both tables, legacy data preserved, backfilled `NULL`, new writes stamped correctly.
- **`checkProjectScope`**: extract a pure `agentCanAccessProject()` boolean (reused by the bulk loop) and add `opts.strictRead` so context **reads** are scope-denied too — context keys can hold secrets, unlike tasks/plans which stay read-shared. Backward-compatible: all 13 existing callers pass no `opts`, behavior unchanged.
- **Routes**: scope every agent-admitting context route — read (`strictRead`), write (stamp the writer's project + scope the existing key), history (`strictRead` — it leaks overwritten secrets), rollback (write-scope **before** restoring), bulk-write (per-entry pure check), and list/search (filter to shared + own project). `delete`/`bulk-delete` stay admin-only (a stricter gate than project scope).

### Test
New `test/unit/context-project-scope.test.js` reproduces the red-team scenario end-to-end through the real Express app:
- `bravo` key's **read / write / history / rollback / bulk / list** of `alpha`'s key → all **403**;
- owning agent (`alpha`) and **admins** retain full access;
- a shared (`NULL`-project) key stays readable swarm-wide (**no regression**).

`schema-drift` snapshot kept in sync. **Full suite green: 264/264.**

### Severity context (from the report)
Within a single Mycelium instance all agents are intended to be one collaborating swarm, and hosted customers get separate provisioned instances — so this is **not** a cross-customer breach. It is a within-instance, cross-*project* trust gap: a compromised or lower-trust agent in project X could silently poison the coordination state other projects act on, and read another project's secrets (including overwritten ones). Rated **Medium**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)