### PR TITLE
fix(safety): 404 phantom sub-resource mutations + read-only GET /admin/health

### DIFF
--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -14,7 +14,7 @@ import {
 
 export function registerAdminRoutes(router, deps) {
   const {
-    AGENT_STATUSES, adminWriteLimiter, asyncHandler, buildMcpConfig, checkAdmin, checkAgentOrAdmin, clearAgentKeyCache, displayName, emitEvent, getAdminDisplayName, getInstanceUrl, getStudioUser, invalidateAgentKeyCache, runHealthPatrol, validateEnum,
+    AGENT_STATUSES, adminWriteLimiter, asyncHandler, buildMcpConfig, checkAdmin, checkAgentOrAdmin, clearAgentKeyCache, computeHealthReport, displayName, emitEvent, getAdminDisplayName, getInstanceUrl, getStudioUser, invalidateAgentKeyCache, runHealthPatrol, validateEnum,
   } = deps;
 
 router.get('/admin/config', asyncHandler(function (req, res) {
@@ -688,9 +688,21 @@ router.get('/admin/backups', asyncHandler(function (req, res) {
   }
 }));
 
+// GET is a safe, side-effect-free PREVIEW — no mutation, no event emission.
 router.get('/admin/health', asyncHandler(function (req, res) {
   var who = checkAgentOrAdmin(req, res);
   if (!who) return;
+  try {
+    res.json(computeHealthReport());
+  } catch (e) {
+    return res.status(500).json({ error: 'Health patrol failed: ' + e.message });
+  }
+}));
+
+// POST actually RUNS the patrol (mutates: marks stale agents/drones offline,
+// releases claimed jobs, emits health_patrol events) — privileged, admin-only.
+router.post('/admin/health/run', asyncHandler(function (req, res) {
+  if (!checkAdmin(req, res)) return;
   try {
     res.json(runHealthPatrol());
   } catch (e) {

--- a/server/routes/drones.js
+++ b/server/routes/drones.js
@@ -55,6 +55,10 @@ export function registerDroneRoutes(router, deps) {
   router.put('/drones/:id/pause', asyncHandler(function (req, res) {
     var who = checkAgentOrAdmin(req, res);
     if (!who) return;
+    // Mirror GET /drones/:id/status's existence check — a ghost id must 404,
+    // not silently UPDATE 0 rows and report { ok:true }.
+    var pauseStatus = getDroneStatus(req.params.id);
+    if (!pauseStatus) return res.status(404).json({ error: 'Drone not found' });
     var result = pauseDrone(req.params.id);
     try {
       createMessage(who, req.params.id, null, 'mycelium',
@@ -67,6 +71,10 @@ export function registerDroneRoutes(router, deps) {
   router.put('/drones/:id/resume', asyncHandler(function (req, res) {
     var who = checkAgentOrAdmin(req, res);
     if (!who) return;
+    // Mirror GET /drones/:id/status's existence check — a ghost id must 404,
+    // not silently UPDATE 0 rows and report { ok:true }.
+    var resumeStatus = getDroneStatus(req.params.id);
+    if (!resumeStatus) return res.status(404).json({ error: 'Drone not found' });
     var result = resumeDrone(req.params.id);
     try {
       createMessage(who, req.params.id, null, 'mycelium',

--- a/server/routes/mycelium.js
+++ b/server/routes/mycelium.js
@@ -1555,7 +1555,7 @@ registerOperatorRoutes(router, {
 // ======== INSTANCE CONFIG ========
 
 registerAdminRoutes(router, {
-  AGENT_STATUSES, adminWriteLimiter, asyncHandler, buildMcpConfig, checkAdmin, checkAgentOrAdmin, clearAgentKeyCache, displayName, emitEvent, getAdminDisplayName, getInstanceUrl, getStudioUser, invalidateAgentKeyCache, runHealthPatrol, validateEnum,
+  AGENT_STATUSES, adminWriteLimiter, asyncHandler, buildMcpConfig, checkAdmin, checkAgentOrAdmin, clearAgentKeyCache, computeHealthReport, displayName, emitEvent, getAdminDisplayName, getInstanceUrl, getStudioUser, invalidateAgentKeyCache, runHealthPatrol, validateEnum,
 });
 
 
@@ -1944,6 +1944,58 @@ function runHealthPatrol() {
     results.actions.push({ type: 'stale_plan_step', step_id: s.id, plan_id: s.plan_id });
   }
   results.stale_plan_steps = staleSteps.length;
+
+  return results;
+}
+
+// Pure read-only PREVIEW of what runHealthPatrol() would do — same stale-detection
+// queries, same config thresholds, same result shape, but NO mutation and NO event
+// emission. GET /admin/health uses this so a plain read stays safe/idempotent;
+// POST /admin/health/run is the one that actually calls runHealthPatrol() above.
+function computeHealthReport() {
+  var config = {};
+  try {
+    var rows = getDB().prepare("SELECT key, value FROM instance_config WHERE key LIKE 'patrol_%'").all();
+    for (var r of rows) config[r.key] = r.value;
+  } catch (e) { /* use defaults */ }
+
+  var staleAgentMins = parseInt(config.patrol_stale_agent_minutes) || 15;
+  var staleTaskMins = parseInt(config.patrol_stale_task_minutes) || 30;
+  var staleRequestMins = parseInt(config.patrol_stale_request_minutes) || 60;
+  var staleDroneMins = parseInt(config.patrol_stale_drone_minutes) || 30;
+  var stalePlanStepMins = parseInt(config.patrol_stale_plan_step_minutes) || 120;
+
+  var results = { stale_agents: 0, stale_tasks: 0, stale_requests: 0, stale_drones: 0, stale_plan_steps: 0, actions: [], run_at: new Date().toISOString(), dry_run: true };
+
+  var staleAgents = getStaleAgents(staleAgentMins);
+  for (var a of staleAgents) {
+    results.actions.push({ type: 'agent_offline', agent_id: a.id });
+  }
+  results.stale_agents = staleAgents.length;
+
+  var staleTasks = getStaleTasks(staleTaskMins);
+  for (var t of staleTasks) {
+    results.actions.push({ type: 'stale_task_warning', task_id: t.id, assignee: t.assignee });
+  }
+  results.stale_tasks = staleTasks.length;
+
+  var staleReqs = getStaleRequests(staleRequestMins);
+  for (var r2 of staleReqs) {
+    results.actions.push({ type: 'stale_request', request_id: r2.id });
+  }
+  results.stale_requests = staleReqs.length;
+
+  var staleDrns = getStaleDrones(staleDroneMins);
+  for (var d of staleDrns) {
+    results.actions.push({ type: 'drone_offline', drone_id: d.id });
+  }
+  results.stale_drones = staleDrns.length;
+
+  var staleSteps2 = getStalePlanSteps(stalePlanStepMins);
+  for (var s2 of staleSteps2) {
+    results.actions.push({ type: 'stale_plan_step', step_id: s2.id, plan_id: s2.plan_id });
+  }
+  results.stale_plan_steps = staleSteps2.length;
 
   return results;
 }

--- a/server/routes/plans.js
+++ b/server/routes/plans.js
@@ -154,6 +154,7 @@ export function registerPlanRoutes(router, deps) {
     if (!plan) return res.status(404).json({ error: 'Plan not found' });
     var stepId0 = parseIntParam(req.params.stepId);
     var planStep = plan.steps ? plan.steps.find(function (s) { return s.id === stepId0; }) : null;
+    if (!planStep) return res.status(404).json({ error: 'Plan step not found' });
     if (!checkProjectScope(req, res, plan.project_id, planStep ? planStep.assignee : null)) return;
     if (!validateEnum(res, req.body.status, PLAN_STEP_STATUSES, 'status')) return;
     var fields = {};
@@ -228,9 +229,12 @@ export function registerPlanRoutes(router, deps) {
     if (!agentId) return;
     var plan = getPlan(parseIntParam(req.params.id));
     if (!plan) return res.status(404).json({ error: 'Plan not found' });
+    var delStepId = parseIntParam(req.params.stepId);
+    var delPlanStep = plan.steps ? plan.steps.find(function (s) { return s.id === delStepId; }) : null;
+    if (!delPlanStep) return res.status(404).json({ error: 'Plan step not found' });
     if (!checkProjectScope(req, res, plan.project_id)) return;
-    deletePlanStep(parseIntParam(req.params.stepId));
-    res.json({ ok: true, deleted: parseIntParam(req.params.stepId) });
+    deletePlanStep(delStepId);
+    res.json({ ok: true, deleted: delStepId });
   }));
 
   // -- Plan Step Comments --

--- a/test/unit/safety-404-and-readonly-health.test.js
+++ b/test/unit/safety-404-and-readonly-health.test.js
@@ -1,0 +1,109 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+
+// Two safety fixes re-applied on master from the held refactor batch:
+//   1. Mutations to a MISSING child resource must 404 BEFORE mutating/emitting —
+//      not a silent 200 + phantom event (plan steps; drone pause/resume). Closes
+//      an IDOR-flavored path (a step of plan B mutated via plan A's URL).
+//   2. GET /admin/health must be side-effect-free (read-only computeHealthReport,
+//      dry_run:true); the mutating patrol moved to admin-only POST /admin/health/run,
+//      so an agent key can preview but can no longer offline peers via a GET.
+//
+// Harness mirrors drone-mesh-rce.test.js.
+
+const ADMIN_KEY = 'test-admin-key-0123456789abcdef0123456789abcdef'
+const AGENT_KEY = 'dvk_' + 'e'.repeat(48)
+
+let tmpDataDir
+let db
+let app
+let planId
+
+beforeAll(async () => {
+  tmpDataDir = mkdtempSync(join(tmpdir(), 'myc-safety-'))
+  process.env.DATA_DIR = tmpDataDir
+  process.env.ADMIN_KEY = ADMIN_KEY
+
+  db = await import('../../server/db.js')
+  db.initDB()
+
+  const routes = (await import('../../server/routes/mycelium.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/mycelium', routes)
+
+  const hash = crypto.createHash('sha256').update(AGENT_KEY).digest('hex')
+  db.createAgent('safety-agent', 'Safety Agent', 'safety-proj', hash, '["code"]')
+  planId = db.createPlan('Safety Plan', 'for 404 tests', 'safety-proj', 'safety-agent', 'normal', '[]', 'safety-agent')
+})
+
+afterAll(() => {
+  if (tmpDataDir) rmSync(tmpDataDir, { recursive: true, force: true })
+})
+
+describe('phantom sub-resource mutations 404 (not silent-200 + ghost event)', () => {
+  test('PUT /plans/:id/steps/:stepId on a non-existent step → 404', async () => {
+    const res = await request(app)
+      .put(`/api/mycelium/plans/${planId}/steps/99999`)
+      .set('X-Agent-Key', AGENT_KEY)
+      .send({ status: 'in_progress' })
+    expect(res.status).toBe(404)
+    expect(res.body.error).toMatch(/step not found/i)
+  })
+
+  test('DELETE /plans/:id/steps/:stepId on a non-existent step → 404', async () => {
+    const res = await request(app)
+      .delete(`/api/mycelium/plans/${planId}/steps/99999`)
+      .set('X-Agent-Key', AGENT_KEY)
+    expect(res.status).toBe(404)
+    expect(res.body.error).toMatch(/step not found/i)
+  })
+
+  test('PUT /drones/:id/pause on a ghost drone → 404 (not silent ok:true)', async () => {
+    const res = await request(app)
+      .put('/api/mycelium/drones/ghost-drone/pause')
+      .set('X-Agent-Key', AGENT_KEY)
+    expect(res.status).toBe(404)
+  })
+
+  test('PUT /drones/:id/resume on a ghost drone → 404', async () => {
+    const res = await request(app)
+      .put('/api/mycelium/drones/ghost-drone/resume')
+      .set('X-Agent-Key', AGENT_KEY)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('GET /admin/health is side-effect-free; mutation is admin-only POST', () => {
+  test('GET /admin/health returns a read-only preview (dry_run:true)', async () => {
+    const res = await request(app)
+      .get('/api/mycelium/admin/health')
+      .set('X-Agent-Key', AGENT_KEY)
+    expect(res.status).toBe(200)
+    expect(res.body.dry_run).toBe(true)
+    expect(res.body).toHaveProperty('actions')
+    expect(res.body).toHaveProperty('stale_agents')
+  })
+
+  test('POST /admin/health/run is admin-only — a non-admin agent is denied', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/admin/health/run')
+      .set('X-Agent-Key', AGENT_KEY)
+    // Master returns 401 here; the separate §1 finding (checkAdmin → 403 for a
+    // valid-but-non-admin agent) will tighten it to 403. Either way, denied.
+    expect([401, 403]).toContain(res.status)
+  })
+
+  test('POST /admin/health/run as admin runs the patrol (200)', async () => {
+    const res = await request(app)
+      .post('/api/mycelium/admin/health/run')
+      .set('X-Admin-Key', ADMIN_KEY)
+      .set('X-Acting-As', 'greatness')
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Summary
Re-applies two safety-first correctness fixes on master from the held refactor batch (they were stranded on the closed `feature/m5max/readme-positioning`). First of the individual-PR series landing that batch cleanly.

## Item 1 — phantom sub-resource mutations now 404
Mutating a **missing child resource** silently returned 200 + emitted a ghost event. Now it 404s before any mutation/emit:
- `PUT`/`DELETE /plans/:id/steps/:stepId` → 404 "Plan step not found" when the step isn't a child of the URL's plan. Closes an **IDOR-flavored path** (a step of plan B mutated via plan A's URL) + the empty-plan phantom auto-completion; kills the ghost `plan_step_updated` event + webhook.
- `PUT /drones/:id/pause|resume` → 404 a ghost drone (mirrors `getDroneStatus`'s existence check) instead of a 0-row UPDATE reporting `{ ok:true }`.

## Item 2 — a GET must not mutate
- `GET /admin/health` now returns a read-only `computeHealthReport()` (`dry_run:true`, same shape) — no `updateAgentHeartbeat`/`releaseStaleClaimedJobs`/`emitEvent`.
- The mutating remediation moved to admin-only `POST /admin/health/run`. An agent key can preview but can no longer offline peers via a GET.

## Verification
- New `test/unit/safety-404-and-readonly-health.test.js` (7 cases): ghost plan-step PUT/DELETE → 404, ghost drone pause/resume → 404, `GET /admin/health` returns `dry_run:true`, `POST /admin/health/run` denied for non-admin.
- Full suite green: **304 tests**.

## Note
Non-admin denial on `POST /admin/health/run` is **401** on master today; the separate §1 finding (`checkAdmin` → 403 for a valid-but-non-admin agent) will tighten it to 403 in its own PR. Security property holds either way.
