### PR TITLE
fix(lint): Node globals for .mjs — unblock red CI (route-manifest.mjs no-undef)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,7 @@ export default [
   },
   js.configs.recommended,
   {
-    files: ['server/**/*.js', 'sdk/**/*.js', 'test/**/*.js'],
+    files: ['server/**/*.{js,mjs}', 'sdk/**/*.{js,mjs}', 'test/**/*.{js,mjs}'],
     languageOptions: {
       ecmaVersion: 2024,
       sourceType: 'module',


### PR DESCRIPTION
The eslint Node-globals block globbed only `*.js`, so `test/refactor/route-manifest.mjs` (which uses `process`/`console`) threw **12 `no-undef` errors** → `npm run lint` failed → **red CI on master and every open PR** since the eslint adoption (#156).

Fix: extend the globs to `{js,mjs}`. Verified locally: **0 errors** (314 non-blocking warnings) after. Unblocks #168 / #169 / #170 and all future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs9CULmcFF6XDk4s3E1y2q
