### PR TITLE
security(drone): gate input_data.setup admin-only + shell=False worker exec (C-4)

### DIFF
--- a/server/routes/drones.js
+++ b/server/routes/drones.js
@@ -155,6 +155,15 @@ export function registerDroneRoutes(router, deps) {
       return apiError(res, 403, 'Raw drone commands are admin-only. Submit a template job (job_type / from-template) instead.');
     }
     var inputData = req.body.input_data || {};
+    // input_data.setup is a free-form command the drone shell-executes at
+    // workspace setup (drone-worker.py). Like a raw `command`, only admins may
+    // supply one — the render-time metachar reject (C-2) blocks shell operators
+    // but not a bare command (`pip install evil`, `python -c "..."`), so an
+    // ungated setup = RCE on the drone from any agent key. Non-admin setup must
+    // come from an admin-defined template (setup_repo), not free-form input (C-4).
+    if (inputData && inputData.setup !== undefined && !req._authIsAdmin) {
+      return apiError(res, 403, 'input_data.setup is admin-only — it is shell-executed on the drone. Use a template setup_repo instead.');
+    }
     var requires = req.body.requires || ['cpu'];
     var priority = parseInt(req.body.priority) || 0;
     var workspaceRepo = req.body.workspace_repo || null;
@@ -187,6 +196,11 @@ export function registerDroneRoutes(router, deps) {
     var template = getJobTemplate(templateId);
     if (!template) return res.status(404).json({ error: 'Template not found: ' + templateId });
     var inputData = req.body.input_data || {};
+    // input_data.setup is admin-only — shell-executed on the drone (see the C-4
+    // gate on POST /drones/jobs). Block non-admin free-form setup here too.
+    if (inputData && inputData.setup !== undefined && !req._authIsAdmin) {
+      return apiError(res, 403, 'input_data.setup is admin-only — it is shell-executed on the drone. Use a template setup_repo instead.');
+    }
     var priority = parseInt(req.body.priority) || 0;
     var requires = [];
     try { requires = JSON.parse(template.requires || '["cpu"]'); } catch (e) { requires = ['cpu']; }

--- a/test/unit/drone-mesh-rce.test.js
+++ b/test/unit/drone-mesh-rce.test.js
@@ -137,3 +137,48 @@ describe('C-3 · drone artifact upload is admin-only, gated before multer', () =
     expect(res.body.ok).toBe(true)
   })
 })
+
+describe('C-4 · input_data.setup is admin-only (shell-executed on the drone)', () => {
+  test('a regular agent submitting input_data.setup is 403', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/drones/jobs')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ title: 'pwn', job_type: 'flux-test', input_data: { prompt: 'x', steps: 1, setup: 'pip install evil-pkg' } })
+    expect(res.status).toBe(403)
+  })
+
+  test('the metachar-free bypass (python -c) is also refused — SHELL_META does not catch it', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/drones/jobs')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ title: 'pwn2', job_type: 'flux-test', input_data: { setup: 'python -c "__import__(\'os\').system(\'id\')"' } })
+    expect(res.status).toBe(403)
+  })
+
+  test('a regular agent submitting setup via from-template is 403', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/drones/jobs/from-template')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ template_id: 'flux-test', input_data: { setup: 'touch /tmp/pwned' } })
+    expect(res.status).toBe(403)
+  })
+
+  test('a template job without setup still works (gate is not over-restrictive)', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/drones/jobs')
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ title: 'render', job_type: 'flux-test', input_data: { prompt: 'a cat', steps: 20 } })
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('id')
+  })
+
+  test('an admin may still supply setup (gate is not over-restrictive)', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/drones/jobs')
+      .set('X-Admin-Key', ADMIN_KEY)
+      .set('X-Acting-As', 'greatness')
+      .send({ title: 'admin setup', command: 'echo hi', input_data: { setup: 'pip install -r requirements.txt' } })
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('id')
+  })
+})

--- a/tools/drone-worker.py
+++ b/tools/drone-worker.py
@@ -572,8 +572,13 @@ def execute_job(api, job, system_info, work_dir=None):
     if setup_cmd and not setup_marker.exists():
         print(f"  Running setup: {setup_cmd[:100]}...")
         try:
+            # Run setup as an argv list with shell=False so a setup string cannot
+            # be shell-interpreted on the drone (defense in depth; setup is also
+            # gated admin-only server-side). shlex.split honors quoting; posix=False
+            # keeps Windows backslash paths intact — mirrors the main command exec.
+            setup_argv = shlex.split(setup_cmd, posix=(os.name != "nt"))
             r = subprocess.run(
-                setup_cmd, shell=True, capture_output=True, text=True,
+                setup_argv, shell=False, capture_output=True, text=True,
                 timeout=1800, cwd=str(workspace),
                 env={**os.environ, "MYCELIUM_JOB_ID": str(job_id)}
             )


### PR DESCRIPTION
## Summary
Closes the residual drone-mesh RCE tracked in task #248. #154 (2026-07-01) closed C-1/C-2/C-3 but left the **setup** path exposed.

## The hole
`tools/drone-worker.py` ran `input_data.get("setup")` with `shell=True`. The only filter was `renderJobForDrone`'s `SHELL_META` reject (C-2), which blocks shell *operators* (`$ ` `` ` `` ` ; | & < > \n`) but **not a bare command**. So any registered agent key → RCE on every drone via a metachar-free setup:
- `input_data.setup = "pip install <evil-pkg>"` → runs the package's `setup.py`
- `input_data.setup = "python -c \"__import__('os').system('…')\""`

Confirmed live on `master` (`drone-worker.py:576 shell=True`), reachable from both `POST /drones/jobs` and `/drones/jobs/from-template` (which took `input_data` verbatim).

## Fix — two reinforcing layers
- **`server/routes/drones.js`** — `input_data.setup` is now **admin-only** (`req._authIsAdmin`) at both create handlers, mirroring the C-1 raw-command gate. Non-admin setup must come from an admin-defined template `setup_repo`.
- **`tools/drone-worker.py`** — setup now runs as an argv list via `shlex.split` + `shell=False` (defense-in-depth, mirroring the already-hardened main command sink), so a setup string can't be shell-interpreted even against an unpatched server.

`setup_steps` is confirmed **dead in the worker** (never executed) — no exec sink there.

## Verification
- `test/unit/drone-mesh-rce.test.js` grows a **C-4** block: non-admin setup → 403 on both routes (incl. the metachar-free `python -c` bypass); admin + no-setup paths still 200.
- Full suite green: **302 tests**.

## Merge gate
Recommend a non-Claude (GLM) cross-check of this diff before merge, per our validity-gate practice. Merge intentionally left to a human operator (security + git = medium tier).
