### PR TITLE
fix(db): import listOrgs so admin overview does not 500

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -8,7 +8,7 @@ import { getSleepMode, listInstanceConfig } from './db/config.js';
 import { listEvents } from './db/events.js';
 import { listBugs, countBugs } from './db/bugs.js';
 import { isNetworkAutonomous, getAvailableOperators, listOperators, getActiveStudioUsers } from './db/operators.js';
-import { getProject, listProjects } from './db/projects.js';
+import { getProject, listProjects, listOrgs } from './db/projects.js';
 import { getProjectConcepts, listConcepts, getConceptProjects } from './db/concepts.js';
 import { listPendingApprovalsByAgent, listApprovals } from './db/approvals.js';
 import { listPendingRequests, getUnreadMessages, markMessagesRead, listMessages, listTeamChat } from './db/messages.js';


### PR DESCRIPTION
`getOverview()` calls `listOrgs()` at `server/db.js:855`, but the named import from `./db/projects.js` only pulls `getProject` and `listProjects`. The admin overview therefore throws `ReferenceError: listOrgs is not defined` and returns HTTP 500.

Regression from the db Wave 0–4 decomposition: `listOrgs` moved into `db/projects.js`, and the wildcard re-export at line 43 covers callers *outside* this module — but the in-module call site still needs the named import.

**Reproduced on a clean boot** against `origin/master`. One-line fix; no behaviour change beyond the route no longer throwing.

Found while merging 52 upstream commits into a downstream fork.